### PR TITLE
Fix to Java and JavaScript runtimes for record concatenation

### DIFF
--- a/Makefile.coq_modules
+++ b/Makefile.coq_modules
@@ -212,6 +212,9 @@ MODULES = \
 	NNRSimp/Typing/TNNRSimp \
 	NNRSimp/Typing/TNNRSimpEq \
 	NNRSimp/Typing/TNNRSimpRename \
+	NNRSimp/NNRSimpRuntime \
+	NNRSimp/NNRSimpTypes \
+	NNRSimp/NNRSimpSystem \
 	NNRSimp/Optim/NNRSimpUnflatten \
 	NNRSimp/Optim/NNRSimpRewrite \
 	NNRSimp/Optim/TNNRSimpUnflatten \
@@ -219,9 +222,6 @@ MODULES = \
 	NNRSimp/Optim/NNRSimpOptimizer \
 	NNRSimp/Optim/NNRSimpOptimizerEngine \
 	NNRSimp/NNRSimpOptim \
-	NNRSimp/NNRSimpRuntime \
-	NNRSimp/NNRSimpTypes \
-	NNRSimp/NNRSimpSystem \
 	Imp/Lang/Imp \
 	Imp/Lang/ImpSize \
 	Imp/Lang/ImpEval \

--- a/coq/Common/OperatorsTyping/TOperatorsInferSub.v
+++ b/coq/Common/OperatorsTyping/TOperatorsInferSub.v
@@ -69,7 +69,7 @@ Section TOperatorsInferSub.
         | false, true =>
            lift (fun _ => (τ₁, τ₁, ⊥)) (tunrec τ₁)
         | false, false =>
-          lift (fun τ => (τ, τ₁, τ₂)) (trecConcat τ₁ τ₂)
+          lift (fun τ => (τ, τ₁, τ₂)) (trecConcatRight τ₁ τ₂)
         end
       | OpRecMerge =>
         match τ₁ ==b ⊥, τ₂ ==b ⊥ with

--- a/coq/Common/OperatorsTyping/TUtil.v
+++ b/coq/Common/OperatorsTyping/TUtil.v
@@ -197,6 +197,46 @@ Section TUtil.
     - exact None.
   Defined.
 
+  Definition trecConcatRight (τ₁ τ₂: rtype) : option rtype.
+  Proof.
+    destruct τ₁; destruct x.
+    - exact None.
+    - exact None.
+    - exact None.
+    - exact None.
+    - exact None.
+    - exact None.
+    - exact None.
+    - exact None.
+    - destruct τ₂; destruct x.
+      + exact None.
+      + exact None.
+      + exact None.
+      + exact None.
+      + exact None.
+      + exact None.
+      + exact None.
+      + exact None.
+      + generalize (from_Rec₀ srl e); intros.
+        generalize (from_Rec₀ srl0 e0); intros.
+        destruct H; destruct H0.
+        destruct k; destruct k0; simpl.
+        * exact None. (* Both open record *)
+        * generalize (rec_concat_sort x x0); intros. (* Left open record *)
+          exact (RecMaybe Open H).
+        * exact None. (* Right open record *)
+        * generalize (rec_concat_sort x x0); intros.
+          exact (RecMaybe Closed H).
+      + exact None.
+      + exact None.
+      + exact None.
+      + exact None.
+    - exact None.
+    - exact None.
+    - exact None.
+    - exact None.
+  Defined.
+
   Definition tmergeConcat (τ₁ τ₂: rtype) : option rtype.
   Proof.
     destruct τ₁; destruct x.

--- a/coq/Tests/HelloWorld.v
+++ b/coq/Tests/HelloWorld.v
@@ -12,10 +12,12 @@
  * limitations under the License.
  *)
 
+Require Import String.
+Require Import List.
 Require Import Qcert.Compiler.Driver.CompLang.
 Require Import Qcert.Compiler.EnhancedCompiler.
-Require Import String.
 Require Import Qcert.Common.DataModel.Data.
+Require Import Qcert.Common.Operators.BinaryOperators.
 Require Import Qcert.NRAEnv.Lang.NRAEnv.
 
 Section HelloWorld.
@@ -28,12 +30,30 @@ Section HelloWorld.
   Definition compile : query -> query :=
     @EnhancedCompiler.QDriver.compile_from_source_target bm _ config source target.
 
-  Section example.
+  Section example1.
     Definition a1 :=
       NRAEnvConst (dstring "Hello World!").
 
