### PR TITLE
Remove constant environment from Imp

### DIFF
--- a/coq/Compiler/Driver/CompCorrectness.v
+++ b/coq/Compiler/Driver/CompCorrectness.v
@@ -212,7 +212,7 @@ Section CompCorrectness.
     match dv with
     | Dv_nnrs_imp_stop => True
     | Dv_nnrs_imp_optim _ dv => False /\ driver_correct_nnrs_imp dv
-    | Dv_nnrs_imp_to_imp_qcert _ _ dv => False /\ driver_correct_imp_qcert dv
+    | Dv_nnrs_imp_to_imp_qcert _ dv => False /\ driver_correct_imp_qcert dv
     | Dv_nnrs_imp_to_js_ast _ dv => False /\ driver_correct_js_ast dv
     end.
 

--- a/coq/Imp/Lang/Imp.v
+++ b/coq/Imp/Lang/Imp.v
@@ -44,7 +44,6 @@ Section Imp.
   
     Inductive imp_expr :=
     | ImpExprError : string -> imp_expr                          (**r raises an error *)
-    | ImpExprGetConstant : var -> imp_expr                       (**r global variable lookup ([$v])*)
     | ImpExprVar : var -> imp_expr                               (**r local variable lookup ([$v])*)
     | ImpExprConst : Data -> imp_expr                            (**r constant data ([d]) *)
     | ImpExprOp : Op -> list imp_expr -> imp_expr                (**r operator ([e₁ ⊠ e₂]) *)
@@ -63,9 +62,9 @@ Section Imp.
   (*| ImpStmtBreak : imp_stnt *)(* XXX Possible? Useful? -- Used in Qcert JS runtime *)
     .
 
-    (* input variables + statements + returned variable *)
+    (* input variable + statements + returned variable *)
     Inductive imp_function :=
-    | ImpFun : list var -> imp_stmt -> var -> imp_function
+    | ImpFun : var -> imp_stmt -> var -> imp_function
     .
 
     (** [imp] is composed of a list of function declarations *)
@@ -76,7 +75,6 @@ Section Imp.
       (** Induction principles used as backbone for inductive proofs on imp *)
       Definition imp_expr_rect (P : imp_expr -> Type)
                  (ferror : forall v : string, P (ImpExprError v))
