### PR TITLE
(fix) Use runtime call for stringLength in ImpJson translation

### DIFF
--- a/coq/Imp/Lang/ImpJson.v
+++ b/coq/Imp/Lang/ImpJson.v
@@ -48,6 +48,7 @@ Section Syntax.
   | JSONRuntimeFlatten : imp_json_runtime_op
   | JSONRuntimeSort : imp_json_runtime_op
   | JSONRuntimeCount : imp_json_runtime_op
+  | JSONRuntimeLength : imp_json_runtime_op
   | JSONRuntimeSubstring : imp_json_runtime_op
   | JSONRuntimeBrand : imp_json_runtime_op
   | JSONRuntimeUnbrand : imp_json_runtime_op
@@ -103,6 +104,7 @@ Section Util.
     | JSONRuntimeFlatten => "flatten"
     | JSONRuntimeSort => "sort"
     | JSONRuntimeCount => "count"
+    | JSONRuntimeLength => "stringLength"
     | JSONRuntimeSubstring => "substring"
     | JSONRuntimeBrand => "brand"
     | JSONRuntimeUnbrand => "unbrand"

--- a/coq/Translation/ImpQcerttoImpJson.v
+++ b/coq/Translation/ImpQcerttoImpJson.v
@@ -83,7 +83,7 @@ Section ImpJsontoJavaScriptAst.
           JSONRuntimeSort (e :: (List.map sortCriteria_to_json_expr scl))
       | OpCount => mk_imp_json_runtime_call JSONRuntimeCount el
       | OpToString => mk_imp_json_op JSONOpToString el
-      | OpLength => mk_imp_json_op JSONOpArrayLength el
+      | OpLength => mk_imp_json_runtime_call JSONRuntimeLength el
       | OpSubstring start len =>
         let start := ImpExprConst (jnumber (float_of_int start)) in
         let args :=


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>