-    (* Eval vm_compute in compile (Q_nraenv a1). *)
-  End example.
+    Section compile.
+      (* Eval vm_compute in compile (Q_nraenv a1). *)
+    End compile.
+    Section eval.
+      (* Eval vm_compute in (nraenv_eval_top nil a1 nil). *)
+    End eval.
+  End example1.
+
+  Section example2.
+    Definition a2 :=
+      NRAEnvBinop OpRecConcat
+                  (NRAEnvConst (drec (("a"%string, dstring "Hello World!")::nil)))
+                  (NRAEnvConst (drec (("a"%string, dnat 1)::nil))).
+
+    Section compile.
+      (* Eval vm_compute in compile (Q_nraenv a2). *)
+    End compile.
+    Section eval.
+      (* Eval vm_compute in (nraenv_eval_top nil a2 nil). *)
+    End eval.
+  End example2.
 
 End HelloWorld.
-

--- a/coq/Translation/cNNRCtoCAMP.v
+++ b/coq/Translation/cNNRCtoCAMP.v
@@ -1452,7 +1452,7 @@ Section cNNRCtoCAMP.
       case_eq (camp_eval h cenv p bind a); simpl; intros; trivial.
       - case_eq (gather_successes (map (camp_eval h cenv p bind) l)); simpl; trivial; intros.
         rewrite merge_bindings_single_nin by trivial.
-        rewrite edot_fresh_concat by trivial.
+        rewrite edot_fresh_concat_right_single by trivial.
         simpl.
         destruct (data_eq_dec (dnat (Z.pos (Pos.of_succ_nat (bcount l))))
                               (dnat (Z.of_nat (bcount res)))).
@@ -1468,32 +1468,32 @@ Section cNNRCtoCAMP.
           inversion e.
           rewrite merge_bindings_nil_r.
           rewrite sort_sorted_is_id; trivial.
-          rewrite edot_fresh_concat; trivial.
+          rewrite edot_fresh_concat_right_single; trivial.
       - case_eq (gather_successes (map (camp_eval h cenv p bind) l)); simpl; trivial; intros.
         rewrite merge_bindings_single_nin by trivial.
-        rewrite edot_fresh_concat by trivial.
+        rewrite edot_fresh_concat_right_single by trivial.
         simpl.
         destruct (data_eq_dec (dnat (Z.pos (Pos.of_succ_nat (bcount l))))
                               (dnat (Z.pos (Pos.of_succ_nat (bcount res0))))).
         trivial; simpl.
         + rewrite merge_bindings_nil_r.
           rewrite sort_sorted_is_id; trivial.
-          rewrite edot_fresh_concat; trivial. simpl.
+          rewrite edot_fresh_concat_right_single; trivial. simpl.
           rewrite merge_bindings_single_nin by trivial.
-          rewrite edot_fresh_concat; trivial.
+          rewrite edot_fresh_concat_right_single; trivial.
           simpl.
           inversion e.
           destruct (data_eq_dec (dnat (Z.of_nat (bcount l)))
                                 (dnat (Z.of_nat (bcount res0)))); simpl; trivial.
           * rewrite merge_bindings_nil_r.
             rewrite sort_sorted_is_id; trivial.
-            rewrite edot_fresh_concat; trivial.
+            rewrite edot_fresh_concat_right_single; trivial.
           * inversion e.
             assert (bcount l = bcount res0)
               by apply (pos_succ_nat_inv (bcount l) (bcount res0) H6).
             rewrite H4 in *. congruence.
         + rewrite merge_bindings_single_nin by trivial.
-          rewrite edot_fresh_concat; trivial.
+          rewrite edot_fresh_concat_right_single; trivial.
           simpl.
           destruct (data_eq_dec (dnat (Z.of_nat (bcount l)))
                                 (dnat (Z.of_nat (bcount res0))));
@@ -1521,11 +1521,11 @@ Section cNNRCtoCAMP.
         intuition. unfold fresh_let_var, let_var in H0.
         eapply H0; trivial; reflexivity.
         rewrite merge_bindings_single_nin by trivial.
-        rewrite edot_fresh_concat by trivial.
+        rewrite edot_fresh_concat_right_single by trivial.
         simpl. 
         rewrite merge_bindings_nil_r.
         rewrite drec_sort_drec_sort_concat.
-        rewrite edot_fresh_concat by trivial.
+        rewrite edot_fresh_concat_right_single by trivial.
         trivial.
       - rewrite camp_eval_mapall_let_cons by trivial.
         rewrite IHl by trivial.
@@ -1687,7 +1687,7 @@ Section cNNRCtoCAMP.
         destruct (camp_eval h cenv (nnrcToCamp_ns n1) b d); trivial.
         simpl.
         rewrite merge_bindings_single_nin by trivial.