-                 (fgetconstant : forall v : string, P (ImpExprGetConstant v))
                  (fvar : forall v : string, P (ImpExprVar v))
                  (fconst : forall d : Data, P (ImpExprConst d))
                  (fop : forall op : Op, forall el : list imp_expr,
@@ -87,7 +85,6 @@ Section Imp.
           fix F (e : imp_expr) : P e :=
             match e as e0 return (P e0) with
             | ImpExprError msg => ferror msg
-            | ImpExprGetConstant v => fgetconstant v
             | ImpExprVar v => fvar v
             | ImpExprConst d => fconst d
             | ImpExprOp op el =>
@@ -106,7 +103,6 @@ Section Imp.
 
       Definition imp_expr_ind (P : imp_expr -> Prop)
                  (ferror : forall v : string, P (ImpExprError v))
-                 (fgetconstant : forall v : string, P (ImpExprGetConstant v))
                  (fvar : forall v : string, P (ImpExprVar v))
                  (fconst : forall d : Data, P (ImpExprConst d))
                  (fop : forall op : Op, forall el : list imp_expr,
@@ -117,7 +113,6 @@ Section Imp.
           fix F (e : imp_expr) : P e :=
             match e as e0 return (P e0) with
             | ImpExprError msg => ferror msg
-            | ImpExprGetConstant v => fgetconstant v
             | ImpExprVar v => fvar v
             | ImpExprConst d => fconst d
             | ImpExprOp op el =>
@@ -183,7 +178,6 @@ End Imp.
 Tactic Notation "imp_expr_cases" tactic(first) ident(c) :=
   first;
   [ Case_aux c "ImpExprError"%string
-  | Case_aux c "ImpExprGetConstant"%string
   | Case_aux c "ImpExprVar"%string
   | Case_aux c "ImpExprConst"%string
   | Case_aux c "ImpExprOp"%string

--- a/coq/Imp/Lang/ImpEval.v
+++ b/coq/Imp/Lang/ImpEval.v
@@ -31,6 +31,8 @@ Require Import CommonRuntime.
 Require Import Imp.
 
 Section ImpEval.
+  Import ListNotations.
+
   Context {Data: Type}.
   Context {Op: Type}.
   Context {Runtime: Type}.
@@ -158,13 +160,13 @@ Section ImpEval.
         end
       end.
 
-    Definition imp_function_eval f (v: Data)  : option Data :=
+    Definition imp_function_eval f (v: Data) : option Data :=
       match f with
       | ImpFun x s ret =>
-        let σ := (x, Some v) :: nil in
+        let σ := [ (ret, None); (x, Some v) ] in
         match imp_stmt_eval s σ with
         | Some σ' =>
-          olift (fun x => x) (lookup equiv_dec σ ret)
+          olift (fun x => x) (lookup equiv_dec σ' ret)
         | None => None
         end
       end.

--- a/coq/Imp/Lang/ImpEval.v
+++ b/coq/Imp/Lang/ImpEval.v
@@ -65,25 +65,23 @@ Section ImpEval.
   (** ** Evaluation Semantics *)
   Section Evaluation.
     Fixpoint imp_expr_eval
-             (σc:rbindings) (σ:pd_rbindings) (e:imp_expr) {struct e} : option Data
+             (σ:pd_rbindings) (e:imp_expr) {struct e} : option Data
       :=
         match e with
         | ImpExprError msg =>
           None
-        | ImpExprGetConstant v =>
-          edot σc v
         | ImpExprVar v =>
           olift (fun x => x) (lookup equiv_dec σ v)
         | ImpExprConst d =>
           Some (DataNormalize d)
         | ImpExprOp op el =>
-          olift (OpEval op) (lift_map (fun x => x) (map (imp_expr_eval σc σ) el))
+          olift (OpEval op) (lift_map (fun x => x) (map (imp_expr_eval σ) el))
         | ImpExprRuntimeCall rt el =>
-          olift (RuntimeEval rt) (lift_map (fun x => x) (map (imp_expr_eval σc σ) el))
+          olift (RuntimeEval rt) (lift_map (fun x => x) (map (imp_expr_eval σ) el))
         end.
 
     Fixpoint imp_stmt_eval
-             (σc:rbindings) (s:imp_stmt) (σ:pd_rbindings) : option pd_rbindings :=
+             (s:imp_stmt) (σ:pd_rbindings) : option pd_rbindings :=
       match s with
       | ImpStmtBlock vl sl =>
         let proc_one_decl c vd :=
@@ -94,7 +92,7 @@ Section ImpEval.
               | (v, None) =>
                 Some ((v, None) :: σ')
               | (v, Some e) =>
-                match imp_expr_eval σc σ' e with
+                match imp_expr_eval σ' e with
                 | None => None
                 | Some d =>
                   Some ((v, Some d) :: σ')
@@ -107,7 +105,7 @@ Section ImpEval.
             match c with
             | None => None
             | Some σ' =>
-              imp_stmt_eval σc s σ'
+              imp_stmt_eval s σ'
             end
         in
         let σblock := fold_left proc_one_stmt sl σdeclared in
@@ -123,20 +121,20 @@ Section ImpEval.
         let σerased := fold_right proc_one_var σblock vl in
         σerased
       | ImpStmtAssign v e =>
-        match imp_expr_eval σc σ e, lookup string_dec σ v with
+        match imp_expr_eval σ e, lookup string_dec σ v with
         | Some d, Some _ => Some (update_first string_dec σ v (Some d))
         | _, _ => None
         end
       | ImpStmtFor v e s =>
-        match imp_expr_eval σc σ e with
+        match imp_expr_eval σ e with
         | Some d =>
           match DataToList d with
           | Some c1 =>
             let fix for_fun (dl:list Data) σ₁ :=
                 match dl with
                 | nil => Some σ₁
-                | dXXX::dl' =>
-                  match imp_stmt_eval σc s ((v,Some dXXX)::σ₁) with
+                | d::dl' =>
+                  match imp_stmt_eval s ((v,Some d)::σ₁) with
                   | Some (_::σ₂) => for_fun dl' σ₂
                   | _ => None
                   end
@@ -148,15 +146,26 @@ Section ImpEval.
         end
       | ImpStmtForRange v e1 e2 s => None (* XXX TBD *)
       | ImpStmtIf e1 s1 s2 =>
-        match imp_expr_eval σc σ e1 with
+        match imp_expr_eval σ e1 with
         | None => None
         | Some d =>
           match DataToBool d with
           | None => None
           | Some b =>
-            if b then imp_stmt_eval σc s1 σ
-            else imp_stmt_eval σc s2 σ
+            if b then imp_stmt_eval s1 σ
+            else imp_stmt_eval s2 σ
           end
+        end
+      end.
+
+    Definition imp_function_eval f (v: Data)  : option Data :=
+      match f with
+      | ImpFun x s ret =>
+        let σ := (x, Some v) :: nil in
+        match imp_stmt_eval s σ with
+        | Some σ' =>
+          olift (fun x => x) (lookup equiv_dec σ ret)
+        | None => None
         end
       end.
 

--- a/coq/Imp/Lang/ImpJsonEval.v
+++ b/coq/Imp/Lang/ImpJsonEval.v
@@ -203,7 +203,7 @@ Section ImpJsonEval.
     Definition pd_jbindings := list (string * option imp_json_data).
 
     Definition imp_json_expr_eval
-             (σc:jbindings) (σ:pd_jbindings) (e:imp_json_expr)
+             (σ:pd_jbindings) (e:imp_json_expr)
     : option imp_json_data
       := @imp_expr_eval
            imp_json_data
@@ -212,10 +212,10 @@ Section ImpJsonEval.
            imp_json_data_normalize
            imp_json_runtime_eval
            imp_json_op_eval
-           σc σ e.
+           σ e.
 
     Definition imp_json_stmt_eval
-             (σc:jbindings) (s:imp_json_stmt) (σ:pd_jbindings) : option (pd_jbindings)
+             (s:imp_json_stmt) (σ:pd_jbindings) : option (pd_jbindings)
       := @imp_stmt_eval
            imp_json_data
            imp_json_op
@@ -225,7 +225,20 @@ Section ImpJsonEval.
            imp_json_data_to_list
            imp_json_runtime_eval
            imp_json_op_eval
-           σc s σ.
+           s σ.
+
+    Definition imp_json_function_eval
+             (f:imp_json_function) args : option imp_json_data
+      := @imp_function_eval
+           imp_json_data
+           imp_json_op
+           imp_json_runtime_op
+           imp_json_data_normalize
+           imp_json_data_to_bool
+           imp_json_data_to_list
+           imp_json_runtime_eval
+           imp_json_op_eval
+           f args.
 
     Definition imp_json_eval (σc:jbindings) (q:imp_json) : option (option imp_json_data)
       := None. (* XXX TODO XXX *)

--- a/coq/Imp/Lang/ImpQcertEval.v
+++ b/coq/Imp/Lang/ImpQcertEval.v
@@ -130,7 +130,7 @@ Section ImpQcertEval.
           denotes an error. An error is always propagated. *)
 
     Definition imp_qcert_expr_eval
-             (σc:bindings) (σ:pd_bindings) (e:imp_qcert_expr)
+             (σ:pd_bindings) (e:imp_qcert_expr)
     : option data
       := @imp_expr_eval
            imp_qcert_data
@@ -139,10 +139,10 @@ Section ImpQcertEval.
            imp_qcert_data_normalize
            imp_qcert_runtime_eval
            imp_qcert_op_eval
-           σc σ e.
+           σ e.
 
     Definition imp_qcert_stmt_eval
-             (σc:bindings) (s:imp_qcert_stmt) (σ:pd_bindings) : option (pd_bindings)
+             (s:imp_qcert_stmt) (σ:pd_bindings) : option (pd_bindings)
       := @imp_stmt_eval
            imp_qcert_data
            imp_qcert_op
@@ -152,16 +152,32 @@ Section ImpQcertEval.
            imp_qcert_data_to_list
            imp_qcert_runtime_eval
            imp_qcert_op_eval
-           σc s σ.
+           s σ.
 
-    Definition imp_qcert_eval (σc:bindings) (q:imp_qcert) : option (option data)
-      := let ignore := h in None. (* XXX TODO XXX *)
+    Definition imp_qcert_function_eval
+             (f:imp_qcert_function) args : option imp_qcert_data
+      := @imp_function_eval
+           imp_qcert_data
+           imp_qcert_op
+           imp_qcert_runtime_op
+           imp_qcert_data_normalize
+           imp_qcert_data_to_bool
+           imp_qcert_data_to_list
+           imp_qcert_runtime_eval
+           imp_qcert_op_eval
+           f args.
+
+    Definition imp_qcert_eval (q:imp_qcert) (d: data) : option (option data)
+      := match q with
+           | ImpLib [ (_, f) ] => Some (imp_qcert_function_eval f d)
+           | _ => None
+         end.
 
     Definition imp_qcert_eval_top σc (q:imp_qcert) :=
-      olift id (imp_qcert_eval (rec_sort σc) q).
+      olift id (imp_qcert_eval q (drec (rec_sort σc))).
 
   End Evaluation.
 
 End ImpQcertEval.
 
-(* Arguments imp_stmt_eval_domain_stack {fruntime h s σc σ₁ σ₂}. *)
+(* Arguments imp_stmt_eval_domain_stack {fruntime h s σ₁ σ₂}. *)

--- a/coq/Imp/Lang/ImpSize.v
+++ b/coq/Imp/Lang/ImpSize.v
@@ -37,7 +37,6 @@ Section ImpSize.
   Fixpoint imp_expr_size (e:imp_expr) : nat
     := match e with
        | ImpExprError v => 1
-       | ImpExprGetConstant v => 1
        | ImpExprVar v => 1
        | ImpExprConst v => 1
        | ImpExprOp op l => S (List.fold_left (fun acc e => acc + imp_expr_size e ) l 0)

--- a/coq/NNRSimp/Lang/NNRSimpEval.v
+++ b/coq/NNRSimp/Lang/NNRSimpEval.v
@@ -36,6 +36,7 @@ Require Import NNRSimp.
 Require Import NNRSimpVars.
 
 Section NNRSimpEval.
+  Import ListNotations.
 
   Context {fruntime:foreign_runtime}.
 
@@ -526,7 +527,7 @@ Section NNRSimpEval.
           apply remove_nin_inv in inn2.
           intuition congruence.
     Qed.
-    
+
     Lemma nnrs_imp_expr_eval_same σc pd₁ pd₂ s :
       lookup_equiv_on (nnrs_imp_expr_free_vars s) pd₁ pd₂ ->
       nnrs_imp_expr_eval σc pd₁ s = nnrs_imp_expr_eval σc pd₂ s.

--- a/coq/NNRSimp/Lang/NNRSimpEval.v
+++ b/coq/NNRSimp/Lang/NNRSimpEval.v
@@ -963,9 +963,9 @@ Section NNRSimpEval.
           + specialize (IHs1 ((v0, Some d0)::l) σ d); cut2p IHs1.
           + specialize (IHs2 ((v1, Some d0)::l) σ d); cut2p IHs2.
       Qed.
-      
+
     End unused.
-    
+
   End eval_eqs.
 
 End NNRSimpEval.

--- a/coq/Translation/ImpJsontoJavaScriptAst.v
+++ b/coq/Translation/ImpJsontoJavaScriptAst.v
@@ -89,7 +89,7 @@ Section ImpJsontoJavaScriptAst.
     | JSONOpObject atts => mk_object atts el
     | JSONOpAccess att => mk_binary_expr expr_access (el++[expr_literal (literal_string att)])
     | JSONOpHasOwnProperty att => mk_binary_expr object_hasOwnProperty (el++[expr_literal (literal_string att)])
-    | JSONOpToString => mk_unary_expr object_toString el
+    | JSONOpToString => expr_call (expr_identifier "toString") el
     | JSONOpMathMin => expr_call (expr_member (expr_identifier "Math") "min") el
     | JSONOpMathMax => expr_call (expr_member (expr_identifier "Math") "max") el
     | JSONOpMathMinApply =>
@@ -114,7 +114,6 @@ Section ImpJsontoJavaScriptAst.
   Fixpoint imp_json_expr_to_js_ast (exp: imp_json_expr) : expr :=
     match exp with
     | ImpExprError v => mk_expr_error
-    | ImpExprGetConstant v => expr_identifier v
     | ImpExprVar v => expr_identifier v
     | ImpExprConst j => json_to_js_ast j
     | ImpExprOp op el => imp_json_op_to_js_ast op (map imp_json_expr_to_js_ast el)
@@ -153,13 +152,13 @@ Section ImpJsontoJavaScriptAst.
 
   Definition imp_json_function_to_js_ast (f: imp_function) : list string * funcbody :=
     match f with
-    | ImpFun lv s ret =>
+    | ImpFun v s ret =>
       let body := imp_json_stmt_to_js_ast s in
       let ret := scope (body :: stat_return (Some (expr_identifier ret)) :: nil) in
       let prog :=
           prog_intro strictness_true [ element_stat ret ]
       in
-      (lv, funcbody_intro prog (prog_to_string prog))
+      ([v], funcbody_intro prog (prog_to_string prog))
     end.
 
   Definition imp_json_to_js_ast (q: imp) : list funcdecl :=

--- a/coq/Translation/ImpQcerttoImpJson.v
+++ b/coq/Translation/ImpQcerttoImpJson.v
@@ -238,7 +238,6 @@ Section ImpJsontoJavaScriptAst.
   Fixpoint imp_qcert_expr_to_imp_json (exp: imp_qcert_expr) : imp_json_expr :=
     match exp with
     | ImpExprError msg => ImpExprError msg
-    | ImpExprGetConstant v => ImpExprGetConstant v
     | ImpExprVar v => ImpExprVar v
     | ImpExprConst d => ImpExprConst (@data_to_json _ _ d)
     | ImpExprOp op el => imp_qcert_op_to_imp_json op (map imp_qcert_expr_to_imp_json el)
@@ -263,15 +262,15 @@ Section ImpJsontoJavaScriptAst.
     Qed.
 
     Lemma test 
-          (σc:bindings) (σ:pd_bindings) (el:list imp_expr) :
+          (σ:pd_bindings) (el:list imp_expr) :
       Forall
         (fun exp : imp_expr =>
-           imp_qcert_expr_eval h σc σ exp =
+           imp_qcert_expr_eval h σ exp =
            lift_result
-             (imp_json_expr_eval (lift_bindings σc) (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json exp))) el -> 
-      map (fun x : imp_qcert_expr => imp_qcert_expr_eval h σc σ x) el =
+             (imp_json_expr_eval (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json exp))) el -> 
+      map (fun x : imp_qcert_expr => imp_qcert_expr_eval h σ x) el =
       map (fun x : imp_qcert_expr => lift_result
-             (imp_json_expr_eval (lift_bindings σc) (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json x))) el.
+             (imp_json_expr_eval (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json x))) el.
     Proof.
       intros.
       apply map_eq.
@@ -279,17 +278,16 @@ Section ImpJsontoJavaScriptAst.
     Qed.
 
     Lemma imp_qcert_unary_op_to_imp_json_expr_correct
-           (σc:bindings) (σ:pd_bindings) (u:unary_op) (el:list imp_expr) :
+           (σ:pd_bindings) (u:unary_op) (el:list imp_expr) :
       Forall
         (fun exp : imp_expr =>
-           imp_qcert_expr_eval h σc σ exp =
+           imp_qcert_expr_eval h σ exp =
            lift_result
              (imp_json_expr_eval
-                (lift_bindings σc)
                 (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json exp))) el -> 
-      imp_qcert_expr_eval h σc σ (ImpExprOp (QcertOpUnary u) el) =
+      imp_qcert_expr_eval h σ (ImpExprOp (QcertOpUnary u) el) =
       lift_result
-        (imp_json_expr_eval (lift_bindings σc) (lift_pd_bindings σ)
+        (imp_json_expr_eval (lift_pd_bindings σ)
                             (imp_qcert_unary_op_to_imp_json u (map imp_qcert_expr_to_imp_json el))).
     Proof.
       intros.
@@ -299,60 +297,57 @@ Section ImpJsontoJavaScriptAst.
         rewrite test; [|assumption]; clear H.
         destruct el; simpl; [reflexivity|]; destruct el; simpl.
         + simpl; unfold lift_result, lift, olift.
-          destruct (imp_json_expr_eval (lift_bindings σc) (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json i));
+          destruct (imp_json_expr_eval (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json i));
             try reflexivity.
         + unfold olift, lift_result, lift; simpl.
-          destruct (imp_json_expr_eval (lift_bindings σc) (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json i)); try reflexivity.
-          destruct (imp_json_expr_eval (lift_bindings σc) (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json i0)); try reflexivity.
+          destruct (imp_json_expr_eval (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json i)); try reflexivity.
+          destruct (imp_json_expr_eval (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json i0)); try reflexivity.
           rewrite lift_map_map_fusion.
           admit.
       - admit.
     Admitted.
 
     Lemma imp_qcert_binary_op_to_imp_json_expr_correct
-           (σc:bindings) (σ:pd_bindings) (b:binary_op) (el:list imp_expr) :
+           (σ:pd_bindings) (b:binary_op) (el:list imp_expr) :
       Forall
         (fun exp : imp_expr =>
-           imp_qcert_expr_eval h σc σ exp =
+           imp_qcert_expr_eval h σ exp =
            lift_result
              (imp_json_expr_eval
-                (lift_bindings σc)
                 (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json exp))) el -> 
-      imp_qcert_expr_eval h σc σ (ImpExprOp (QcertOpBinary b) el) =
+      imp_qcert_expr_eval h σ (ImpExprOp (QcertOpBinary b) el) =
       lift_result
-        (imp_json_expr_eval (lift_bindings σc) (lift_pd_bindings σ)
+        (imp_json_expr_eval (lift_pd_bindings σ)
                             (imp_qcert_binary_op_to_imp_json b (map imp_qcert_expr_to_imp_json el))).
     Proof.
     Admitted.
 
     Lemma imp_qcert_runtime_call_to_imp_json_expr_correct
-           (σc:bindings) (σ:pd_bindings) (rt:imp_qcert_runtime_op) (el:list imp_expr) :
+            (σ:pd_bindings) (rt:imp_qcert_runtime_op) (el:list imp_expr) :
       Forall
         (fun exp : imp_expr =>
-           imp_qcert_expr_eval h σc σ exp =
+           imp_qcert_expr_eval h σ exp =
            lift_result
              (imp_json_expr_eval
-                (lift_bindings σc)
                 (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json exp))) el -> 
-      imp_qcert_expr_eval h σc σ (ImpExprRuntimeCall rt el) =
+      imp_qcert_expr_eval h σ (ImpExprRuntimeCall rt el) =
       lift_result
-        (imp_json_expr_eval (lift_bindings σc) (lift_pd_bindings σ)
+        (imp_json_expr_eval (lift_pd_bindings σ)
                             (imp_qcert_runtime_call_to_imp_json rt (map imp_qcert_expr_to_imp_json el))).
     Proof.
     Admitted.
 
     Lemma imp_qcert_op_to_imp_json_correct
-          (σc:bindings) (σ:pd_bindings) (op:imp_qcert_op) (el:list imp_expr) :
+          (σ:pd_bindings) (op:imp_qcert_op) (el:list imp_expr) :
       Forall
         (fun exp : imp_expr =>
-           imp_qcert_expr_eval h σc σ exp =
+           imp_qcert_expr_eval h σ exp =
            lift_result
              (imp_json_expr_eval
-                (lift_bindings σc)
                 (lift_pd_bindings σ) (imp_qcert_expr_to_imp_json exp))) el -> 
-      imp_qcert_expr_eval h σc σ (ImpExprOp op el) =
+      imp_qcert_expr_eval h σ (ImpExprOp op el) =
       lift_result
-        (imp_json_expr_eval (lift_bindings σc) (lift_pd_bindings σ)
+        (imp_json_expr_eval (lift_pd_bindings σ)
                             (imp_qcert_op_to_imp_json op (map imp_qcert_expr_to_imp_json el))).
     Proof.
       intros.
@@ -361,17 +356,15 @@ Section ImpJsontoJavaScriptAst.
       + apply imp_qcert_binary_op_to_imp_json_expr_correct; assumption.
     Qed.
      
-    Lemma imp_qcert_expr_to_imp_json_expr_correct (σc:bindings) (σ:pd_bindings) (exp:imp_qcert_expr) :
-      imp_qcert_expr_eval h σc σ exp =
+    Lemma imp_qcert_expr_to_imp_json_expr_correct (σ:pd_bindings) (exp:imp_qcert_expr) :
+      imp_qcert_expr_eval h σ exp =
       lift_result
-        (imp_json_expr_eval (lift_bindings σc) (lift_pd_bindings σ)
+        (imp_json_expr_eval (lift_pd_bindings σ)
                             (imp_qcert_expr_to_imp_json exp)).
     Proof.
       imp_expr_cases (induction exp) Case.
       - Case "ImpExprError"%string.
         reflexivity.
-      - Case "ImpExprGetConstant"%string.
-        admit. (* XXX Needs lift/unlift roundtrip property over edot *)
       - Case "ImpExprVar"%string.
         admit. (* XXX Needs lift/unlift roundtrip property over lookup *)
       - Case "ImpExprConst"%string.
@@ -422,7 +415,7 @@ Section ImpJsontoJavaScriptAst.
 
   Definition imp_qcert_function_to_imp_json (f:imp_qcert_function) : imp_json_function :=
     match f with
-    | ImpFun lv s ret => ImpFun lv (imp_qcert_stmt_to_imp_json lv s) ret
+    | ImpFun v s ret => ImpFun v (imp_qcert_stmt_to_imp_json [v] s) ret
     end.
 
   Fixpoint imp_qcert_to_imp_json (i:imp_qcert) : imp_json :=

--- a/ocaml/src/AstsToSExp.ml
+++ b/ocaml/src/AstsToSExp.ml
@@ -663,7 +663,6 @@ let sexp_to_nnrs_imp (se:sexp) : QLang.nnrs_imp =
 let imp_expr_to_sexp data_to_sexp op_to_sexp runtime_op_to_sexp e : sexp =
   let rec imp_expr_to_sexp e : sexp =
     match e with
-    | ImpExprGetConstant v -> STerm ("ImpExprGetConstant", [SString (string_of_char_list v)])
     | ImpExprVar v -> STerm ("ImpExprVar", [SString (string_of_char_list v)])
     | ImpExprConst d -> STerm ("ImpExprConst", [data_to_sexp d])
     | ImpExprOp (op, args) -> STerm ("ImpExprOp", (op_to_sexp op) :: List.map imp_expr_to_sexp args)
@@ -682,8 +681,8 @@ let imp_stmt_to_sexp data_to_sexp op_to_sexp runtime_op_to_sexp s : sexp =
   in
   imp_stmt_to_sexp s
 
-let imp_function_to_sexp data_to_sexp op_to_sexp runtime_op_to_sexp (ImpFun(vars, s, ret)) : sexp =
-  STerm ("ImpFun", [STerm ("ImpFunArgs", List.map (fun x -> SString (string_of_char_list x)) vars);
+let imp_function_to_sexp data_to_sexp op_to_sexp runtime_op_to_sexp (ImpFun(var, s, ret)) : sexp =
+  STerm ("ImpFun", [STerm ("ImpFunArgs", [SString (string_of_char_list var)]);
                     imp_stmt_to_sexp data_to_sexp op_to_sexp runtime_op_to_sexp s;
                     STerm ("ImpFunReturn", [SString (string_of_char_list ret)])])
 

--- a/ocaml/src/PrettyQuery.ml
+++ b/ocaml/src/PrettyQuery.ml
@@ -385,7 +385,6 @@ let pretty_nnrs_imp greek margin annot inheritance link_runtime q =
 let pretty_imp_expr pretty_data pretty_op pretty_runtime p sym ff e =
   let rec pretty_imp_expr p sym ff e =
     match e with
-    | QcertCompiler.ImpExprGetConstant v -> fprintf ff "%s"  (Util.string_of_char_list v)
     | QcertCompiler.ImpExprVar v -> fprintf ff "%s"  (Util.string_of_char_list v)
     | QcertCompiler.ImpExprConst d -> fprintf ff "%a" pretty_data d
     | QcertCompiler.ImpExprOp (op,args) -> (pretty_op p sym pretty_imp_expr) ff (op, args)
@@ -442,9 +441,9 @@ let pretty_imp_return pretty_data pretty_op pretty_runtime p sym ff ret =
     (pretty_imp_expr 0 sym) (QcertCompiler.ImpExprVar ret)
 
 let pretty_imp_function pretty_data pretty_op pretty_runtime p sym ff f =
-  let QcertCompiler.ImpFun (args, body, ret) = f in
+  let QcertCompiler.ImpFun (arg, body, ret) = f in
   fprintf ff "@[<hv 0>function (@[<hv 2>%a@]) {@;<1 2>%a@;<1 2>%a@ }@]"
-    (pp_print_list ~pp_sep:(fun ff () -> fprintf ff ",@;<1 0>") (fun ff v -> fprintf ff "%s" (Util.string_of_char_list v))) args
+    (fun ff v -> fprintf ff "%s" (Util.string_of_char_list v)) arg
     (pretty_imp_stmt pretty_data pretty_op pretty_runtime p sym) body
     (pretty_imp_return pretty_data pretty_op pretty_runtime p sym) ret
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -101,7 +101,7 @@ oql-string-tests:
                             -eval-validate -output oql/string$(N).out || exit 1;))
 oql-string-tests-js:
 	@$(foreach N,$(OQLSTRINGNUM), \
-	       $(QCERTCOMP) -source oql -target js oql/string$(N).oql \
+	       $(QCERTCOMP) -source oql -path imp_qcert -target js oql/string$(N).oql \
                             -eval-validate -schema oql/string.schema; \
 	       $(JAVARUN) -cp $(CPATH) testing.runners.RunJavascript \
                           -runtime ../runtimes/javascript/qcert-runtime.js \


### PR DESCRIPTION
The constants are given by the argument of the query as a record named `constants`. The access to a constant `x`
is then `constants.x`.

To simplify the code, Imp functions now only take one argument.