-        rewrite edot_fresh_concat by trivial.
+        rewrite edot_fresh_concat_right_single by trivial.
         destruct res; trivial.
         destruct b0; simpl.
         + repeat rewrite merge_bindings_nil_r.

--- a/coq/Utils/Bindings.v
+++ b/coq/Utils/Bindings.v
@@ -1686,14 +1686,36 @@ Section Edot.
     apply assoc_lookupr_nodup_perm.
   Qed.
   
-  Lemma edot_fresh_concat {A} x (d:A) b :
-    ~ In x (domain b) ->
+  Lemma edot_fresh_concat_right_single {A} x (d:A) b :
     edot (rec_concat_sort b ((x,d)::nil)) x = Some d.
   Proof.
     intros.
-    apply (@assoc_lookupr_insertion_sort_fresh string ODT_string); trivial.
+    unfold rec_concat_sort.
+    unfold edot.
+    rewrite assoc_lookupr_drec_sort.
+    simpl.
+    induction b; simpl.
+    match_destr; try congruence.
+    destruct a; simpl.
+    rewrite IHb.
+    reflexivity.
   Qed.
 
+  Lemma edot_concat_right {A} x (d:A) b c :
+    edot c x = Some d ->
+    edot (rec_concat_sort b c) x = Some d.
+  Proof.
+    intros.
+    unfold rec_concat_sort.
+    unfold edot in *.
+    rewrite assoc_lookupr_drec_sort.
+    simpl.
+    induction b; simpl; auto.
+    destruct a; simpl.
+    rewrite IHb.
+    reflexivity.
+  Qed.
+    
 End Edot.
 
 Hint Unfold rec_sort rec_concat_sort.

--- a/coq/Version.v
+++ b/coq/Version.v
@@ -20,7 +20,7 @@ Require Import String.
 
 Section Version.
   (** Variables are defined as strings *)
-  Definition qcert_version := "1.4.0"%string.
+  Definition qcert_version := "1.4.1"%string.
 
 End Version.
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "qcert",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "The Q*cert compiler",
 	"repository": {
 		"type": "git",

--- a/runtimes/java/src/org/qcert/runtime/BinaryOperators.java
+++ b/runtimes/java/src/org/qcert/runtime/BinaryOperators.java
@@ -18,8 +18,14 @@ package org.qcert.runtime;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
@@ -90,12 +96,31 @@ public class BinaryOperators {
 	public static JsonElement concat(JsonElement e1, JsonElement e2) {
 		final JsonObject rec1 = asRec(e1);
 		final JsonObject rec2 = asRec(e2);
-		final JsonObject dst = new JsonObject();
-		for(final Entry<String, JsonElement> entry : rec1.entrySet()) {
-			dst.add(entry.getKey(), entry.getValue());
-		}
+
+    // Sort based on keys first and do not add fields in rec1 which are in rec
+    Set<Entry<String,JsonElement>> entryset = new HashSet<Entry<String,JsonElement>>();
 		for(final Entry<String, JsonElement> entry : rec2.entrySet()) {
-			dst.add(entry.getKey(), entry.getValue());
+      entryset.add(entry);
+		}
+		for(final Entry<String, JsonElement> entry : rec1.entrySet()) {
+      if (!rec2.has(entry.getKey())) {
+        entryset.add(entry);
+      }
+		}
+
+    List<Entry<String,JsonElement>> entrylist = new ArrayList<Entry<String,JsonElement>>(entryset);
+    Comparator<Entry<String,JsonElement>> compareByKey = new Comparator<Entry<String,JsonElement>>() {
+            @Override
+            public int compare(Entry<String,JsonElement> e1, Entry<String,JsonElement> e2) {
+                return e1.getKey().compareTo( e2.getKey() );
+            }
+        };
+
+    Collections.sort(entrylist, compareByKey);
+    
+		final JsonObject dst = new JsonObject();
+		for(final Entry<String, JsonElement> entry : entrylist) {
+        dst.add(entry.getKey(), entry.getValue());
 		}
 		return dst;
 	}

--- a/runtimes/javascript/qcert-runtime-core.js
+++ b/runtimes/javascript/qcert-runtime-core.js
@@ -34,11 +34,11 @@ function unwrap(doc) {
 }
 function concat(r1, r2) {
     var result = { };
-    for (var key1 in r1)
-	result[key1] = r1[key1];
     for (var key2 in r2)
-	if (!(key2 in r1))
-	    result[key2] = r2[key2];
+        result[key2] = r2[key2];
+    for (var key1 in r1)
+        if (!(key1 in r2))
+            result[key1] = r1[key1];
     return result;
 }
 function contains(v, b) {

--- a/test/Makefile
+++ b/test/Makefile
@@ -67,7 +67,7 @@ endif
 ## OQL
 OQLPERSONSNUM=1 2 3 4 5 6 7 8 9 10 11 12
 OQLWORLDNUM=1 2
-OQLSTRINGNUM=1 2
+OQLSTRINGNUM=1 2 3
 OQLEMPLOYEESNUM=1 2
 OQLTARGETS=oql nraenv nnrc nnrs nnrs_imp nnrcmr cldmr nra nraenv_core nnrc_core dnnrc # dnnrc_typed
 
@@ -205,7 +205,7 @@ oql-employees-tests-java:
                           employees$(N) || exit 1;)
 
 ## λ-NRA
-LAMBDANRAPERSONSNUM=1 2 3 4 5 6 7
+LAMBDANRAPERSONSNUM=0 1 2 3 4 5 6 7
 LAMBDANRATARGETS=lambda_nra nraenv nnrc nnrs nnrs_imp nnrcmr cldmr nra nraenv_core nnrc_core dnnrc # dnnrc_typed
 
 lambda_nra-tests:
@@ -226,7 +226,7 @@ lambda_nra-persons-tests:
 	       $(QCERTCOMP) -source lambda_nra -target $(T) lambda_nra/persons$(N).lnra \
                             -eval -input lambda_nra/persons.input \
                             -schema lambda_nra/persons.schema \
-                            -eval-validate -output lambda_nra/persons$(N).out;))
+                            -eval-validate -output lambda_nra/persons$(N).out || exit 1;))
 lambda_nra-persons-tests-js:
 	@$(foreach N,$(LAMBDANRAPERSONSNUM), \
 	       $(QCERTCOMP) -source lambda_nra -path imp_json  -target js lambda_nra/persons$(N).lnra \
@@ -236,7 +236,7 @@ lambda_nra-persons-tests-js:
                           -input lambda_nra/persons.input \
                           -schema lambda_nra/persons.schema \
                           -output lambda_nra/persons$(N).out \
-                          lambda_nra/persons$(N).js;)
+                          lambda_nra/persons$(N).js || exit 1;)
 lambda_nra-persons-tests-java:
 	@$(foreach N,$(LAMBDANRAPERSONSNUM), \
 	       $(QCERTCOMP) -source lambda_nra -target java lambda_nra/persons$(N).lnra \
@@ -246,7 +246,7 @@ lambda_nra-persons-tests-java:
                           -input lambda_nra/persons.input \
                           -schema lambda_nra/persons.schema \
                           -output lambda_nra/persons$(N).out \
-                          persons$(N);)
+                          persons$(N) || exit 1;)
 
 ## CAMP
 CAMPWORLDNUM=1
@@ -270,7 +270,7 @@ camp-world-tests:
 	       $(QCERTCOMP) -source camp -target $(T) camp/world$(N).camp \
                             -eval -input camp/world.input \
                             -schema camp/world.schema \
-                            -eval-validate -output camp/world$(N).out;))
+                            -eval-validate -output camp/world$(N).out || exit 1;))
 camp-world-tests-js:
 	@$(foreach N,$(CAMPWORLDNUM), \
 	       $(QCERTCOMP) -source camp -path imp_json  -target js camp/world$(N).camp \
@@ -280,7 +280,7 @@ camp-world-tests-js:
                           -input camp/world.input \
                           -schema camp/world.schema \
                           -output camp/world$(N).out \
-                          camp/world$(N).js;)
+                          camp/world$(N).js || exit 1;)
 camp-world-tests-java:
 	@$(foreach N,$(CAMPWORLDNUM), \
 	       $(QCERTCOMP) -source camp -target java camp/world$(N).camp \
@@ -290,10 +290,10 @@ camp-world-tests-java:
                           -input camp/world.input \
                           -schema camp/world.schema \
                           -output camp/world$(N).out \
-                          world$(N);)
+                          world$(N) || exit 1;)
 
 ## SQL
-SQLORGNUM=1 2 3 4 5 6 7 8 9 10
+SQLORGNUM=1 2 3 4 5 6 7 8 9 10 11
 SQLTARGETS=nraenv nnrc nnrs nnrs_imp nnrcmr cldmr nra nraenv_core nnrc_core dnnrc # dnnrc_typed
 
 sql-tests:
@@ -314,7 +314,7 @@ sql-org-tests:
 	       $(QCERTCOMP) -source sql -target $(T) sql/org$(N).sql \
                             -eval -input sql/org.input \
                             -schema sql/org.schema \
-                            -eval-validate -output sql/org$(N).out;))
+                            -eval-validate -output sql/org$(N).out || exit 1;))
 sql-org-tests-js:
 	@$(foreach N,$(SQLORGNUM), \
 	       $(QCERTCOMP) -source sql -path imp_json  -target js sql/org$(N).sql \
@@ -324,7 +324,7 @@ sql-org-tests-js:
                           -input sql/org.input \
                           -schema sql/org.schema \
                           -output sql/org$(N).out \
-                          sql/org$(N).js;)
+                          sql/org$(N).js || exit 1;)
 sql-org-tests-java:
 	@$(foreach N,$(SQLORGNUM), \
 	       $(QCERTCOMP) -source sql -target java sql/org$(N).sql \
@@ -334,7 +334,7 @@ sql-org-tests-java:
                           -input sql/org.input \
                           -schema sql/org.schema \
                           -output sql/org$(N).out \
-                          org$(N);)
+                          org$(N) || exit 1;)
 
 
 ## TECHRULE
@@ -359,7 +359,7 @@ tech_rule-test-tests:
 	       $(QCERTCOMP) -source tech_rule -target $(T) tech_rule/test$(N).arl \
                             -eval -input tech_rule/test.input \
                             -schema tech_rule/test.schema \
-                            -eval-validate -output tech_rule/test$(N).out;))
+                            -eval-validate -output tech_rule/test$(N).out || exit 1;))
 tech_rule-test-tests-js:
 	@$(foreach N,$(TECHRULETESTNUM), \
 	       $(QCERTCOMP) -source tech_rule -path imp_json  -target js tech_rule/test$(N).arl \
@@ -369,7 +369,7 @@ tech_rule-test-tests-js:
                           -input tech_rule/test.input \
                           -schema tech_rule/test.schema \
                           -output tech_rule/test$(N).out \
-                          tech_rule/test$(N).js;)
+                          tech_rule/test$(N).js || exit 1;)
 tech_rule-test-tests-java:
 	@$(foreach N,$(TECHRULETESTNUM), \
 	       $(QCERTCOMP) -source tech_rule -target java tech_rule/test$(N).arl \
@@ -379,7 +379,7 @@ tech_rule-test-tests-java:
                           -input tech_rule/test.input \
                           -schema tech_rule/test.schema \
                           -output tech_rule/test$(N).out \
-                          test$(N);)
+                          test$(N) || exit 1;)
 
 ## DESIGNERRULE
 DESIGNERRULETESTNUM=
@@ -400,7 +400,7 @@ designer_rule-test-tests:
 	       $(QCERTCOMP) -source designer_rule -target $(T) designer_rule/test$(N).agg \
                             -eval -input designer_rule/test.input \
                             -schema designer_rule/test.schema \
-                            -eval-validate -output designer_rule/test$(N).out;))
+                            -eval-validate -output designer_rule/test$(N).out || exit 1;))
 designer_rule-test-tests-js:
 	@$(foreach N,$(DESIGNERRULETESTNUM), \
 	       $(QCERTCOMP) -source designer_rule -path imp_json  -target js designer_rule/test$(N).agg \
@@ -410,7 +410,7 @@ designer_rule-test-tests-js:
                           -input designer_rule/test.input \
                           -schema designer_rule/test.schema \
                           -output designer_rule/test$(N).out \
-                          designer_rule/test$(N).js;)
+                          designer_rule/test$(N).js || exit 1;)
 
 clean:
 	@rm -f */*.txt

--- a/test/oql/string3.oql
+++ b/test/oql/string3.oql
@@ -1,0 +1,2 @@
+select struct(name:x->name)
+from x as Customer in WORLD

--- a/test/oql/string3.out
+++ b/test/oql/string3.out
@@ -1,0 +1,6 @@
+[{"name" : "John Doe"},
+ {"name" : "Jane Doe"},
+ {"name" : "Jim Does"},
+ {"name" : "Jill Does"},
+ {"name" : "Joan Doe"},
+ {"name" : "James Do"}]

--- a/test/sql/org11.out
+++ b/test/sql/org11.out
@@ -1,0 +1,2 @@
+[{"age" : { "nat" : 26 },
+  "name" : "Thandy Coe"}]

--- a/test/sql/org11.sql
+++ b/test/sql/org11.sql
@@ -1,0 +1,5 @@
+select age, name
+from students, employees
+where eid = 1.0
+  and sid = 1.0
+;


### PR DESCRIPTION
Addresses Issue #118 
- JavaScript runtime concats according to spec (right field first)
- Java runtime concats according to spec (right field first)
- Java runtime sorts entries in records during concatenation
- Fixes to tests