### PR TITLE
Coq 8.11.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ common_steps: &common_steps
     - run:
         name: "Install Coq deps"
         command: |
-          opam install -y -v coq.8.8.2 coq-flocq coq-jsast.1.0.9
+          opam install -y -v coq.8.11.2 coq-jsast.2.0.0
         no_output_timeout: 30m
     - save_cache:
         <<: *common_cache_key

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ log/
 *~
 .#*
 *.vo
+*.vos
+*.vok
 *.v.d
 *.glob
 *.aux

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ log/
 *.glob
 *.aux
 .DS_Store
+*.lia.cache
+.Makefile.coq.d

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ An easy way to get set up on most platforms is to use the OCaml package manager 
 ```
 $ opam repo add coq-released https://coq.inria.fr/opam/released
 $ opam install dune menhir base64 js_of_ocaml js_of_ocaml-ppx calendar uri
-$ opam install coq.8.8.2 coq-flocq coq-jsast
+$ opam install coq.8.11.2 coq-jsast
 ```
 
 #### Java (Recommended)

--- a/compiler/core/Brands/BrandRelation.v
+++ b/compiler/core/Brands/BrandRelation.v
@@ -1413,7 +1413,7 @@ Proof.
     apply c. reflexivity.
 Defined.
    
-Hint Resolve canon_brands_is_canon_brands.
+Hint Resolve canon_brands_is_canon_brands : qcert.
 
 Instance ToString_brands : ToString brands
   := { toString := fun b => (String.concat " & " b)}.

--- a/compiler/core/Brands/BrandRelation.v
+++ b/compiler/core/Brands/BrandRelation.v
@@ -1356,7 +1356,7 @@ Section brands_lattice.
 
   Context {br:brand_relation}.
   
-  Global Instance brands_lattice : Lattice brands (equiv_brands brand_relation_brands)
+  #[refine] Global Instance brands_lattice : Lattice brands (equiv_brands brand_relation_brands)
     := { meet:=brand_meet brand_relation_brands;
          join:=brand_join brand_relation_brands
        }.

--- a/compiler/core/CAMP/Lang/CAMP.v
+++ b/compiler/core/CAMP/Lang/CAMP.v
@@ -38,7 +38,9 @@ Require Import Morphisms.
 Require Import Utils.
 Require Import DataRuntime.
 Require Import CAMPUtil.
-  
+
+Declare Scope camp_scope.
+
 Section CAMP.
   Local Open Scope string.
 

--- a/compiler/core/CAMP/Lang/CAMPSize.v
+++ b/compiler/core/CAMP/Lang/CAMPSize.v
@@ -12,7 +12,7 @@
  * limitations under the License.
  *)
 
-Require Import Omega.
+Require Import Lia.
 Require Import DataRuntime.
 Require Import CAMP.
 
@@ -38,7 +38,7 @@ Section CAMPSize.
 
   Lemma camp_size_nzero (a:camp) : camp_size a <> 0.
   Proof.
-    induction a; simpl; omega.
+    induction a; simpl; lia.
   Qed.
 
 End CAMPSize.

--- a/compiler/core/CAMP/Lang/CAMPUtil.v
+++ b/compiler/core/CAMP/Lang/CAMPUtil.v
@@ -97,7 +97,7 @@ Section CAMPUtil.
 
   (** Accumulates successful evaluation, but propagating match failure to the top *)
   
-  Fixpoint enforce_successes {A:Type} (os:list (presult A)) : presult (list A)
+  Definition enforce_successes {A:Type} (os:list (presult A)) : presult (list A)
     := match os with
        | nil => Success nil
        | (TerminalError)::xs => TerminalError
@@ -172,7 +172,7 @@ Section CAMPUtil.
          | (Success_debug a)::xs => liftpr_debug (cons a) (gather_successes_debug xs)
          end.
 
-    Fixpoint enforce_successes_debug {A:Type} (os:list (presult_debug A)) : presult_debug (list A)
+    Definition enforce_successes_debug {A:Type} (os:list (presult_debug A)) : presult_debug (list A)
       := match os with
          | nil => Success_debug nil
          | (TerminalError_debug s loc)::xs => TerminalError_debug s loc

--- a/compiler/core/CAMP/Typing/TCAMP.v
+++ b/compiler/core/CAMP/Typing/TCAMP.v
@@ -37,7 +37,7 @@ Section TCAMP.
   (** Typing for CAMP *)
 
   Context {m:basic_model}.
-  Hint Resolve bindings_type_has_type.
+  Hint Resolve bindings_type_has_type : qcert.
 
   Reserved Notation "Γ  |= p ; a ~> b" (at level 90).
 
@@ -105,7 +105,7 @@ Section TCAMP.
     apply Forall2_nil.
   Qed.
 
-  Hint Resolve data_type_drec_nil.
+  Hint Resolve data_type_drec_nil : qcert.
 
   Lemma concat_bindings_type {env₁ env₂ Γ₁ Γ₂} :
     bindings_type env₁ Γ₁ ->
@@ -240,7 +240,7 @@ Section TCAMP.
     - destruct (IHp _ _ _ _ _ tenv H1 tdat) as [[dout[camp_evaleq tx]]|camp_evaleq];
         rewrite camp_evaleq; simpl; [|eauto].
       inversion tx; subst.
-      destruct b; simpl; eauto.
+      destruct b; simpl; qeauto.
     (* porElse *)
     - destruct (IHp1 _ _ _ _ _ tenv H2 tdat) as [[dout1[camp_evaleq1 tx1]]|camp_evaleq1];
         rewrite camp_evaleq1; simpl; [|eauto].
@@ -264,7 +264,7 @@ Section TCAMP.
       rewrite eqq1.
       eauto.
     (* penv *)
-    - eauto.
+    - qeauto.
     (* pletEnv *)
     - destruct (IHp1 _ _ _ _ _ tenv H1 tdat) as [[dout1[camp_evaleq1 tx1]]|camp_evaleq1];
         rewrite camp_evaleq1; simpl; [|eauto].
@@ -285,7 +285,7 @@ Section TCAMP.
       + subst; eauto.
   Qed.
 
-  Hint Constructors camp_type.
+  Hint Constructors camp_type : qcert.
 
   (** Additional lemma used in the correctness for typed translation from NNRC to CAMP *)
   Lemma camp_type_tenv_rec {τc Γ p τ₁ τ₂} :
@@ -295,9 +295,9 @@ Section TCAMP.
   Proof.
     simpl.
     intros nod tdev.
-    dependent induction tdev; simpl; eauto.
+    dependent induction tdev; simpl; qeauto.
     - rewrite <- (Rec_rewrite Closed (rec_sort_is_sorted Γ) pf (@sort_sorted_is_id string ODT_string _ Γ pf)).
-      eauto.
+      qeauto.
     - econstructor; eauto.
       unfold merge_bindings in *.      
       case_eq (Compat.compatible Γ Γ'); 
@@ -305,7 +305,7 @@ Section TCAMP.
       inversion H; subst.
       assert (perm:Permutation Γ (rec_sort Γ)) 
         by (apply rec_sort_perm; auto).
-      apply (compatible_perm_proper_l _ _ _ perm) in comp; eauto 2.
+      apply (compatible_perm_proper_l _ _ _ perm) in comp; eauto 2 with qcert.
       rewrite comp.
       f_equal.
       unfold rec_concat_sort.
@@ -317,7 +317,7 @@ Section TCAMP.
     [τc & Γ] |= p; τ₁ ~> τ₂.
   Proof.
     revert τc Γ τ₁ τ₂.
-    induction p; simpl; inversion 1; rtype_equalizer; subst; eauto.
+    induction p; simpl; inversion 1; rtype_equalizer; subst; qeauto.
     unfold tdot, edot in *.
     rewrite (assoc_lookupr_drec_sort (odt:=ODT_string)) in H2.
     econstructor. apply H2.
@@ -328,7 +328,7 @@ Section TCAMP.
     [rec_sort τc & Γ] |= p; τ₁ ~> τ₂.
   Proof.
     revert τc Γ τ₁ τ₂.
-    induction p; simpl; inversion 1; rtype_equalizer; subst; eauto.
+    induction p; simpl; inversion 1; rtype_equalizer; subst; qeauto.
     econstructor.
     unfold tdot, edot.
     rewrite (assoc_lookupr_drec_sort (odt:=ODT_string)).

--- a/compiler/core/CAMP/Typing/TCAMPSugar.v
+++ b/compiler/core/CAMP/Typing/TCAMPSugar.v
@@ -24,7 +24,7 @@ Require Export TCAMP.
 Section TCAMPSugar.
   Local Open Scope camp_scope.
 
-  Hint Constructors camp_type.
+  Hint Constructors camp_type : qcert.
 
   Context {m:basic_model}.
 
@@ -48,7 +48,7 @@ Section TCAMPSugar.
     econstructor.
     + repeat econstructor; eauto.
     + rewrite merge_bindings_nil_r; eauto.
-    + simpl. apply camp_type_tenv_rec; eauto.
+    + simpl. apply camp_type_tenv_rec; qeauto.
       Grab Existential Variables.
       eauto.
   Qed.

--- a/compiler/core/CAMPRule/Lang/CAMPRuleSugar.v
+++ b/compiler/core/CAMPRule/Lang/CAMPRuleSugar.v
@@ -18,7 +18,7 @@ Require Import Utils.
 Require Import DataRuntime.
 Require Export CAMPSugar.
 Require Export CAMPRule.
-  
+
 Section CAMPRuleSugar.
   (* This file defines derived patterns, notations, and concepts *)
   Local Open Scope camp_scope.

--- a/compiler/core/Compiler/Enhanced/EnhancedType.v
+++ b/compiler/core/Compiler/Enhanced/EnhancedType.v
@@ -96,7 +96,7 @@ Proof.
     inversion H; inversion H0; congruence.
 Qed.
 
-Instance enhanced_type_lattice : Lattice enhanced_type eq
+#[refine] Instance enhanced_type_lattice : Lattice enhanced_type eq
   := {
       join := enhanced_type_join
       ; meet := enhanced_type_meet

--- a/compiler/core/Compiler/Lib/QUtil.v
+++ b/compiler/core/Compiler/Lib/QUtil.v
@@ -46,7 +46,7 @@ Module QUtil(runtime:CompilerRuntime).
 
   Section results.
     Definition qerror {fdata:foreign_data} : Set := DataResult.qerror.
-    Definition qresult {fdata:foreign_data} (A:Set) : Set := DataResult.qresult A.
+    Definition qresult {fdata:foreign_data} (A:Set) := DataResult.qresult A.
 
     Definition qsuccess {fdata:foreign_data} (A:Set) : A -> qresult A := DataResult.qsuccess.
     Definition qfailure {fdata:foreign_data} (A:Set) : qerror -> qresult A := DataResult.qfailure.

--- a/compiler/core/Compiler/Model/CompilerModel.v
+++ b/compiler/core/Compiler/Model/CompilerModel.v
@@ -36,29 +36,27 @@ Require Import DNNRC.
 Require Import tDNNRC.
 Require Import NNRSimp.
 
-Set Typeclasses Axioms Are Instances.
-
 Module Type CompilerModel.
-  Axiom compiler_basic_model : basic_model.
-  Axiom compiler_model_foreign_runtime : foreign_runtime.
-  Axiom compiler_model_foreign_ejson : foreign_ejson.
-  Axiom compiler_model_foreign_to_ejson : foreign_to_ejson.
-  Axiom compiler_model_foreign_to_ejson_runtime : foreign_to_ejson_runtime.
-  Axiom compiler_model_foreign_to_json : foreign_to_json.
-  Axiom compiler_model_foreign_to_java : foreign_to_java.
-  Axiom compiler_model_foreign_ejson_to_ajavascript : foreign_ejson_to_ajavascript.
-  Axiom compiler_model_foreign_to_scala : foreign_to_scala.
-  Axiom compiler_model_foreign_type_to_JSON : foreign_type_to_JSON.
-  Axiom compiler_model_foreign_reduce_op : foreign_reduce_op.
-  Axiom compiler_model_foreign_to_reduce_op : foreign_to_reduce_op.
-  Axiom compiler_model_foreign_to_spark : foreign_to_spark.
-  Axiom compiler_model_nraenv_optimizer_logger : optimizer_logger string nraenv.
-  Axiom compiler_model_nnrc_optimizer_logger : optimizer_logger string nnrc.
-  Axiom compiler_model_nnrs_imp_expr_optimizer_logger : optimizer_logger string nnrs_imp_expr.
-  Axiom compiler_model_nnrs_imp_stmt_optimizer_logger : optimizer_logger string nnrs_imp_stmt.
-  Axiom compiler_model_nnrs_imp_optimizer_logger : optimizer_logger string nnrs_imp.
-  Axiom compiler_model_dnnrc_optimizer_logger : forall {br:brand_relation}, optimizer_logger string (dnnrc_typed).
-  Axiom compiler_model_foreign_data_typing : foreign_data_typing.
+  Declare Instance compiler_basic_model : basic_model.
+  Declare Instance compiler_model_foreign_runtime : foreign_runtime.
+  Declare Instance compiler_model_foreign_ejson : foreign_ejson.
+  Declare Instance compiler_model_foreign_to_ejson : foreign_to_ejson.
+  Declare Instance compiler_model_foreign_to_ejson_runtime : foreign_to_ejson_runtime.
+  Declare Instance compiler_model_foreign_to_json : foreign_to_json.
+  Declare Instance compiler_model_foreign_to_java : foreign_to_java.
+  Declare Instance compiler_model_foreign_ejson_to_ajavascript : foreign_ejson_to_ajavascript.
+  Declare Instance compiler_model_foreign_to_scala : foreign_to_scala.
+  Declare Instance compiler_model_foreign_type_to_JSON : foreign_type_to_JSON.
+  Declare Instance compiler_model_foreign_reduce_op : foreign_reduce_op.
+  Declare Instance compiler_model_foreign_to_reduce_op : foreign_to_reduce_op.
+  Declare Instance compiler_model_foreign_to_spark : foreign_to_spark.
+  Declare Instance compiler_model_nraenv_optimizer_logger : optimizer_logger string nraenv.
+  Declare Instance compiler_model_nnrc_optimizer_logger : optimizer_logger string nnrc.
+  Declare Instance compiler_model_nnrs_imp_expr_optimizer_logger : optimizer_logger string nnrs_imp_expr.
+  Declare Instance compiler_model_nnrs_imp_stmt_optimizer_logger : optimizer_logger string nnrs_imp_stmt.
+  Declare Instance compiler_model_nnrs_imp_optimizer_logger : optimizer_logger string nnrs_imp.
+  Declare Instance compiler_model_dnnrc_optimizer_logger : forall {br:brand_relation}, optimizer_logger string (dnnrc_typed).
+  Declare Instance compiler_model_foreign_data_typing : foreign_data_typing.
 End CompilerModel.
 
 Module CompilerModelRuntime(model:CompilerModel) <: CompilerRuntime.
@@ -106,9 +104,9 @@ End CompilerModelRuntime.
 
 (* Useful utility module functors that create a CompilerModel *)
 Module Type CompilerForeignType.
-  Axiom compiler_foreign_type : foreign_type.
+  Declare Instance compiler_foreign_type : foreign_type.
 End CompilerForeignType.
 Module Type CompilerBrandModel(ftype:CompilerForeignType).
-  Axiom compiler_brand_model : brand_model.
+  Declare Instance compiler_brand_model : brand_model.
 End CompilerBrandModel.
 

--- a/compiler/core/Compiler/Model/CompilerRuntime.v
+++ b/compiler/core/Compiler/Model/CompilerRuntime.v
@@ -35,28 +35,26 @@ Require Import DNNRC.
 Require Import tDNNRC.
 Require Import NNRSimp.
 
-Set Typeclasses Axioms Are Instances.
-
 Module Type CompilerRuntime.
-  Axiom compiler_foreign_type : foreign_type.
-  Axiom compiler_foreign_runtime : foreign_runtime.
-  Axiom compiler_foreign_ejson : foreign_ejson.
-  Axiom compiler_foreign_to_ejson : foreign_to_ejson.
-  Axiom compiler_foreign_to_ejson_runtime : foreign_to_ejson_runtime.
-  Axiom compiler_foreign_to_json : foreign_to_json.
-  Axiom compiler_foreign_to_java : foreign_to_java.
-  Axiom compiler_foreign_ejson_to_ajavascript : foreign_ejson_to_ajavascript.
-  Axiom compiler_foreign_to_scala : foreign_to_scala.
-  Axiom compiler_foreign_type_to_JSON : foreign_type_to_JSON.
-  Axiom compiler_foreign_reduce_op : foreign_reduce_op.
-  Axiom compiler_foreign_to_reduce_op : foreign_to_reduce_op.
-  Axiom compiler_foreign_to_spark : foreign_to_spark.
-  Axiom compiler_nraenv_optimizer_logger : optimizer_logger string nraenv.
-  Axiom compiler_nnrc_optimizer_logger : optimizer_logger string nnrc.
-  Axiom compiler_nnrs_imp_expr_optimizer_logger : optimizer_logger string nnrs_imp_expr.
-  Axiom compiler_nnrs_imp_stmt_optimizer_logger : optimizer_logger string nnrs_imp_stmt.
-  Axiom compiler_nnrs_imp_optimizer_logger : optimizer_logger string nnrs_imp.
-  Axiom compiler_dnnrc_optimizer_logger : forall {br:brand_relation}, optimizer_logger string (dnnrc_typed).
-  Axiom compiler_foreign_data_typing : foreign_data_typing.
+  Declare Instance compiler_foreign_type : foreign_type.
+  Declare Instance compiler_foreign_runtime : foreign_runtime.
+  Declare Instance compiler_foreign_ejson : foreign_ejson.
+  Declare Instance compiler_foreign_to_ejson : foreign_to_ejson.
+  Declare Instance compiler_foreign_to_ejson_runtime : foreign_to_ejson_runtime.
+  Declare Instance compiler_foreign_to_json : foreign_to_json.
+  Declare Instance compiler_foreign_to_java : foreign_to_java.
+  Declare Instance compiler_foreign_ejson_to_ajavascript : foreign_ejson_to_ajavascript.
+  Declare Instance compiler_foreign_to_scala : foreign_to_scala.
+  Declare Instance compiler_foreign_type_to_JSON : foreign_type_to_JSON.
+  Declare Instance compiler_foreign_reduce_op : foreign_reduce_op.
+  Declare Instance compiler_foreign_to_reduce_op : foreign_to_reduce_op.
+  Declare Instance compiler_foreign_to_spark : foreign_to_spark.
+  Declare Instance compiler_nraenv_optimizer_logger : optimizer_logger string nraenv.
+  Declare Instance compiler_nnrc_optimizer_logger : optimizer_logger string nnrc.
+  Declare Instance compiler_nnrs_imp_expr_optimizer_logger : optimizer_logger string nnrs_imp_expr.
+  Declare Instance compiler_nnrs_imp_stmt_optimizer_logger : optimizer_logger string nnrs_imp_stmt.
+  Declare Instance compiler_nnrs_imp_optimizer_logger : optimizer_logger string nnrs_imp.
+  Declare Instance compiler_dnnrc_optimizer_logger : forall {br:brand_relation}, optimizer_logger string (dnnrc_typed).
+  Declare Instance compiler_foreign_data_typing : foreign_data_typing.
 End CompilerRuntime.
 

--- a/compiler/core/DNNRC/Lang/DNNRCBase.v
+++ b/compiler/core/DNNRC/Lang/DNNRCBase.v
@@ -22,6 +22,7 @@ Require Import Utils.
 Require Import DataRuntime.
 Require Import cNRAEnv.
 
+Declare Scope dnnrc_scope.
 Section DNNRCBase.
   Context {fruntime:foreign_runtime}.
   

--- a/compiler/core/DNNRC/Lang/DNNRCBaseEq.v
+++ b/compiler/core/DNNRC/Lang/DNNRCBaseEq.v
@@ -121,7 +121,7 @@ Section DNNRCBaseEq.
 
   (* DNNRCFor *)
 
-  Hint Resolve data_normalized_dcoll_in.
+  Hint Resolve data_normalized_dcoll_in : qcert.
 
   Global Instance dfor_proper : Proper (eq ==> eq ==> dnnrc_base_eq ==> dnnrc_base_eq ==> dnnrc_base_eq) DNNRCFor.
   Proof.

--- a/compiler/core/DNNRC/Lang/DNNRCBaseSize.v
+++ b/compiler/core/DNNRC/Lang/DNNRCBaseSize.v
@@ -13,7 +13,7 @@
  *)
 
 Require Import List.
-Require Import Omega.
+Require Import Lia.
 Require Import DataRuntime.
 Require Import DNNRCBase.
 
@@ -43,7 +43,7 @@ Section size.
 
   Lemma dnnrc_base_size_nzero (d:@dnnrc_base _ A plug_type) : dnnrc_base_size d <> 0.
   Proof.
-    induction d; simpl; omega.
+    induction d; simpl; lia.
   Qed.
 
 End size.

--- a/compiler/core/DNNRC/Typing/TDNNRCBase.v
+++ b/compiler/core/DNNRC/Typing/TDNNRCBase.v
@@ -22,6 +22,9 @@ Require Import Utils.
 Require Import DataSystem.
 Require Import DNNRCBase.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section TDNNRCBase.
 
   Context {m:basic_model}.

--- a/compiler/core/Data/DataRuntime.v
+++ b/compiler/core/Data/DataRuntime.v
@@ -12,7 +12,10 @@
  * limitations under the License.
  *)
 
+Declare Scope data_scope.
+
 Require Export ForeignRuntime.
 Require Export BrandRelation.
 Require Export DataModel.
 Require Export Operators.
+

--- a/compiler/core/Data/Model/DataNorm.v
+++ b/compiler/core/Data/Model/DataNorm.v
@@ -107,7 +107,7 @@ Section DataNorm.
         reflexivity.
     - constructor; trivial.
     - constructor; trivial.
-    - constructor; trivial.
+    - constructor; qtrivial.
     - constructor.
       apply foreign_data_normalize_normalizes.
   Qed.
@@ -195,9 +195,9 @@ Section DataNorm.
     data_normalized (drec (rec_sort (l1 ++ l2))).
   Proof.
     inversion 1; inversion 1; subst.
-    constructor; eauto 1.
+    constructor; eauto 1 with qcert.
     apply Forall_sorted.
-    apply Forall_app; trivial.
+    apply Forall_app; qtrivial.
   Qed.
 
   Lemma data_normalized_rec_concat_sort l1 l2 :
@@ -235,7 +235,7 @@ Section DataNorm.
     Forall (fun d : string * data => data_normalized (snd d)) c ->
     data_normalized (drec (rec_sort c)).
   Proof.
-    intros F; econstructor; trivial.
+    intros F; econstructor; trivial with qcert.
     apply Forall_sorted; trivial.
   Qed.
 

--- a/compiler/core/Data/ModelTyping/TBindings.v
+++ b/compiler/core/Data/ModelTyping/TBindings.v
@@ -76,7 +76,7 @@ Section TBindings.
     apply bindings_type_app; trivial.
   Qed.
   
-  Hint Resolve data_type_normalized.
+  Hint Resolve data_type_normalized : qcert.
   Lemma bindings_type_Forall_normalized c τc :
     bindings_type c τc ->
     Forall
@@ -85,10 +85,10 @@ Section TBindings.
   Proof.
     induction 1; trivial.
     intuition.
-    eauto.
+    qeauto.
   Qed.
 
 End TBindings.
 
-Hint Resolve bindings_type_Forall_normalized.
+Hint Resolve bindings_type_Forall_normalized : qcert.
 

--- a/compiler/core/Data/ModelTyping/TDBindings.v
+++ b/compiler/core/Data/ModelTyping/TDBindings.v
@@ -42,7 +42,7 @@ Section TDBindings.
                       (fst xy1) = (fst xy2)
                   /\ ddata_type (snd xy1) (snd xy2)) b t.
 
-  Hint Resolve ddata_dtype_normalized.
+  Hint Resolve ddata_dtype_normalized : qcert.
   Lemma dbindings_type_Forall_normalized c τc :
     dbindings_type c τc ->
     Forall
@@ -131,5 +131,5 @@ Section TDBindings.
 
 End TDBindings.
 
-Hint Resolve dbindings_type_Forall_normalized.
+Hint Resolve dbindings_type_Forall_normalized : qcert.
 

--- a/compiler/core/Data/ModelTyping/TData.v
+++ b/compiler/core/Data/ModelTyping/TData.v
@@ -511,7 +511,7 @@ Lemma data_type_Rec_domain {r k l pf} :
 Proof.
   revert l pf. induction r; inversion 1; rtype_equalizer; subst;
                inversion H5; subst; clear H5.
-  - apply sublist_nil_r in H3; subst; simpl; auto.
+  - apply sublist_nil_r in H3; subst; simpl; qauto.
   - simpl. intuition.
     rewrite H0.
     apply sublist_domain in H3.
@@ -845,7 +845,8 @@ Qed.
   Proof.
     apply dttop.
   Qed.
-  Hint Resolve dttop dttop'.
+  
+  Hint Resolve dttop dttop' : qcert.
 
   Lemma Forall_map {A B} P (f:A->B) l :
     Forall P (map f l) <-> Forall (fun x => P (f x)) l.
@@ -859,10 +860,10 @@ Qed.
   Lemma data_type_normalized d τ :
     d ▹ τ -> data_normalized brand_relation_brands d.
   Proof.
-    Hint Constructors data_normalized.
+    Hint Constructors data_normalized : qcert.
     revert τ.
     induction d using dataInd2; intros; try assumption; simpl in *;
-    auto 2.
+    auto 2 with qcert.
     - constructor. inversion H0; subst.
       + inversion H1; trivial.
       + revert H2; apply Forall_impl_in.
@@ -879,13 +880,13 @@ Qed.
       + apply sorted_forall_same_domain in H4.
         rewrite H4.
         trivial.
-    - inversion H; subst; trivial; eauto.
-    - inversion H; subst; trivial; eauto.
-    - inversion H; subst; trivial; constructor; eauto.
+    - inversion H; subst; trivial; qeauto.
+    - inversion H; subst; trivial; qeauto.
+    - inversion H; subst; trivial; constructor; qeauto.
     - invcs H.
       + eauto.
       + constructor.
-        eapply foreign_data_typing_normalized; eauto.
+        eapply foreign_data_typing_normalized; qeauto.
   Qed.
 
   (** Lemma showing that normalization preserves typing *)
@@ -900,7 +901,7 @@ Qed.
   Lemma dttop_weaken {d τ} : data_type d τ -> data_type d ⊤.
   Proof.
     intros H; apply data_type_normalized in H.
-    auto 2.
+    auto 2 with qcert.
   Qed.
 
 End TData.
@@ -989,8 +990,8 @@ Ltac dtype_enrich :=
       extend (dcoll_coll_in_inv H H2)
   end.
 
-Hint Immediate dttop dttop'.
-Hint Resolve dttop_weaken.
+Hint Immediate dttop dttop' : qcert.
+Hint Resolve dttop_weaken : qcert.
 
 Section subtype.
 
@@ -1084,20 +1085,20 @@ Global Instance data_type_subtype_prop
   Proof.
     unfold Proper, respectful, impl, flip.
     intros ? d ? τ₁ τ₂ sub ; subst.
-    Hint Resolve data_type_ext.
-    Hint Resolve data_type_not_bottom.
-    Hint Resolve dtrec_closed_is_open.
-    Hint Constructors data_normalized.
+    Hint Resolve data_type_ext : qcert.
+    Hint Resolve data_type_not_bottom : qcert.
+    Hint Resolve dtrec_closed_is_open : qcert.
+    Hint Constructors data_normalized : qcert.
     
     revert d τ₂ sub.
       induction τ₁ using rtype_rect;
         induction τ₂ using rtype_rect; simpl;
         try autorewrite with rtype_join;
         try solve[inversion 1; subst; intros; 
-                  try solve [intros; dtype_inverter; eauto 2
-                            | eelim data_type_not_bottom; eauto
+                  try solve [intros; dtype_inverter; eauto 2 with qcert
+                            | eelim data_type_not_bottom; qeauto
                             | unfold Top, Bottom, Unit, Nat, Float, Bool, String, Coll, Rec in *;
-                              eauto 2; try r_ext]].
+                              eauto 2 with qcert; try r_ext]].
     - clear IHτ₂. intros.
       inversion H; rtype_equalizer.
       subst.
@@ -1218,20 +1219,20 @@ Global Instance data_type_subtype_prop
           {m:brand_model} {d τ₁ τ₂}:
     d ▹ τ₁ -> d ▹ τ₂ -> d ▹ (τ₁ ⊓ τ₂).
   Proof.
-    Hint Resolve data_type_ext.
-    Hint Resolve data_type_not_bottom.
-    Hint Resolve dtrec_closed_is_open.
-    Hint Constructors data_normalized.
+    Hint Resolve data_type_ext : qcert.
+    Hint Resolve data_type_not_bottom : qcert.
+    Hint Resolve dtrec_closed_is_open : qcert.
+    Hint Constructors data_normalized : qcert.
     
     revert d τ₂.
       induction τ₁ using rtype_rect;
         induction τ₂ using rtype_rect; simpl;
         try autorewrite with rtype_meet;
         try solve[inversion 1; subst; intros; 
-                  try solve [intros; dtype_inverter_with_either; try discriminate; eauto 2
-                            | eelim data_type_not_bottom; eauto
+                  try solve [intros; dtype_inverter_with_either; try discriminate; eauto 2 with qcert
+                            | eelim data_type_not_bottom; qeauto
                             | unfold Top, Bottom, Unit, Nat, Float, Bool, String, Coll, Rec in *;
-                              eauto 2; try r_ext]].
+                              eauto 2 with qcert; try r_ext]].
     - intros; dtype_inverter.
       inversion H; clear H; subst.
       inversion H0; clear H0; subst.
@@ -1426,9 +1427,9 @@ Global Instance data_type_subtype_prop
                 apply sublist_domain in H9.
                 eapply is_list_sorted_sublist; try eapply H9; eauto.
             + rewrite domain_app, map_rtype_meet_domain.
-              apply NoDup_app; eauto 2.
+              apply NoDup_app; eauto 2 with qcert.
               * symmetry; apply lookup_diff_disjoint.
-              * apply NoDup_lookup_diff; eauto.
+              * apply NoDup_lookup_diff; qeauto.
           - intros.
             destruct k; destruct k0; simpl in H0.
             + discriminate.
@@ -1509,15 +1510,15 @@ Global Instance data_type_subtype_prop
                 d ▹ τ
            ) b).
   Proof.
-    Hint Resolve data_type_normalized.
+    Hint Resolve data_type_normalized : qcert.
     rewrite brands_type_alt.
-    induction b; simpl; [ intuition; eauto | ].
+    induction b; simpl; [ intuition; qeauto | ].
     destruct IHb as [IHb1 IHb2].
     case_eq ( lookup string_dec brand_context_types a); intros; simpl.
     - generalize (meet_data_type_iff d r (fold_right rtype_meet ⊤ (brands_type_list b))); simpl; intros eqq.
       rewrite eqq; clear eqq.
       { split; intros [dt dtf].
-        - split; [eauto | ].
+        - split; [qeauto | ].
           constructor.
           + rewrite H. intro; inversion 1; subst; trivial.
           + apply IHb1; trivial.
@@ -1526,7 +1527,7 @@ Global Instance data_type_subtype_prop
           apply IHb2; split; trivial.
       }
     - { split; [intros dt | intros [dt dtf]].
-        - split; [ eauto | ].
+        - split; [ qeauto | ].
           constructor.
           + rewrite H; intros; discriminate.
           + apply IHb1; trivial.
@@ -1596,5 +1597,4 @@ Global Instance data_type_subtype_prop
 *)
 End subtype.
 
-Hint Resolve data_type_normalized. 
-
+Hint Resolve data_type_normalized : qcert. 

--- a/compiler/core/Data/ModelTyping/TDataInfer.v
+++ b/compiler/core/Data/ModelTyping/TDataInfer.v
@@ -192,10 +192,10 @@ Section TDataInfer.
     infer_data_type d = Some τ ->
     d ▹ τ.
   Proof.
-    Hint Constructors data_type Forall Forallt.
+    Hint Constructors data_type Forall Forallt : qcert.
     revert τ.
     induction d; simpl; 
-    try solve[inversion 1; subst; eauto 2].
+    try solve[inversion 1; subst; eauto 2 with qcert].
     - intros τ eqs. apply some_lift in eqs.
       destruct eqs as [t ? ?]; subst τ.
       constructor.
@@ -232,11 +232,11 @@ Section TDataInfer.
     - intros τ eqs.
       apply some_lift in eqs.
       destruct eqs as [t ? ?]; subst τ.
-      eauto.
+      qeauto.
     - intros τ eqs.
       apply some_lift in eqs.
       destruct eqs as [t ? ?]; subst τ.
-      eauto.
+      qeauto.
     - intros τ eqs.
       case_option_in eqs
       ; match_case_in eqs; intros ? re1; rewrite re1 in eqs
@@ -245,7 +245,7 @@ Section TDataInfer.
       ; try discriminate.
       invcs eqs.
       constructor; trivial.
-      + eauto.
+      + qeauto.
       + rewrite Forall_forall.
         intros ? inn τ look.
         specialize (IHd _ eqs0).
@@ -256,12 +256,12 @@ Section TDataInfer.
       + invcs eqs.
         constructor.
         constructor; trivial.
-        eauto.
+        qeauto.
     -intros τ eqs.
      apply some_lift in eqs.
      destruct eqs as [t ? ?]; subst τ.
      apply foreign_data_typing_infer_correct in e.
-     eauto.
+     qeauto.
   Qed.
 
   Theorem infer_data_type_least {d τ₁ τ₂} : 
@@ -269,15 +269,15 @@ Section TDataInfer.
     d ▹τ₂ ->
     τ₁ <: τ₂.
   Proof.
-    Hint Constructors subtype.
+    Hint Constructors subtype : qcert.
     revert τ₁ τ₂.
     induction d; simpl;
       try solve[inversion 1; subst; intros; destruct (istop τ₂); subst; trivial; dtype_inverter; trivial
-               | intros; invcs H; invcs H0; auto 2].
+               | intros; invcs H; invcs H0; auto 2 with qcert].
     - intros τ₁ τ₂ eqs ht.
       apply some_lift in eqs.
       destruct eqs as [? eqs' ?]; subst.
-      destruct (istop τ₂); subst; trivial.
+      destruct (istop τ₂); subst; qtrivial.
       destruct (data_type_dcoll_inv e ht) as [τ₂' ?]; subst.
       constructor.
       clear e.
@@ -285,7 +285,7 @@ Section TDataInfer.
       rtype_equalizer.
       subst.
       revert x H H2 eqs'; clear.
-      induction c; simpl; intros τ fl1 fl2 eqs; invcs eqs; trivial.
+      induction c; simpl; intros τ fl1 fl2 eqs; invcs eqs; qtrivial.
       unfold lift2 in H0.
       case_option_in H0; try discriminate.
       case_option_in H0; try discriminate.
@@ -299,7 +299,7 @@ Section TDataInfer.
       case_option_in eqs; try discriminate.
       destruct (RecMaybe_some_pf eqs) as [pf ?]; subst.
       clear eqs; rename eqs0 into eqs.
-      invcs ht; trivial.
+      invcs ht; qtrivial.
       constructor.
       + intros s τ look.
         apply lookup_in in look.
@@ -340,29 +340,29 @@ Section TDataInfer.
     - intros τ₁ τ₂ eqs ht.
       apply some_lift in eqs.
       destruct eqs as [? eqs' ?]; subst.
-      destruct (istop τ₂); subst; trivial.
+      destruct (istop τ₂); subst; qtrivial.
       destruct (data_type_dleft_inv e ht) as [τ₂' [? ?]]; subst.
       clear e.
       invcs ht; rtype_equalizer.
       subst.
-      eauto.
+      qeauto.
     - intros τ₁ τ₂ eqs ht.
       apply some_lift in eqs.
       destruct eqs as [? eqs' ?]; subst.
-      destruct (istop τ₂); subst; trivial.
+      destruct (istop τ₂); subst; qtrivial.
       destruct (data_type_dright_inv e ht) as [τ₂' [? ?]]; subst.
       clear e.
       invcs ht; rtype_equalizer.
       subst.
-      eauto.
+      qeauto.
     - intros τ₁ τ₂ eqs ht.
       match_destr_in eqs.
       case_option_in eqs; try discriminate.
       match_destr_in eqs.
       + invcs eqs.
-        destruct (istop τ₂); subst; trivial.
-        invcs ht; trivial.
-        eauto.
+        destruct (istop τ₂); subst; qtrivial.
+        invcs ht; qtrivial.
+        qeauto.
       + invcs eqs.
         cut (τ₂ = ⊤); [intros; subst; reflexivity | ].
         invcs ht; trivial.
@@ -371,7 +371,7 @@ Section TDataInfer.
         clear.
         (*        unfold brands_type. *)
         rewrite brands_type_alt.
-        induction b; simpl; trivial; intros.
+        induction b; simpl; qtrivial; intros.
         invcs H3.
         specialize (IHb H2 IHd eqs0).
         rewrite fold_right_app.
@@ -387,7 +387,7 @@ Section TDataInfer.
     - intros τ₁ τ₂ eqs ht.
      apply some_lift in eqs.
      destruct eqs as [t ? ?]; subst.
-     invcs ht; trivial.
+     invcs ht; qtrivial.
      constructor.
      eapply foreign_data_typing_infer_least; eauto.
   Qed.

--- a/compiler/core/Data/Operators/BinaryOperatorsSem.v
+++ b/compiler/core/Data/Operators/BinaryOperatorsSem.v
@@ -129,12 +129,13 @@ Section BinaryOperatorsSem.
     | OpForeignBinary fb => foreign_operators_binary_interp h fb d1 d2
     end.
 
+  Hint Constructors data_normalized Forall : qcert.
+
   Lemma binary_op_eval_normalized {b d1 d2 o} :
     binary_op_eval b d1 d2 = Some o ->
     data_normalized h d1 -> data_normalized h d2 ->
     data_normalized h o.
   Proof.
-    Hint Constructors data_normalized Forall.
     destruct b; simpl; intros;
       try solve [
             unfold rondcoll2 in *;
@@ -155,9 +156,9 @@ Section BinaryOperatorsSem.
       apply data_normalized_rec_sort_app; trivial.
     - do 2 match_destr_in H.
       unfold merge_bindings in H.
-      destruct (Compat.compatible l l0); inversion H; eauto 2.
+      destruct (Compat.compatible l l0); inversion H; qeauto.
       constructor. constructor; trivial.
-      apply data_normalized_rec_concat_sort; trivial.
+      apply data_normalized_rec_concat_sort; qtrivial.
     - do 2 match_destr_in H.
       destruct z; simpl in *; try discriminate.
       + destruct l; simpl in *.
@@ -177,11 +178,11 @@ Section BinaryOperatorsSem.
         * inversion H; subst; repeat constructor.
       + inversion H; subst; repeat constructor.
     - destruct d2; simpl in *; try discriminate.
-      match_destr_in H; inversion H; eauto.
+      match_destr_in H; inversion H; qeauto.
     - destruct d1; destruct d2; simpl in *; try discriminate.
       unfold lifted_join in H.
       apply some_lift in H; destruct H; subst.
-      eauto.
+      qeauto.
     - eapply foreign_operators_binary_normalized; eauto.
   Qed.
   

--- a/compiler/core/Data/Operators/Iterators.v
+++ b/compiler/core/Data/Operators/Iterators.v
@@ -418,7 +418,7 @@ Section Iterators.
 
     Lemma oflatten_lift_cons_dcoll a l:
       olift oflatten
-            (lift (fun t' : list data => dcoll [a] :: t') l) =
+            (lift (fun t' : list data => dcoll (a::nil) :: t') l) =
       lift (fun t' => a::t') (olift oflatten l).
     Proof.
       destruct l; simpl; try reflexivity.

--- a/compiler/core/Data/Operators/OperatorsUtils.v
+++ b/compiler/core/Data/Operators/OperatorsUtils.v
@@ -45,7 +45,7 @@ Section OperatorsUtils.
   Lemma Zquot_zero n :
     Z.quot n 0%Z = 0%Z.
   Proof.
-    apply Zquot.Zquot_0_r.
+    now apply Z.quot_0_r_ext.
   Qed.
     
   Definition darithmean_alt (ns:list data) : option Z

--- a/compiler/core/Data/Operators/SortBy.v
+++ b/compiler/core/Data/Operators/SortBy.v
@@ -16,7 +16,7 @@ Require Import Orders.
 Require Import Equivalence.
 Require Import EquivDec.
 Require Import Compare_dec.
-Require Import Omega.
+Require Import Lia.
 Require Import String.
 Require Import List.
 Require Import ZArith.

--- a/compiler/core/Data/Operators/UnaryOperatorsSem.v
+++ b/compiler/core/Data/Operators/UnaryOperatorsSem.v
@@ -285,17 +285,17 @@ Section UnaryOperatorsSem.
     repeat constructor; trivial.
   Qed.
 
+  Hint Constructors data_normalized Forall : qcert.
+  Hint Resolve dnnone dnsome : qcert.
+  
   Lemma unary_op_eval_normalized {u d o} :
     unary_op_eval u d = Some o ->
     data_normalized h d ->
     data_normalized h o.
   Proof.
-    Hint Constructors data_normalized Forall.
-    Hint Resolve dnnone dnsome.
-
     unary_op_cases (destruct u) Case; simpl;
-    try solve [inversion 1; subst; eauto 3
-              | destruct d; inversion 1; subst; eauto 3].
+    try solve [inversion 1; subst; eauto 3 with qcert
+              | destruct d; inversion 1; subst; eauto 3 with qcert].
     - Case "OpDot"%string.
       destruct d; try discriminate.
       intros. eapply data_normalized_edot; eauto.
@@ -310,9 +310,9 @@ Section UnaryOperatorsSem.
     - Case "OpSingleton"%string.
       destruct d; simpl; try discriminate.
       destruct l.
-      + inversion 1. inversion 1; subst; eauto.
-      + destruct l; inversion 1; subst; eauto 2.
-        rewrite <- data_normalized_dcoll; intros [??]; eauto.
+      + inversion 1. inversion 1; subst; qeauto.
+      + destruct l; inversion 1; subst; eauto 2 with qcert.
+        rewrite <- data_normalized_dcoll; intros [??]; qeauto.
     - Case "OpFlatten"%string.
       destruct d; simpl; try discriminate.
       unfold oflatten.
@@ -340,53 +340,53 @@ Section UnaryOperatorsSem.
       inversion 1; subst; trivial.
     - Case "OpCast"%string.
       destruct d; simpl; try discriminate.
-      match_destr; inversion 1; subst; eauto.
+      match_destr; inversion 1; subst; qeauto.
     - Case "OpNatSum"%string.
       destruct d; simpl; try discriminate.
       intros ll; apply some_lift in ll.
       destruct ll; subst.
-      eauto.
+      qeauto.
     - Case "OpNatMin"%string.
       destruct d; simpl; try discriminate.
       unfold lifted_min.
       intros ll; apply some_lift in ll.
       destruct ll; subst.
-      eauto.
+      qeauto.
     - Case "OpNatMax"%string.
       destruct d; simpl; try discriminate.
       unfold lifted_min.
       intros ll; apply some_lift in ll.
       destruct ll; subst.
-      eauto.
+      qeauto.
     - Case "OpNatMean"%string.
       destruct d; simpl; try discriminate.
       intros.
       apply some_lift in H.
       destruct H as [???]; subst.
-      eauto.
+      qeauto.
     - Case "OpFloatSum"%string.
       destruct d; simpl; try discriminate.
       intros ll; apply some_lift in ll.
       destruct ll; subst.
-      eauto.
+      qeauto.
     - Case "OpFloatMean"%string.
       destruct d; simpl; try discriminate.
       intros.
       apply some_lift in H.
       destruct H as [???]; subst.
-      eauto.
+      qeauto.
     - Case "OpFloatBagMin"%string.
       destruct d; simpl; try discriminate.
       unfold lifted_min.
       intros ll; apply some_lift in ll.
       destruct ll; subst.
-      eauto.
+      qeauto.
     - Case "OpFloatBagMax"%string.
       destruct d; simpl; try discriminate.
       unfold lifted_min.
       intros ll; apply some_lift in ll.
       destruct ll; subst.
-      eauto.
+      qeauto.
     - Case "OpForeignUnary"%string.
       intros eqq dn.
       eapply foreign_operators_unary_normalized in eqq; eauto.

--- a/compiler/core/Data/OperatorsTyping/TBinaryOperators.v
+++ b/compiler/core/Data/OperatorsTyping/TBinaryOperators.v
@@ -475,7 +475,7 @@ Section TBinaryOperators.
     constructor.
     - simpl; split; trivial.
       match_destr.
-      match_case; intros; eauto 2.
+      match_case; intros; eauto 2 with qcert.
       apply lookup_in in H2.
       destruct (Forall2_In_r H3 (sublist_In H1 _ H2)) as [[??] [?[??]]].
       simpl in *; subst.
@@ -486,7 +486,7 @@ Section TBinaryOperators.
          unfold equiv in *; subst.
          apply assoc_lookupr_in in H4.
          assert (nd:NoDup (domain x0)).
-         (rewrite (sorted_forall_same_domain H3); eauto 2).
+         (rewrite (sorted_forall_same_domain H3); eauto 2 with qcert).
          generalize (nodup_in_eq nd H4 H6); intros; subst.
          trivial.
       + apply assoc_lookupr_none_nin in H4. apply in_dom in H6.
@@ -521,14 +521,14 @@ Section TBinaryOperators.
     exists (mapTopNotSub (domain t1) t2 rl).  
     exists (mapTopNotSub (domain t2) t1 rl0).
     intuition.
-    - apply mapTopNotSub_compatible; eauto.
+    - apply mapTopNotSub_compatible; qeauto.
     - apply mapTopNotSub_sublist_same; trivial.
     - apply mapTopNotSub_sublist_same; trivial.
     - eapply Forall2_compat_mapTopNotSub; eauto.
     - eapply Forall2_compat_mapTopNotSub;
         try eapply H4; eauto.
       + unfold compatible in *. apply compatible_true_sym in H6; trivial.
-         rewrite (sorted_forall_same_domain H5); eauto.
+         rewrite (sorted_forall_same_domain H5); qeauto.
   Qed.                 
 
   Lemma sorted_sublists_sorted_concat (τ₁ τ₂ rl rl0:list (string*rtype)):
@@ -556,7 +556,7 @@ Section TBinaryOperators.
     (d1 ▹ τ₁) -> (d2 ▹ τ₂) -> (binary_op_type  b τ₁ τ₂ τout) ->
     (exists x, binary_op_eval brand_relation_brands b d1 d2 = Some x /\ x ▹ τout).
   Proof.
-    Hint Constructors data_type.
+    Hint Constructors data_type : qcert.
     intros.
     binary_op_type_cases (dependent induction H1) Case; simpl.
     - Case "type_OpEqual"%string.
@@ -590,7 +590,7 @@ Section TBinaryOperators.
       destruct (Compat.compatible τ₁ τ₂); try discriminate.
       inversion H1; clear H1; subst.
       destruct (Compat.compatible x x0);
-        (eexists; split; [reflexivity|]); eauto.
+        (eexists; split; [reflexivity|]); qeauto.
       econstructor. econstructor; eauto.
       apply dtrec_full.
       unfold rec_concat_sort.
@@ -620,11 +620,11 @@ Section TBinaryOperators.
           rewrite (sorted_forall_same_domain H9); trivial.
           (* need a lemma about strengthening here *)
           apply (@dtrec_open _ _ _ _ (rec_sort (x ++ x0)) (rec_sort (rl' ++ rl0'))); try assumption.
-          eauto.
+          qeauto.
           apply sorted_sublists_sorted_concat; trivial.
           apply rec_concat_with_drec_concat_well_typed; try assumption.
           unfold rec_concat_sort.
-          eauto.
+          qeauto.
         * congruence.
       + exists (dcoll []); split; try reflexivity;
         apply dtcoll; apply Forall_nil.
@@ -712,7 +712,7 @@ Section TBinaryOperators.
         apply dtbool.
     - Case "type_OpStringConcat"%string.
       dependent induction H; dependent induction H0; simpl.
-      eauto.
+      qeauto.
     - Case "type_OpStringJoin"%string.
       dependent induction H; dependent induction H0; simpl.
       rtype_equalizer; subst.
@@ -721,7 +721,7 @@ Section TBinaryOperators.
       unfold lifted_join; simpl.
       induction dl; simpl in *.
       + rewrite Forall_forall in H; simpl in *.
-        exists (dstring ""); eauto.
+        exists (dstring ""); qeauto.
       + inversion H; subst.
         specialize (IHdl H3).
         elim IHdl; clear IHdl; intros.
@@ -736,16 +736,16 @@ Section TBinaryOperators.
                   | [] => x0
                   | _ :: _ => x0 ++ s ++ String.concat s l
                         end).
-        auto.
+        qauto.
     - Case "type_OpNatBinary"%string.
       dependent induction H; dependent induction H0; simpl.
-      eauto.
+      qeauto.
     - Case "type_OpFloatBinary"%string.
       dependent induction H; dependent induction H0; simpl.
-      eauto.
+      qeauto.
     - Case "type_OpFloatCompare"%string.
       dependent induction H; dependent induction H0; simpl.
-      eauto.
+      qeauto.
     - Case "type_OpForeignBinary"%string.
       eapply foreign_operators_typing_binary_sound; eauto.
   Qed.

--- a/compiler/core/Data/OperatorsTyping/TBinaryOperators.v
+++ b/compiler/core/Data/OperatorsTyping/TBinaryOperators.v
@@ -626,7 +626,7 @@ Section TBinaryOperators.
           unfold rec_concat_sort.
           qeauto.
         * congruence.
-      + exists (dcoll []); split; try reflexivity;
+      + exists (dcoll nil); split; try reflexivity;
         apply dtcoll; apply Forall_nil.
     - Case "type_OpAnd"%string.
       dependent induction H; dependent induction H0; simpl.
@@ -733,7 +733,7 @@ Section TBinaryOperators.
         destruct (lift_map (ondstring (fun x2 : string => x2)) dl); try congruence.
         simpl.
         exists (dstring match l with
-                  | [] => x0
+                  | nil => x0
                   | _ :: _ => x0 ++ s ++ String.concat s l
                         end).
         qauto.
@@ -754,7 +754,7 @@ Section TBinaryOperators.
 
   Lemma tdot_rec_concat_sort_neq {A} (l:list (string*A)) a b xv :
        a <> b ->
-       tdot (rec_concat_sort l [(a, xv)]) b = 
+       tdot (rec_concat_sort l ((a, xv)::nil)) b = 
        tdot (rec_sort l) b.
    Proof.
      unfold tdot, edot; intros.
@@ -765,7 +765,7 @@ Section TBinaryOperators.
 
   Lemma tdot_rec_concat_sort_eq {A} (l : list (string * A)) a b :
                ~ In a (domain l) ->
-               tdot (rec_concat_sort l [(a, b)]) a = Some b.
+               tdot (rec_concat_sort l ((a, b)::nil)) a = Some b.
   Proof.
     unfold tdot.
     apply (@assoc_lookupr_insertion_sort_fresh string ODT_string).

--- a/compiler/core/Data/OperatorsTyping/TOperatorsInfer.v
+++ b/compiler/core/Data/OperatorsTyping/TOperatorsInfer.v
@@ -204,10 +204,10 @@ Section TOperatorsInfer.
       infer_binary_op_type b τ₁ τ₂ = Some τout ->
       binary_op_type b τ₁ τ₂ τout.
     Proof.
-      Hint Constructors binary_op_type.
-      Hint Resolve infer_concat_trec infer_merge_tmerge.
+      Hint Constructors binary_op_type : qcert.
+      Hint Resolve infer_concat_trec infer_merge_tmerge : qcert.
       binary_op_cases (case_eq b) Case; intros; simpl in *; destructer;
-        try congruence; try solve[ erewrite Rec_pr_irrel; reflexivity]; eauto 3.
+        try congruence; try solve[ erewrite Rec_pr_irrel; reflexivity]; eauto 3 with qcert.
       - constructor; apply foreign_operators_typing_binary_infer_correct;
         apply H0.
     Qed.
@@ -428,12 +428,12 @@ Section TOperatorsInfer.
       is_list_sorted ODT_lt_dec (domain l) = true ->
       is_list_sorted ODT_lt_dec (domain (rremove l s)) = true.
     Proof.
-      Hint Resolve Forall_rremove.
+      Hint Resolve Forall_rremove : qcert.
       repeat rewrite sorted_StronglySorted by apply StringOrder.lt_strorder.
       induction l; simpl; try constructor.
       inversion 1; subst.
       destruct (string_dec s (fst a)); simpl; auto.
-      constructor; auto.
+      constructor; qauto.
     Qed.
 
     Lemma infer_dot_tunrec {s} {τ₁ τout} :
@@ -493,12 +493,11 @@ Section TOperatorsInfer.
       infer_unary_op_type u τ₁ = Some τout ->
       unary_op_type u τ₁ τout.
     Proof.
-      Hint Constructors unary_op_type.
+      Hint Constructors unary_op_type : qcert.
       Hint Resolve infer_dot_tunrec infer_recremove_tunrec infer_recproject_tunrec
-           infer_orderby_tunrec infer_singleton_tsingleton.
+           infer_orderby_tunrec infer_singleton_tsingleton : qcert.
       unary_op_cases (case_eq u) Case; intros; simpl in *; destructer; unfold olift in *; try autorewrite with type_canon in *; destructer;
-        try congruence; try solve[ erewrite Rec_pr_irrel; reflexivity]; eauto 3.
-      - constructor.
+        try congruence; try solve[ erewrite Rec_pr_irrel; reflexivity]; eauto 3 with qcert.
       - constructor; apply foreign_operators_typing_unary_infer_correct;
         apply H0.
     Qed.

--- a/compiler/core/Data/OperatorsTyping/TUnaryOperators.v
+++ b/compiler/core/Data/OperatorsTyping/TUnaryOperators.v
@@ -281,8 +281,8 @@ Section TUnaryOperators.
     (d1 ▹ τ₁) -> (unary_op_type u τ₁ τout) ->
     (exists x, unary_op_eval brand_relation_brands u d1 = Some x /\ x ▹ τout).
   Proof.
-    Hint Resolve dtsome dtnone.
-    Hint Constructors data_type.
+    Hint Resolve dtsome dtnone : qcert.
+    Hint Constructors data_type : qcert.
     intros.
     unary_op_type_cases (dependent induction H0) Case; simpl.
     - Case "type_OpIdentity"%string.
@@ -302,7 +302,7 @@ Section TUnaryOperators.
       unfold tdot in *.
       unfold edot in *.
       apply (Forall2_lookupr_some H1).
-      eapply assoc_lookupr_nodup_sublist; eauto.
+      eapply assoc_lookupr_nodup_sublist; qeauto.
     - Case "type_OpRecRemove"%string.
       dependent induction H; rtype_equalizer. subst.
       exists (drec (rremove dl s)); split; try reflexivity.
@@ -324,9 +324,9 @@ Section TUnaryOperators.
     - Case "type_OpSingleton"%string.
       inversion H; rtype_equalizer.
       subst.
-      repeat (destruct dl; eauto).
+      repeat (destruct dl; qeauto).
       inversion H2; subst.
-      eauto.
+      qeauto.
     - Case "type_OpFlatten"%string.
       dependent induction H.
       rewrite Forall_forall in *.
@@ -389,26 +389,26 @@ Section TUnaryOperators.
       exists (dnat (Z_of_nat (bcount dl))).
       split; [reflexivity|apply dtnat].
     - Case "type_OpToString"%string.
-      eauto.
+      qeauto.
     - Case "type_OpToText"%string.
-      eauto.
+      qeauto.
     - Case "type_OpLength"%string.
       dtype_inverter.
-      eauto.
+      qeauto.
     - Case "type_OpSubstring"%string.
       dtype_inverter.
-      eauto.
+      qeauto.
     - Case "type_OpLike"%string.
       dtype_inverter.
-      eauto.
+      qeauto.
     - Case "type_OpLeft"%string.
-      eauto.
+      qeauto.
     - Case "type_OpRight"%string.
-      eauto.
+      qeauto.
     - Case "type_OpBrand"%string.
       eexists; split; try reflexivity.
       apply dtbrand'.
-      + eauto.
+      + qeauto.
       + rewrite brands_type_of_canon; trivial.
       + rewrite canon_brands_equiv; reflexivity.
     - Case "type_OpUnbrand"%string.
@@ -420,27 +420,27 @@ Section TUnaryOperators.
       trivial.
     - Case "type_OpCast"%string.
       inversion H; subst.
-      match_destr; [| eauto].
+      match_destr; [| qeauto].
       econstructor; split; try reflexivity.
       constructor. 
-      econstructor; eauto.
+      econstructor; qeauto.
     - Case "type_OpNatUnary"%string.
       dependent induction H; simpl.
-      eauto.
+      qeauto.
     - Case "type_OpNatSum"%string.
-      dependent induction H. revert r x H. induction dl; simpl; [eauto|intros].
+      dependent induction H. revert r x H. induction dl; simpl; [qeauto|intros].
       inversion H; subst. destruct (IHdl r x H3) as [x0 [x0eq x0d]].
       destruct H2; try solve[simpl in x; discriminate].
       simpl in *.
       destruct (some_lift x0eq); subst.
-      rewrite e. simpl. eauto.
+      rewrite e. simpl. qeauto.
     - Case "type_OpNatMin"%string.
       dependent induction H.
       destruct r.
       destruct x0; simpl in x; try congruence.
       induction dl. rewrite Forall_forall in H.
       unfold lifted_min; simpl.
-      exists (dnat 0). auto.
+      exists (dnat 0). qauto.
       inversion H. subst.
       specialize (IHdl H3).
       elim IHdl; clear IHdl; intros.
@@ -456,14 +456,14 @@ Section TUnaryOperators.
       destruct (lift_map (ondnat (fun x3 : Z => x3)) dl); try congruence.
       simpl.
       exists (dnat (fold_right (fun x3 y : Z => Z.min x3 y) x1 l)).
-      split; [reflexivity|auto].
+      split; [reflexivity|qauto].
     - Case "type_OpNatMax"%string.
       dependent induction H.
       destruct r.
       destruct x0; simpl in x; try congruence.
       induction dl. rewrite Forall_forall in H.
       unfold lifted_max; simpl.
-      exists (dnat 0). auto.
+      exists (dnat 0). qauto.
       inversion H. subst.
       specialize (IHdl H3).
       elim IHdl; clear IHdl; intros.
@@ -479,15 +479,15 @@ Section TUnaryOperators.
       destruct (lift_map (ondnat (fun x3 : Z => x3)) dl); try congruence.
       simpl.
       exists (dnat (fold_right (fun x3 y : Z => Z.max x3 y) x1 l)).
-      split; [reflexivity|auto].
+      split; [reflexivity|qauto].
     - Case "type_OpNatMean"%string.
       assert(dsum_pf:exists x : data, lift dnat (lift_oncoll dsum d1) = Some x /\ x ▹ Nat).
-      {dependent induction H. revert r x H. induction dl; simpl; [eauto|intros].
+      {dependent induction H. revert r x H. induction dl; simpl; [qeauto|intros].
       inversion H; subst. destruct (IHdl r x H3) as [x0 [x0eq x0d]].
       destruct H2; try solve[simpl in x; discriminate].
       simpl in *.
       destruct (some_lift x0eq); subst.
-      rewrite e. simpl. eauto.
+      rewrite e. simpl. qeauto.
       }
       destruct dsum_pf as [x [xeq xtyp]].
       dtype_inverter.
@@ -496,7 +496,7 @@ Section TUnaryOperators.
       simpl in eqq1.
       inversion eqq2; clear eqq2; subst.
       destruct (is_nil_dec d1); simpl.
-      + subst; simpl; eauto.
+      + subst; simpl; qeauto.
       + exists (dnat (Z.quot x (Z_of_nat (length d1)))).
          split; [ | constructor ].
          unfold darithmean.
@@ -504,18 +504,18 @@ Section TUnaryOperators.
          destruct d1; simpl; congruence.
     - Case "type_OpFloatOfNat"%string.
       dependent induction H; simpl.
-      eauto.
+      qeauto.
     - Case "type_OpFloatUnary"%string.
       dependent induction H; simpl.
-      eauto.
+      qeauto.
     - Case "type_OpFloatTruncate"%string.
       dependent induction H; simpl.
-      eauto.
+      qeauto.
     - Case "type_OpFloatSum"%string.
       dependent induction H.
       destruct r.
       destruct x0; simpl in x; try congruence.
-      induction dl; unfold lifted_fsum; simpl; [eauto|intros].
+      induction dl; unfold lifted_fsum; simpl; [qeauto|intros].
       inversion H; subst.
       destruct (IHdl H3) as [x0 [x0eq x0d]].
       inversion H2.
@@ -526,12 +526,12 @@ Section TUnaryOperators.
       simpl.
       unfold lifted_fbag in *; simpl.
       destruct (some_lift e0); subst.
-      rewrite e1; simpl; eauto.
+      rewrite e1; simpl; qeauto.
     - Case "type_OpFloatMean"%string.
       dependent induction H.
       destruct r.
       destruct x0; simpl in x; try congruence.
-      induction dl; unfold lifted_farithmean; simpl; [eauto|intros].
+      induction dl; unfold lifted_farithmean; simpl; [qeauto|intros].
       inversion H; subst.
       destruct (IHdl H3) as [x0 [x0eq x0d]].
       inversion H2.
@@ -542,12 +542,12 @@ Section TUnaryOperators.
       simpl.
       unfold lifted_fbag in *; simpl.
       destruct (some_lift e0); subst.
-      rewrite e1; simpl; eauto.
+      rewrite e1; simpl; qeauto.
     - Case "type_OpFloatBagMin"%string.
       dependent induction H.
       destruct r.
       destruct x0; simpl in x; try congruence.
-      induction dl; unfold lifted_fmin; simpl; [eauto|intros].
+      induction dl; unfold lifted_fmin; simpl; [qeauto|intros].
       inversion H; subst.
       destruct (IHdl H3) as [x0 [x0eq x0d]].
       inversion H2.
@@ -558,12 +558,12 @@ Section TUnaryOperators.
       simpl.
       unfold lifted_fbag in *; simpl.
       destruct (some_lift e0); subst.
-      rewrite e1; simpl; eauto.
+      rewrite e1; simpl; qeauto.
     - Case "type_OpFloatBagMax"%string.
       dependent induction H.
       destruct r.
       destruct x0; simpl in x; try congruence.
-      induction dl; unfold lifted_fmax; simpl; [eauto|intros].
+      induction dl; unfold lifted_fmax; simpl; [qeauto|intros].
       inversion H; subst.
       destruct (IHdl H3) as [x0 [x0eq x0d]].
       inversion H2.
@@ -574,7 +574,7 @@ Section TUnaryOperators.
       simpl.
       unfold lifted_fbag in *; simpl.
       destruct (some_lift e0); subst.
-      rewrite e1; simpl; eauto.
+      rewrite e1; simpl; qeauto.
     - Case "type_OpForeignUnary"%string.
       eapply foreign_operators_typing_unary_sound; eauto.
   Qed.

--- a/compiler/core/Data/OperatorsTyping/TUnaryOperators.v
+++ b/compiler/core/Data/OperatorsTyping/TUnaryOperators.v
@@ -235,7 +235,7 @@ Section TUnaryOperators.
   
   (* TODO: move this stuff *)
   Definition canon_brands_alt {br:brand_relation} (b:brands) :=
-    fold_right meet [] (map (fun x => x::nil) b).
+    fold_right meet nil (map (fun x => x::nil) b).
 
   Lemma canon_brands_alt_is_canon {br:brand_relation} (b:brands) :
     is_canon_brands brand_relation_brands (canon_brands_alt b).
@@ -249,10 +249,10 @@ Section TUnaryOperators.
   Lemma canon_brands_fold_right_hoist {br:brand_relation} (l:list brands) :
     fold_right
       (fun a b : brands => canon_brands brand_relation_brands (a ++ b))
-      [] l =
+      nil l =
     canon_brands brand_relation_brands
                  (fold_right (fun a b : brands => (a ++ b))
-                             [] l).
+                             nil l).
   Proof.
     induction l; simpl.
     - reflexivity.
@@ -292,7 +292,7 @@ Section TUnaryOperators.
       exists (dbool (negb b)).
       split; [reflexivity|apply dtbool].
     - Case "type_OpRec"%string.
-      exists (drec [(s,d1)]).
+      exists (drec ((s,d1)::nil)).
       split; [reflexivity|apply dtrec_full].
       apply Forall2_cons.
       split; [reflexivity|assumption].
@@ -318,7 +318,7 @@ Section TUnaryOperators.
       clear H0 pf1.
       apply (rproject_well_typed τ rl); try assumption.
     - Case "type_OpBag"%string.
-      exists (dcoll [d1]); split; try
+      exists (dcoll (d1::nil)); split; try
       reflexivity.  apply dtcoll; apply Forall_forall; intros.  elim H0;
       intros.  rewrite <- H1; assumption.  contradiction.
     - Case "type_OpSingleton"%string.
@@ -332,7 +332,7 @@ Section TUnaryOperators.
       rewrite Forall_forall in *.
       unfold oflatten.
       induction dl; simpl in *.
-      exists (dcoll []).
+      exists (dcoll nil).
       split; try reflexivity.
       apply dtcoll; apply Forall_nil.
       assert (forall x : data, In x dl -> data_type x r) by

--- a/compiler/core/Dataframe/Lang/Dataframe.v
+++ b/compiler/core/Dataframe/Lang/Dataframe.v
@@ -367,7 +367,7 @@ Section Dataframe.
                 trivial.
             }
             rewrite dxdl; clear dxdl.
-            eauto.
+            qeauto.
       - apply some_lift in de.
         destruct de as [dl' de ?]; subst.
         specialize (IHds _ de).

--- a/compiler/core/Dataframe/Lang/DataframeSize.v
+++ b/compiler/core/Dataframe/Lang/DataframeSize.v
@@ -13,7 +13,7 @@
  *)
 
 Require Import List.
-Require Import Omega.
+Require Import Lia.
 Require Import DataSystem.
 Require Import Dataframe.
 
@@ -51,12 +51,12 @@ Section DataframeSize.
 
   Lemma column_size_nzero (c:column) : column_size c <> 0.
   Proof.
-    induction c; simpl; omega.
+    induction c; simpl; lia.
   Qed.
 
     Lemma dataframe_size_nzero (d:dataframe) : dataframe_size d <> 0.
   Proof.
-    induction d; simpl; omega.
+    induction d; simpl; lia.
   Qed.
 
 End DataframeSize.

--- a/compiler/core/Driver/CompConfig.v
+++ b/compiler/core/Driver/CompConfig.v
@@ -16,6 +16,7 @@ Require Import List.
 Require Import String.
 Require Import Permutation.
 Require Import ZArith.
+Require Import Lia.
 
 (* Common *)
 Require Import Utils.
@@ -366,7 +367,7 @@ Section CompConfig.
           repeat rewrite float_roundtrip.
           rewrite Nat2Z.id.
           match_case; intros.
-          omega.
+          lia.
         Qed.
 
         Lemma optim_phase3_config_to_json_to_optim_phase3_config
@@ -378,7 +379,7 @@ Section CompConfig.
           repeat rewrite float_roundtrip.
           rewrite Nat2Z.id.
           match_case; intros.
-          omega.
+          lia.
         Qed.
 
         Lemma optim_config_of_language_to_json_to_optim_config_of_language

--- a/compiler/core/Driver/CompDriver.v
+++ b/compiler/core/Driver/CompDriver.v
@@ -1858,7 +1858,7 @@ Section CompDriver.
   Proof.
     unfold Transitive.
     intros dv'' dv' dv H_dv''_dv' H_dv'_dv.
-    induction 0.
+    induction H_dv'_dv.
     - rewrite H in *; clear H.
       assumption.
     - apply (is_postfix_plus_one dv'' dv config lang);

--- a/compiler/core/Driver/CompDriver.v
+++ b/compiler/core/Driver/CompDriver.v
@@ -546,7 +546,7 @@ Section CompDriver.
     | Dv_imp_ejson_to_js_ast _ dv => 1 + driver_length_js_ast dv
     end.
 
-  Fixpoint driver_length_imp_data (dv: imp_data_driver) :=
+  Definition driver_length_imp_data (dv: imp_data_driver) :=
     match dv with
     | Dv_imp_data_stop => 1
     | Dv_imp_data_to_imp_ejson dv => 1 + driver_length_imp_ejson dv

--- a/compiler/core/EJson/Model/EJson.v
+++ b/compiler/core/EJson/Model/EJson.v
@@ -17,7 +17,6 @@ Require Import Ascii.
 Require Import String.
 Require Import ZArith.
 Require Import Bool.
-Require Import JsAst.JsNumber.
 Require Import Float.
 Require Import ToString.
 Require Import CoqLibAdd.
@@ -48,7 +47,7 @@ Section EJson.
   (** Induction principles used as backbone for inductive proofs on json *)
   Definition ejson_rect (P : ejson -> Type)
              (fnull : P ejnull)
-             (fnumber : forall n : number, P (ejnumber n))
+             (fnumber : forall n : float, P (ejnumber n))
              (fbigint : forall n : Z, P (ejbigint n))
              (fbool : forall b : bool, P (ejbool b))
              (fstring : forall s : string, P (ejstring s))
@@ -78,7 +77,7 @@ Section EJson.
 
   Definition ejson_ind (P : ejson -> Prop)
              (fnull : P ejnull)
-             (fnumber : forall n : number, P (ejnumber n))
+             (fnumber : forall n : float, P (ejnumber n))
              (fbigint : forall n : Z, P (ejbigint n))
              (fbool : forall b : bool, P (ejbool b))
              (fstring : forall s : string, P (ejstring s))
@@ -110,7 +109,7 @@ Section EJson.
 
   Lemma ejsonInd2 (P : ejson -> Prop)
         (f : P ejnull)
-        (f0 : forall n : number, P (ejnumber n))
+        (f0 : forall n : float, P (ejnumber n))
         (f1 : forall n : Z, P (ejbigint n))
         (f2 : forall b : bool, P (ejbool b))
         (f3 : forall s : string, P (ejstring s))

--- a/compiler/core/EJson/Model/EJsonNorm.v
+++ b/compiler/core/EJson/Model/EJsonNorm.v
@@ -174,7 +174,7 @@ Section EJsonNorm.
     ejson_normalized (ejobject (rec_sort (l1 ++ l2))).
   Proof.
     inversion 1; inversion 1; subst.
-    constructor; eauto 1.
+    constructor; eauto 1 with qcert.
     apply Forall_sorted.
     apply Forall_app; trivial.
   Qed.
@@ -214,7 +214,7 @@ Section EJsonNorm.
     Forall (fun d : string * ejson => ejson_normalized (snd d)) c ->
     ejson_normalized (ejobject (rec_sort c)).
   Proof.
-    intros F; econstructor; trivial.
+    intros F; econstructor; trivial with qcert.
     apply Forall_sorted; trivial.
   Qed.
 

--- a/compiler/core/EJson/Operators/EJsonSortBy.v
+++ b/compiler/core/EJson/Operators/EJsonSortBy.v
@@ -16,7 +16,7 @@ Require Import Orders.
 Require Import Equivalence.
 Require Import EquivDec.
 Require Import Compare_dec.
-Require Import Omega.
+Require Import Lia.
 Require Import String.
 Require Import List.
 Require Import ZArith.

--- a/compiler/core/Extraction/ExtrOcamlFloatNatIntZInt.v
+++ b/compiler/core/Extraction/ExtrOcamlFloatNatIntZInt.v
@@ -23,57 +23,45 @@ Require Import Float.
 Require Import EquivDec.
 Require Import Extraction.
 
-(** BUG !!! B755_zero false = +0 ; B755_zero true = -0 *)
-(** BUG !!! SAME FOR INFINITY *)
-Extract Inductive Fappli_IEEE.binary_float => float [
-  "(fun s -> if s then (-0.) else (0.))"
-  "(fun s -> if s then neg_infinity else infinity)"
-  "nan"
-  "(fun (s, m, e) -> if s then -. (ldexp (float_of_int m) e) else (ldexp (float_of_int m) e))"
-].
-Extract Inlined Constant nan => "nan".
-Extract Inlined Constant zero => "0.".
-Extract Inlined Constant neg_zero => "(-0.)".
-Extract Inlined Constant one => "1.".
-Extract Inlined Constant neg_one => "(-1.)".
-Extract Inlined Constant infinity => "infinity".
-Extract Inlined Constant neg_infinity => "neg_infinity".
-Extract Inlined Constant max_value => "max_float".
-Extract Inlined Constant min_value => "(Int64.float_of_bits Int64.one)". (** XXX Why not min_float in OCaml? *)
+(* PrimFloat.float extraction via ExtrOCamlFloats depends on the kernel float Float64 library.
+   This is annoying for building, and also causes problems because the type t is opaque
+   and there is no non-magic way to get a float out of it
+ *)
 
-Extract Inlined Constant float_floor => "(fun x -> floor x)".
-Extract Inlined Constant float_absolute => "(fun x -> abs_float x)".
-Extract Inlined Constant float_neg => "(fun x -> ~-. x)".
+Extract Inlined Constant PrimFloat.float => "float".
+Extract Inlined Constant float => "float".
+
+Extract Inlined Constant float_nan => "Float.nan".
+Extract Inlined Constant float_zero => "0.".
+Extract Inlined Constant float_neg_zero => "(-0.)".
+Extract Inlined Constant float_one => "1.".
+Extract Inlined Constant float_neg_one => "(-1.)".
+Extract Inlined Constant float_infinity => "Float.infinity".
+Extract Inlined Constant float_neg_infinity => "Float.neg_infinity".
+
+(*
+Extract Inductive FloatClass.float_class =>
+  "Float64.float_class"
+  [ "PNormal" "NNormal" "PSubn" "NSubn" "PZero" "NZero" "PInf" "NInf" "NaN" ].
+Extract Inductive PrimFloat.float_comparison =>
+  "Float64.float_comparison"
+    [ "FEq" "FLt" "FGt" "FNotComparable" ].
+
+*)
+Extract Inlined Constant float_max_value => "Float.max_float".
+Extract Inlined Constant float_min_value => "Float.min_value".
+
+Extract Inlined Constant float_from_string => "(fun x -> float_of_string (Util.string_of_char_list x))".
+Extract Inlined Constant float_to_string => "(fun x -> Util.char_list_of_string (Util.qcert_string_of_float x))".
+
+Extract Inlined Constant float_neg => "(fun x -> Float.neg x)".
+
+Extract Inlined Constant float_floor => "(fun x -> Float.floor x)".
+Extract Inlined Constant float_absolute => "(fun x -> Float.abs x)".
+
+Extract Inlined Constant float_sign => "(fun x -> Util.float_sign x)".
 
 (** Defines additional operations on FLOATs *)
-(** Unary operations *)
-
-Extract Inlined Constant float_sqrt => "(fun x -> sqrt x)".
-Extract Inlined Constant float_exp => "(fun x -> exp x)".
-Extract Inlined Constant float_log => "(fun x -> log x)".
-Extract Inlined Constant float_log10 => "(fun x -> log10 x)".
-Extract Inlined Constant float_ceil => "(fun x -> ceil x)".
-
-Extract Inlined Constant float_eq => "(fun x y -> x = y)".
-
-Conjecture float_eq_correct :
-  forall f1 f2, (float_eq f1 f2 = true <-> f1 = f2).
-Lemma float_eq_dec : EqDec float eq.
-Proof.
-  unfold EqDec.
-  intros x y.
-  case_eq (float_eq x y); intros eqq.
-  + left.
-    f_equal.
-    apply float_eq_correct in eqq.
-    trivial.
-  + right; intros eqq2.
-    red in eqq2.
-    apply float_eq_correct in eqq2.
-    congruence.
-Defined.
-  
-Extract Constant float_eq_dec => "(fun n1 n2 -> 0 = compare n1 n2)".
 
 (** Binary operations *)
 Extract Inlined Constant float_add => "(fun x y -> x +. y)".
@@ -81,20 +69,30 @@ Extract Inlined Constant float_sub => "(fun x y -> x -. y)".
 Extract Inlined Constant float_mult => "(fun x y -> x *. y)".
 Extract Inlined Constant float_div => "(fun x y -> x /. y)".
 
+(** Unary operations *)
+Extract Inlined Constant float_sqrt => "(fun x -> Float.sqrt x)".
+Extract Inlined Constant float_exp => "(fun x -> Float.exp x)".
+Extract Inlined Constant float_log => "(fun x -> Float.log x)".
+Extract Inlined Constant float_log10 => "(fun x -> Float.log10 x)".
+Extract Inlined Constant float_ceil => "(fun x -> Float.ceil x)".
+
+Extract Constant float_eq => "(fun n1 n2 -> n1 = n2)".
+(* Extract Constant float_eq_dec => "(fun n1 n2 -> n1 = n2)". *)
+
+
 Extract Inlined Constant float_pow => "(fun x y -> x ** y)".
 Extract Inlined Constant float_min => "(fun x y -> min x y)".
 Extract Inlined Constant float_max => "(fun x y -> max x y)".
 Extract Inlined Constant float_ne => "(fun x y -> x <> y)".
+
 Extract Inlined Constant float_lt => "(fun x y -> x < y)".
-Extract Inlined Constant float_le => "(fun x y -> x <= y)".
-Extract Inlined Constant float_gt => "(fun x y -> x > y)".
-Extract Inlined Constant float_ge => "(fun x y -> x >= y)".
+Extract Inlined Constant float_le  => "(fun x y -> x <= y)".
+Extract Inlined Constant float_gt  => "(fun x y -> x > y)".
+Extract Inlined Constant float_ge  => "(fun x y -> x >= y)".
 
 Require Import ZArith.
 Extract Inlined Constant float_of_int => "(fun x -> float_of_int x)".
 
 Extract Inlined Constant float_truncate => "(fun x -> truncate x)".
 
-Extract Inlined Constant from_string => "(fun x -> float_of_string (Util.string_of_char_list x))".
-Extract Inlined Constant to_string => "(fun x -> Util.char_list_of_string (Util.qcert_string_of_float x))".
-
+Extract Inlined Constant JsNumber.to_string => "(fun x -> Util.char_list_of_string (Util.qcert_string_of_float x))".

--- a/compiler/core/Imp/Lang/Imp.v
+++ b/compiler/core/Imp/Lang/Imp.v
@@ -31,15 +31,15 @@ Require Import Utils.
 Section Imp.
 
   Section Syntax.
-    Context {Constant: Type}.
-    Context {Op: Type}.
-    Context {Runtime: Type}.
+    Context {Constant: Set}.
+    Context {Op: Set}.
+    Context {Runtime: Set}.
 
     Definition var := string.
 
     Unset Elimination Schemes.
   
-    Inductive imp_expr :=
+    Inductive imp_expr : Set :=
     | ImpExprError : string -> imp_expr                          (**r raises an error *)
     | ImpExprVar : var -> imp_expr                               (**r local variable lookup ([$v])*)
     | ImpExprConst : Constant -> imp_expr                        (**r constant data ([d]) *)
@@ -187,23 +187,23 @@ Section Imp.
           try solve [apply binary_op_eqdec | apply unary_op_eqdec
                      | apply Constant_eqdec | apply Op_eqdec | apply Runtime_eqdec | apply string_eqdec].
         - revert l; induction el; intros; destruct l; simpl in *; try solve[right ;inversion 1].
-          left; reflexivity.
-          inversion X; subst; clear X.
-          elim (X0 i); intros; subst; clear X0.
-          + specialize (IHel X1); clear X1.
-            elim (IHel l); intros; clear IHel.
-            * subst; left; reflexivity.
+          + left; reflexivity.
+          + inversion H; subst; clear H.
+            elim (H2 i); intros; subst; clear H2.
+            * specialize (IHel H3); clear H3.
+              elim (IHel l); intros; clear IHel.
+              -- subst; left; reflexivity.
+              -- right; congruence.
             * right; congruence.
-          + right; congruence.
         - revert l; induction el; intros; destruct l; simpl in *; try solve[right ;inversion 1].
-          left; reflexivity.
-          inversion X; subst; clear X.
-          elim (X0 i); intros; subst; clear X0.
-          + specialize (IHel X1); clear X1.
-            elim (IHel l); intros; clear IHel.
-            * subst; left; reflexivity.
+          +  left; reflexivity.
+          + inversion H; subst; clear H.
+            elim (H2 i); intros; subst; clear H2.
+            * specialize (IHel H3); clear H3.
+              elim (IHel l); intros; clear IHel.
+              -- subst; left; reflexivity.
+              -- right; congruence.
             * right; congruence.
-          + right; congruence.
       Defined.
 
       Global Instance imp_stmt_eqdec : EqDec imp_stmt eq.
@@ -214,14 +214,14 @@ Section Imp.
         - subst; clear l.
           revert l0; induction sl; intros; destruct l0; simpl in *; try solve[right ;inversion 1].
           left; reflexivity.
-          inversion X; subst; clear X.
-          elim (X0 i); intros; subst; clear X0.
-          + specialize (IHsl X1); clear X1.
+          inversion H; subst; clear H.
+          elim (H2 i); intros; subst; clear H2.
+          + specialize (IHsl H3); clear H3.
             elim (IHsl l0); intros; clear IHsl.
             * subst; left; reflexivity.
             * right; congruence.
           + right; congruence.
-        - clear X.
+        - clear H.
           revert l; induction el; intros; destruct l; simpl in *; try solve[right ;inversion 1].
           left; reflexivity.
           destruct a; simpl in *; destruct o; simpl in *;

--- a/compiler/core/Imp/Lang/Imp.v
+++ b/compiler/core/Imp/Lang/Imp.v
@@ -28,6 +28,7 @@ Require Import EquivDec.
 Require Import Decidable.
 Require Import Utils.
 
+Declare Scope imp_scope.
 Section Imp.
 
   Section Syntax.
@@ -287,5 +288,4 @@ Tactic Notation "imp_cases" tactic(first) ident(c) :=
   first;
   [ Case_aux c "ImpLib"%string].
 
-
-Delimit Scope imp with imp_scope.
+Delimit Scope imp_scope with imp.

--- a/compiler/core/Imp/Lang/ImpData.v
+++ b/compiler/core/Imp/Lang/ImpData.v
@@ -26,14 +26,14 @@ Section ImpData.
   Section Syntax.
 
     Definition imp_data_model := data.
-    Definition imp_data_constant := data.
+    Definition imp_data_constant : Set := data.
 
-    Inductive imp_data_op :=
+    Inductive imp_data_op : Set :=
     | DataOpUnary : unary_op -> imp_data_op
     | DataOpBinary : binary_op -> imp_data_op
     .
 
-    Inductive imp_data_runtime_op :=
+    Inductive imp_data_runtime_op : Set :=
     | DataRuntimeGroupby : string -> list string -> imp_data_runtime_op
     | DataRuntimeEither : imp_data_runtime_op
     | DataRuntimeToLeft : imp_data_runtime_op

--- a/compiler/core/Imp/Lang/ImpDataSize.v
+++ b/compiler/core/Imp/Lang/ImpDataSize.v
@@ -13,7 +13,7 @@
  *)
 
 Require Import String.
-Require Import Omega.
+Require Import Lia.
 Require Import EquivDec.
 Require Import Decidable.
 Require Import Utils.
@@ -35,7 +35,7 @@ Section ImpDataSize.
   Definition imp_data_function_size (q:imp_data_function) : nat :=
     imp_function_size q.
 
-  Fixpoint imp_data_size (q: imp_data) : nat :=
+  Definition imp_data_size (q: imp_data) : nat :=
     imp_size q.
 
 End ImpDataSize.

--- a/compiler/core/Imp/Lang/ImpEJsonSize.v
+++ b/compiler/core/Imp/Lang/ImpEJsonSize.v
@@ -13,7 +13,7 @@
  *)
 
 Require Import String.
-Require Import Omega.
+Require Import Lia.
 Require Import EquivDec.
 Require Import Decidable.
 Require Import Utils.
@@ -36,7 +36,7 @@ Section ImpEJsonSize.
   Definition imp_ejson_function_size (q:imp_ejson_function) : nat :=
     imp_function_size q.
 
-  Fixpoint imp_ejson_size (q: imp_ejson) : nat :=
+  Definition imp_ejson_size (q: imp_ejson) : nat :=
     imp_size q.
 
 End ImpEJsonSize.

--- a/compiler/core/Imp/Lang/ImpEq.v
+++ b/compiler/core/Imp/Lang/ImpEq.v
@@ -32,9 +32,9 @@ Section NNRSimpEq.
   Local Open Scope imp_scope.
 
   Context {Model: Type}.
-  Context {Constant: Type}.
-  Context {Op: Type}.
-  Context {Runtime: Type}.
+  Context {Constant: Set}.
+  Context {Op: Set}.
+  Context {Runtime: Set}.
 
   Context {ConstantNormalize: Constant -> Model}.
   Context {ModelToBool: Model -> option bool}.

--- a/compiler/core/Imp/Lang/ImpEq.v
+++ b/compiler/core/Imp/Lang/ImpEq.v
@@ -278,9 +278,9 @@ Section NNRSimpEq.
   
 End NNRSimpEq.
 
-Notation "X ≡ᵉ Y" := (imp_expr_eq X Y) (at level 90) : nnrs_imp. (* ≡ = \equiv *)
+Notation "X ≡ᵉ Y" := (imp_expr_eq X Y) (at level 90) : imp_scope. (* ≡ = \equiv *)
 
-Notation "X ≡ˢ Y" := (imp_stmt_eq X Y) (at level 90) : nnrs_imp. (* ≡ = \equiv *)
+Notation "X ≡ˢ Y" := (imp_stmt_eq X Y) (at level 90) : imp_scope. (* ≡ = \equiv *)
 
-Notation "X ≡ˢⁱ Y" := (imp_eq X Y) (at level 90) : nnrs_imp. (* ≡ = \equiv *)
+Notation "X ≡ˢⁱ Y" := (imp_eq X Y) (at level 90) : imp_scope. (* ≡ = \equiv *)
 

--- a/compiler/core/Imp/Lang/ImpEval.v
+++ b/compiler/core/Imp/Lang/ImpEval.v
@@ -24,9 +24,9 @@ Section ImpEval.
   Import ListNotations.
 
   Context {Model: Type}.
-  Context {Constant: Type}.
-  Context {Op: Type}.
-  Context {Runtime: Type}.
+  Context {Constant: Set}.
+  Context {Op: Set}.
+  Context {Runtime: Set}.
 
   Context {ConstantNormalize: Constant -> Model}.
   Context {ModelToBool: Model -> option bool}.

--- a/compiler/core/Imp/Lang/ImpSize.v
+++ b/compiler/core/Imp/Lang/ImpSize.v
@@ -13,7 +13,7 @@
  *)
 
 Require Import String.
-Require Import Omega.
+Require Import Lia.
 Require Import EquivDec.
 Require Import Decidable.
 Require Import Utils.
@@ -67,7 +67,7 @@ Section ImpSize.
       | ImpFun args s ret => imp_stmt_size s
       end.
 
-    Fixpoint imp_size (q: imp) : nat :=
+    Definition imp_size (q: imp) : nat :=
       match q with
       | ImpLib l =>
         List.fold_left
@@ -78,12 +78,12 @@ Section ImpSize.
 
     Lemma imp_expr_size_nzero (e:imp_expr) : imp_expr_size e <> 0.
     Proof.
-      induction e; simpl; try omega.
+      induction e; simpl; try lia.
     Qed.
 
     Lemma imp_stmt_size_nzero (s:imp_stmt) : imp_stmt_size s <> 0.
     Proof.
-      induction s; simpl; try destruct o; try omega.
+      induction s; simpl; try destruct o; try lia.
     Qed.
 
     Corollary imp_function_size_nzero (q:imp_function) : imp_function_size q <> 0.
@@ -94,7 +94,7 @@ Section ImpSize.
 
     (* Corollary imp_size_nzero (q:imp) : imp_size q <> 0. *)
     (* Proof. *)
-    (*   induction q; simpl; try destruct o; try omega. *)
+    (*   induction q; simpl; try destruct o; try lia. *)
     (*   apply imp_stmt_size_nzero. *)
     (* Qed. *)
 

--- a/compiler/core/Imp/Lang/ImpSize.v
+++ b/compiler/core/Imp/Lang/ImpSize.v
@@ -21,9 +21,9 @@ Require Import Imp.
 
 Section ImpSize.
 
-  Context {Model: Type}.
-  Context {Op: Type}.
-  Context {Runtime: Type}.
+  Context {Model: Set}.
+  Context {Op: Set}.
+  Context {Runtime: Set}.
 
   Definition imp_expr := @Imp.imp_expr Model Op Runtime.
   Definition imp_stmt := @Imp.imp_stmt Model Op Runtime.

--- a/compiler/core/Imp/Lang/ImpVars.v
+++ b/compiler/core/Imp/Lang/ImpVars.v
@@ -35,9 +35,9 @@ Section ImpVars.
   (* Context {fruntime:foreign_runtime}. *)
   (* Context (h:brand_relation_t). *)
 
-  Context {Constant: Type}.
-  Context {Op: Type}.
-  Context {Runtime: Type}.
+  Context {Constant: Set}.
+  Context {Op: Set}.
+  Context {Runtime: Set}.
 
 
   Fixpoint imp_expr_free_vars (e:@imp_expr Constant Op Runtime) : list var

--- a/compiler/core/Imp/Optim/ImpEJsonRewrite.v
+++ b/compiler/core/Imp/Optim/ImpEJsonRewrite.v
@@ -19,7 +19,6 @@ Require Import List.
 Require Import Bool.
 Require Import Arith.
 Require Import Utils.
-Require Import JsAst.JsNumber.
 Require Import EJsonRuntime.
 Require Import Imp.
 Require Import ImpEJson.

--- a/compiler/core/Imp/Optim/ImpOptimizerEngine.v
+++ b/compiler/core/Imp/Optim/ImpOptimizerEngine.v
@@ -31,9 +31,9 @@ Section ImpOptimizerEngine.
   Local Open Scope imp.
   Local Open Scope string.
 
-  Context {Constant: Type}.
-  Context {Op: Type}.
-  Context {Runtime: Type}.
+  Context {Constant: Set}.
+  Context {Op: Set}.
+  Context {Runtime: Set}.
 
   Section map.
     Fixpoint imp_expr_map_deep

--- a/compiler/core/JSON/Model/JSON.v
+++ b/compiler/core/JSON/Model/JSON.v
@@ -17,7 +17,6 @@ Require Import Ascii.
 Require Import String.
 Require Import ZArith.
 Require Import Bool.
-Require Import JsAst.JsNumber.
 Require Import Float.
 Require Import ToString.
 Require Import CoqLibAdd.
@@ -42,7 +41,7 @@ Section JSON.
   (** Induction principles used as backbone for inductive proofs on json *)
   Definition json_rect (P : json -> Type)
              (fnull : P jnull)
-             (fnumber : forall n : number, P (jnumber n))
+             (fnumber : forall n : float, P (jnumber n))
              (fbool : forall b : bool, P (jbool b))
              (fstring : forall s : string, P (jstring s))
              (farray : forall c : list json, Forallt P c -> P (jarray c))
@@ -68,7 +67,7 @@ Section JSON.
 
   Definition json_ind (P : json -> Prop)
              (fnull : P jnull)
-             (fnumber : forall n : number, P (jnumber n))
+             (fnumber : forall n : float, P (jnumber n))
              (fbool : forall b : bool, P (jbool b))
              (fstring : forall s : string, P (jstring s))
              (farray : forall c : list json, Forall P c -> P (jarray c))
@@ -96,7 +95,7 @@ Section JSON.
 
   Lemma jsonInd2 (P : json -> Prop)
         (f : P jnull)
-        (f0 : forall n : number, P (jnumber n))
+        (f0 : forall n : float, P (jnumber n))
         (f1 : forall b : bool, P (jbool b))
         (f2 : forall s : string, P (jstring s))
         (f3 : forall c : list json, (forall x, In x c -> P x) -> P (jarray c))

--- a/compiler/core/JSON/Model/JSONNorm.v
+++ b/compiler/core/JSON/Model/JSONNorm.v
@@ -159,7 +159,7 @@ Section JSONNorm.
     json_normalized (jobject (rec_sort (l1 ++ l2))).
   Proof.
     inversion 1; inversion 1; subst.
-    constructor; eauto 1.
+    constructor; eauto 1 with qcert.
     apply Forall_sorted.
     apply Forall_app; trivial.
   Qed.
@@ -199,7 +199,7 @@ Section JSONNorm.
     Forall (fun d : string * json => json_normalized (snd d)) c ->
     json_normalized (jobject (rec_sort c)).
   Proof.
-    intros F; econstructor; trivial.
+    intros F; econstructor; trivial with qcert.
     apply Forall_sorted; trivial.
   Qed.
 

--- a/compiler/core/LambdaNRA/Lang/LambdaNRA.v
+++ b/compiler/core/LambdaNRA/Lang/LambdaNRA.v
@@ -304,7 +304,7 @@ Section LambdaNRA.
                 apply Forall_app.
                 * invcs H4; trivial.
                 * invcs H8; trivial.
-              + eauto.
+              + qeauto.
           }
           apply Forall_sorted.
           apply Forall_app; trivial.
@@ -344,7 +344,7 @@ Section LambdaNRA.
                 apply Forall_app.
                 * invcs H4; trivial.
                 * invcs H8; trivial.
-              + eauto.
+              + qeauto.
           }
           trivial.
           trivial.

--- a/compiler/core/LambdaNRA/Typing/TLambdaNRA.v
+++ b/compiler/core/LambdaNRA/Typing/TLambdaNRA.v
@@ -22,6 +22,9 @@ Require Import Utils.
 Require Import DataSystem.
 Require Import LambdaNRA.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section TLambdaNRA.
   (** Typing for LambdaNRA *)
   Section typ.

--- a/compiler/core/LambdaNRA/Typing/TLambdaNRA.v
+++ b/compiler/core/LambdaNRA/Typing/TLambdaNRA.v
@@ -312,7 +312,7 @@ Section TLambdaNRA.
     Qed.
 
     (* we are only sensitive to the environment up to lookup *)
-  Global Instance nnrc_type_lookup_equiv_prop {m:basic_model} :
+  Global Instance nnrc_type_lookup_equiv_prop :
     Proper (assoc_lookupr_equiv ==> eq ==> assoc_lookupr_equiv ==> eq ==> iff) lambda_nra_type.
   Proof.
     cut (Proper (assoc_lookupr_equiv ==> eq ==> assoc_lookupr_equiv ==> eq ==> impl) lambda_nra_type);

--- a/compiler/core/NNRC/Lang/NNRCSize.v
+++ b/compiler/core/NNRC/Lang/NNRCSize.v
@@ -13,7 +13,7 @@
  *)
 
 Require Import String.
-Require Import Omega.
+Require Import Lia.
 Require Import EquivDec.
 Require Import Decidable.
 Require Import Utils.
@@ -41,7 +41,7 @@ Section NNRCSize.
 
   Lemma nnrc_size_nzero (n:nnrc) : nnrc_size n <> 0.
   Proof.
-    induction n; simpl; omega.
+    induction n; simpl; lia.
   Qed.
 
   Lemma nnrc_rename_lazy_size n x1 x2:

--- a/compiler/core/NNRC/Lang/NNRCStratify.v
+++ b/compiler/core/NNRC/Lang/NNRCStratify.v
@@ -21,6 +21,7 @@
 Require Import String.
 Require Import List.
 Require Import Bool.
+Require Import BinInt.
 Require Import Arith.
 Require Import EquivDec.
 Require Import Morphisms.
@@ -37,6 +38,7 @@ Require Import cNNRCShadow.
 Require Import NNRC.
 Require Import NNRCEq.
 Require Import NNRCShadow.
+
 
 Section Stratify.
   
@@ -298,7 +300,8 @@ Section Stratify.
     Local Open Scope nnrc_scope.
     Local Open Scope string_scope.
 
-    Example nnrc1 := (‵abs ‵ (dnat 3) ‵+ ‵(dnat 5)) ‵+ ((‵(dnat 4) ‵+ ‵(dnat 7)) ‵+‵`(dnat  3)).
+
+    Example nnrc1 := ((‵abs ‵ (dnat 3) ‵+ ‵(dnat 5)) ‵+ ((‵(dnat 4) ‵+ ‵(dnat 7)) ‵+‵`(dnat  3))).
     (* Eval vm_compute in (stratify nnrc1).  *)
 
     Example nnrc2 := NNRCLet "x" nnrc1 (NNRCVar "x").
@@ -1922,10 +1925,3 @@ Section Stratify.
   End Core.
   
 End Stratify.
-
-(* 
- *** Local Variables: ***
- *** coq-load-path: (("../../../coq" "Qcert")) ***
- *** End: ***
- *)
-

--- a/compiler/core/NNRC/Lang/NNRCStratify.v
+++ b/compiler/core/NNRC/Lang/NNRCStratify.v
@@ -145,15 +145,15 @@ Section Stratify.
     Lemma stratifiedLevel_spec_lifts k e :
       stratifiedLevel_spec k e -> stratifiedLevel_spec nnrcStmt e.
     Proof.
-      Hint Constructors stratifiedLevel_spec.
-      destruct k; eauto.
+      Hint Constructors stratifiedLevel_spec : qcert.
+      destruct k; qeauto.
     Qed.
 
     Lemma stratifiedLevel_spec_lifte k e :
       stratifiedLevel_spec nnrcExpr e -> stratifiedLevel_spec k e.
     Proof.
-      Hint Constructors stratifiedLevel_spec.
-      destruct k; eauto.
+      Hint Constructors stratifiedLevel_spec : qcert.
+      destruct k; qeauto.
     Qed.
 
     Lemma stratifiedLevel_spec_stratified k (e:nnrc) :
@@ -166,11 +166,11 @@ Section Stratify.
     Lemma stratifiedLevel_correct k e:
       stratifiedLevel k e <-> stratifiedLevel_spec k e.
     Proof.
-      Hint Constructors stratifiedLevel_spec.
-      Hint Resolve stratifiedLevel_spec_lifts stratifiedLevel_spec_lifte.
+      Hint Constructors stratifiedLevel_spec : qcert.
+      Hint Resolve stratifiedLevel_spec_lifts stratifiedLevel_spec_lifte : qcert.
       split; revert k.
-      - induction e; simpl; destruct k; simpl; intros; intuition (eauto; try discriminate).
-      - induction e; simpl; intros k; intros HH; invcs HH; simpl; eauto 3;
+      - induction e; simpl; destruct k; simpl; intros; intuition (qeauto; try discriminate).
+      - induction e; simpl; intros k; intros HH; invcs HH; simpl; eauto 3 with qcert;
           try (invcs H; eauto); intuition eauto.
     Qed.
 
@@ -388,7 +388,7 @@ Section Stratify.
       stratifiedLevel required_level n /\
       Forall (stratifiedLevel nnrcStmt) (codomain sdefs).
     Proof.
-      Hint Resolve Forall_nil Forall_app.
+      Hint Resolve Forall_nil Forall_app : qcert.
       revert required_level bound_vars n sdefs.
       induction e; intros required_level bound_vars n sdefs eqq
       ; invcs eqq; simpl in *; eauto 2; simpl.
@@ -398,7 +398,7 @@ Section Stratify.
         rewrite codomain_app.
         destruct (IHe1 _ _ _ _ eqq1).
         destruct (IHe2 _ _ _ _ eqq2).
-        intuition eauto.
+        intuition qeauto.
       - match_case_in H0;  intros ? ? eqq1; rewrite eqq1 in *; simpl in *.
         invcs H0; simpl in *.
         destruct (IHe _ _ _ _ eqq1).
@@ -1825,7 +1825,6 @@ Section Stratify.
       nnrcIsCore e <->
       nnrcIsCore n /\ Forall nnrcIsCore (codomain sdefs).
     Proof.
-      Hint Resolve Forall_nil.
       revert required_level bound_vars n sdefs.
       induction e; intros required_level bound_vars n sdefs eqq1
       ; simpl in *; invcs eqq1; simpl.

--- a/compiler/core/NNRC/Optim/NNRCOptimizer.v
+++ b/compiler/core/NNRC/Optim/NNRCOptimizer.v
@@ -34,6 +34,9 @@ Require Import TNNRCRewrite.
 Require Import OptimizerLogger.
 Require Import OptimizerStep.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section NNRCOptimizer.
   Local Open Scope nnrc_scope.
   Local Open Scope string.

--- a/compiler/core/NNRC/Optim/NNRCOptimizer.v
+++ b/compiler/core/NNRC/Optim/NNRCOptimizer.v
@@ -17,6 +17,7 @@
 Require Import String.
 Require Import List.
 Require Import ListSet.
+Require Import BinInt.
 Require Import Arith.
 Require Import Equivalence.
 Require Import Morphisms.

--- a/compiler/core/NNRC/Optim/NNRCRewrite.v
+++ b/compiler/core/NNRC/Optim/NNRCRewrite.v
@@ -15,6 +15,7 @@
 (* This includes some rewrites/simplification rules for the Nested relational calculus *)
 
 Require Import String.
+Require Import BinInt.
 Require Import List.
 Require Import ListSet.
 Require Import Arith.

--- a/compiler/core/NNRC/Optim/TNNRCRewrite.v
+++ b/compiler/core/NNRC/Optim/TNNRCRewrite.v
@@ -15,6 +15,7 @@
 (* This includes some rewrites/simplification rules for the Nested relational calculus *)
 
 Require Import String.
+Require Import BinInt.
 Require Import List.
 Require Import ListSet.
 Require Import Arith.

--- a/compiler/core/NNRC/Typing/TNNRCEq.v
+++ b/compiler/core/NNRC/Typing/TNNRCEq.v
@@ -55,7 +55,7 @@ Section TNNRCEq.
     apply bindings_type_Forall_normalized.
   Qed.
 
-  Hint Resolve data_normalized_bindings_type_map.
+  Hint Resolve data_normalized_bindings_type_map : qcert.
   
   Lemma nnrc_rewrites_typed_with_untyped (e1 e2:nnrc) :
     e1 ≡ᶜ e2 ->
@@ -67,16 +67,16 @@ Section TNNRCEq.
     intros.
     unfold tnnrc_rewrites_to; simpl; intros.
     split; auto 2; intros.
-    apply H; eauto.
+    apply H; qeauto.
   Qed.
 
   (****************
    * Proper stuff *
    ****************)
 
-  Hint Constructors nnrc_core_type.
-  Hint Constructors unary_op_type.
-  Hint Constructors binary_op_type.
+  Hint Constructors nnrc_core_type : qcert.
+  Hint Constructors unary_op_type : qcert.
+  Hint Constructors binary_op_type : qcert.
 
   Global Instance tnnrc_rewrites_to_pre : PreOrder tnnrc_rewrites_to.
   Proof.
@@ -287,7 +287,7 @@ Section TNNRCEq.
     destruct (H3 _ _ _ H12).
     clear H H1 H3.
     simpl.
-    split; [eauto | ]; intros.
+    split; [qeauto | ]; intros.
     rewrite H2; trivial.
     destruct (@typed_nnrc_core_yields_typed_data _ _ _ _ _ _ _ H H1 H0) as [?[??]].
     rewrite H3.
@@ -325,5 +325,5 @@ Section TNNRCEq.
 
 End TNNRCEq.
 
-Notation "e1 ⇒ᶜ e2" := (tnnrc_rewrites_to e1 e2) (at level 80).
+Notation "e1 ⇒ᶜ e2" := (tnnrc_rewrites_to e1 e2) (at level 80) : nnrc_scope.
 

--- a/compiler/core/NNRC/Typing/TNNRCShadow.v
+++ b/compiler/core/NNRC/Typing/TNNRCShadow.v
@@ -27,7 +27,7 @@ Require Import TcNNRC.
 Require Import TNNRC.
   
 Section TNNRCShadow.
-  Hint Constructors nnrc_core_type.
+  Hint Constructors nnrc_core_type : qcert.
 
   Context {m:basic_model}.
 
@@ -44,9 +44,9 @@ Section TNNRCShadow.
     (nnrc_type τcenv (l ++ (v,x)::l') e τ <-> nnrc_type τcenv (l ++ l') e τ).
   Proof.
     split; revert l v x l' τ H;
-    induction e; unfold nnrc_type in *; simpl; inversion 2; subst; intuition; eauto 3.
+    induction e; unfold nnrc_type in *; simpl; inversion 2; subst; intuition; eauto 3 with qcert.
     - constructor. erewrite <- lookup_remove_nin; eauto.
-    - apply nin_app_or in H. intuition. eauto.
+    - apply nin_app_or in H. intuition. qeauto.
     - apply nin_app_or in H. intuition.
       econstructor; eauto.
       destruct (equiv_dec v v0); unfold Equivalence.equiv in *; subst.
@@ -60,7 +60,7 @@ Section TNNRCShadow.
       + eapply (IHe2 ((v, τ₁) :: l)); eauto. 
          intro; elim H2; apply remove_in_neq; eauto.
     - apply nin_app_or in H; destruct H as [? HH]; apply nin_app_or in HH.
-      intuition. eauto.
+      intuition. qeauto.
     - apply nin_app_or in H. destruct H as [neq1 neq2].
       apply nin_app_or in neq2. destruct neq2 as [neq2 neq3].
       econstructor; eauto.
@@ -83,7 +83,7 @@ Section TNNRCShadow.
       rtype_equalizer. subst.
       repeat (econstructor; eauto).
     - constructor. erewrite lookup_remove_nin; eauto.
-    - apply nin_app_or in H. intuition. eauto.
+    - apply nin_app_or in H. intuition. qeauto.
     - apply nin_app_or in H. intuition.
       econstructor; eauto.
       destruct (equiv_dec v v0); unfold Equivalence.equiv in *; subst.
@@ -149,11 +149,11 @@ Section TNNRCShadow.
        constructor. destruct (string_dec v v₀); simpl; subst; intuition; inversion H; subst; simpl in *; repeat dest_eqdec; intuition.
     -  intuition.
        constructor. destruct (string_dec v v₀); simpl; subst; intuition; inversion H; subst; simpl in *; repeat dest_eqdec; intuition.
-    - inversion 1; subst. eauto.
+    - inversion 1; subst. qeauto.
     - inversion 1; subst.
       rewrite nin_app_or in nfree, nbound.
-      intuition; eauto.
-    - inversion 1; subst. eauto.
+      intuition; qeauto.
+    - inversion 1; subst. qeauto.
     - inversion 1; subst.
       rewrite nin_app_or in nfree. intuition.
       apply nin_app_or in H3. intuition.
@@ -187,7 +187,7 @@ Section TNNRCShadow.
     - inversion 1; subst.
       apply nin_app_or in nfree; destruct nfree as [? HH]; apply nin_app_or in HH.
       apply nin_app_or in nbound; destruct nbound as [? HHH]; apply nin_app_or in HHH.
-      intuition; eauto.
+      intuition; qeauto.
     - intro HH; inversion HH; subst; clear HH.
       apply not_or in nbound; destruct nbound as [nb1 nb2].
       apply not_or in nb2; destruct nb2 as [nb2 nb3].
@@ -233,11 +233,11 @@ Section TNNRCShadow.
         inversion H; subst; simpl in *; repeat dest_eqdec; intuition;
         inversion H4; subst; constructor; simpl;
         repeat dest_eqdec; intuition.
-    - inversion 1; subst. eauto.
+    - inversion 1; subst. qeauto.
     - inversion 1; subst.
       rewrite nin_app_or in nfree, nbound.
-      intuition; eauto.
-    - inversion 1; subst. eauto.
+      intuition; qeauto.
+    - inversion 1; subst. qeauto.
     - inversion 1; subst.
       rewrite nin_app_or in nfree. intuition.
       apply nin_app_or in H3. intuition.
@@ -330,7 +330,7 @@ Section TNNRCShadow.
     - Case "NNRCVar"%string.
       match_destr.
       + congruence.
-      + auto.
+      + qauto.
     - Case "NNRCConst"%string.
       econstructor; trivial.
     - Case "NNRCBinop"%string.
@@ -436,8 +436,8 @@ Section TNNRCShadow.
     nnrc_type τcenv Γ n τ <-> nnrc_type τcenv Γ (unshadow sep renamer avoid n) τ.
   Proof.
     unfold nnrc_type.
-    Hint Resolve really_fresh_from_free  really_fresh_from_bound.
-    split; revert Γ τ; induction n; simpl in *; inversion 1; subst; eauto; simpl.
+    Hint Resolve really_fresh_from_free  really_fresh_from_bound : qcert.
+    split; revert Γ τ; induction n; simpl in *; inversion 1; subst; qeauto; simpl.
     - econstructor; [eauto|..].
       apply nnrc_type_rename_pick_subst.
       unfold nnrc_type; eauto.
@@ -486,4 +486,3 @@ Section TNNRCShadow.
   Qed.
 
 End TNNRCShadow.
-

--- a/compiler/core/NNRC/Typing/TNNRCStratify.v
+++ b/compiler/core/NNRC/Typing/TNNRCStratify.v
@@ -140,20 +140,20 @@ Section TNNRCStratify.
         type_substs Γc Γ sdefs τdefs
         /\ nnrc_type Γc (rev τdefs ++ Γ) n τ.
   Proof.
-    Hint Constructors nnrc_core_type.
+    Hint Constructors nnrc_core_type : qcert.
     unfold nnrc_type.
     revert required_kind bound_vars n sdefs.
     induction e; simpl; intros required_kind bound_vars n sdefs inclb eqq Γc Γ τ typ.
     - invcs eqq.
       (* add this case to the nnrc_core_inverter Ltac *)
       invcs typ.
-      simpl; exists nil; simpl; eauto.
+      simpl; exists nil; simpl; qeauto.
     - invcs eqq.
       nnrc_core_inverter.
-      simpl; exists nil; simpl; eauto.
+      simpl; exists nil; simpl; qeauto.
     - invcs eqq.
       nnrc_core_inverter.
-      simpl; exists nil; simpl; eauto.
+      simpl; exists nil; simpl; qeauto.
     - match_case_in eqq; intros ? ? eqq1; rewrite eqq1 in eqq.
       match_case_in eqq; intros ? ? eqq2; rewrite eqq2 in eqq.
       invcs eqq.
@@ -162,7 +162,7 @@ Section TNNRCStratify.
       destruct (IHe1 _ _ _ _ inclb1 eqq1 _ _ _ H5)
         as [τdefs1 [typdefs1 typn1]].
       assert (inclb2':incl (nnrc_free_vars e2) (domain l ++ bound_vars))
-        by (unfold incl in *; intros; rewrite in_app_iff; eauto).
+        by (unfold incl in *; intros; rewrite in_app_iff; qeauto).
       assert (type2':nnrc_core_type Γc (rev τdefs1 ++ Γ) (nnrc_to_nnrc_base e2) τ₂).
       {
         apply (nnrc_core_type_remove_disjoint_env nil (rev τdefs1) Γ); simpl; trivial.
@@ -182,7 +182,7 @@ Section TNNRCStratify.
       + apply type_substs_app; trivial.
       + rewrite rev_app_distr.
         rewrite app_ass.
-        econstructor; eauto.
+        econstructor; qeauto.
         apply (nnrc_core_type_remove_disjoint_env nil (rev τdefs2 )(rev τdefs1 ++ Γ)); simpl; trivial.
         rewrite domain_rev.
         rewrite disjoint_rev_l.
@@ -201,7 +201,7 @@ Section TNNRCStratify.
       destruct (IHe _ _ _ _ inclb eqq1 _ _ _ H4)
         as [τdefs1 [typdefs1 typn1]].
       exists τdefs1.
-      eauto.
+      qeauto.
     - apply incl_app_iff in inclb; destruct inclb as [inclb1 inclb2].
       apply incl_remove in inclb2.
       nnrc_core_inverter.
@@ -224,7 +224,7 @@ Section TNNRCStratify.
         as [τdefs1 [typdefs1 typn1]].
       apply (stratify1_aux_preserves_types_fw eqq τdefs1); simpl; trivial.
       unfold nnrc_type in *; simpl.
-      econstructor; eauto.
+      econstructor; qeauto.
       case_eq (stratify_aux e2 nnrcStmt (v::bound_vars)); intros ? ? eqq2; rewrite eqq2 in eqq.
       destruct (IHe2 _ _ _ _ inclb2 eqq2 _ _ _ H5)
         as [τdefs2 [typdefs2 typn2]].
@@ -251,7 +251,7 @@ Section TNNRCStratify.
         as [τdefs1 [typdefs1 typn1]].
       apply (stratify1_aux_preserves_types_fw eqq τdefs1); simpl; trivial.
       unfold nnrc_type in *; simpl.
-      econstructor; eauto.
+      econstructor; qeauto.
       + case_eq (stratify_aux e2 nnrcStmt bound_vars); intros ? ? eqq2; rewrite eqq2 in eqq.
         destruct (IHe2 _ _ _ _ inclb2 eqq2 _ _ _ H5)
           as [τdefs2 [typdefs2 typn2]].
@@ -298,7 +298,7 @@ Section TNNRCStratify.
         as [τdefs1 [typdefs1 typn1]].
       apply (stratify1_aux_preserves_types_fw eqq τdefs1); simpl; trivial.
       unfold nnrc_type in *; simpl.
-      econstructor; eauto.
+      econstructor; qeauto.
       + case_eq (stratify_aux e2 nnrcStmt (v::bound_vars)); intros ? ? eqq2; rewrite eqq2 in eqq.
         destruct (IHe2 _ _ _ _ inclb2 eqq2 _ _ _ H7)
           as [τdefs2 [typdefs2 typn2]].
@@ -357,7 +357,7 @@ Section TNNRCStratify.
     case_eq (stratify_aux e required_kind bound_vars); intros ? ? eqq.
     destruct (stratify_aux_preserves_types_fw _ _ _ _ _ inclb eqq _ _ _ typ)
       as [? [typs typn]].
-    eapply mk_expr_from_vars_preserves_types_fw; eauto.
+    eapply mk_expr_from_vars_preserves_types_fw; qeauto.
   Qed.
 
   Theorem stratify_preserves_types_fw
@@ -378,7 +378,7 @@ Section TNNRCStratify.
   Proof.
     revert Γ sdefs2 τdefs1 τdefs2.
     induction sdefs1; simpl; intros Γ sdefs2 τdefs1 τdefs2 ts1 ts2.
-    - match_destr; simpl in *; eauto.
+    - match_destr; simpl in *; qeauto.
     - destruct a.
       match_destr; simpl in *; try discriminate.
       destruct p.
@@ -444,7 +444,7 @@ Section TNNRCStratify.
         invcs H2.
         intuition.
       + rewrite <- domain_length, deq, domain_length; trivial.
-    - eauto.
+    - qeauto.
   Qed.
 
   Lemma mk_expr_from_vars_preserves_types_bk
@@ -458,7 +458,7 @@ Section TNNRCStratify.
     unfold mk_expr_from_vars.
     revert n Γ.
     induction sdefs; simpl; intros n Γ typ.
-    - exists nil; simpl; eauto.
+    - exists nil; simpl; qeauto.
     - destruct a; unfold nnrc_type in *; simpl in *.
       invcs typ.
       specialize (IHsdefs _ _ H5).
@@ -479,19 +479,19 @@ Section TNNRCStratify.
         nnrc_type Γc (rev τdefs ++ Γ) n τ ->
         nnrc_type Γc Γ e τ.
   Proof.
-    Hint Constructors nnrc_core_type.
+    Hint Constructors nnrc_core_type : qcert.
     unfold nnrc_type.
     revert required_kind bound_vars n sdefs.
     induction e; simpl; intros required_kind bound_vars n sdefs inclb eqq Γc Γ τdefs typs τ typn.
     - invcs eqq.
       destruct τdefs; simpl in *; try contradiction.
-      eauto.
+      qeauto.
     - invcs eqq.
       destruct τdefs; simpl in *; try contradiction.
-      eauto.
+      qeauto.
     - invcs eqq.
       destruct τdefs; simpl in *; try contradiction.
-      eauto.
+      qeauto.
     - match_case_in eqq; intros ? ? eqq1; rewrite eqq1 in eqq.
       match_case_in eqq; intros ? ? eqq2; rewrite eqq2 in eqq.
       invcs eqq.
@@ -502,7 +502,7 @@ Section TNNRCStratify.
       destruct typs as [τdefs1 [τdefs2 [? [typs1 typs2]]]]; subst.
       repeat rewrite rev_app_distr in *.
       repeat rewrite app_ass in *.
-      econstructor; eauto.
+      econstructor; qeauto.
       + apply (IHe1 _ _ _ _ inclb1 eqq1 _ _ _ typs1 τ₁).
         apply (nnrc_core_type_remove_disjoint_env nil (rev τdefs2) (rev τdefs1 ++ Γ)); simpl; trivial.
         rewrite domain_rev.
@@ -532,7 +532,7 @@ Section TNNRCStratify.
       invcs eqq.
       simpl in *.
       nnrc_core_inverter.
-      econstructor; eauto.
+      econstructor; qeauto.
     - apply incl_app_iff in inclb; destruct inclb as [inclb1 inclb2].
       apply incl_remove in inclb2.
       destruct (stratify1_aux_preserves_types_bk eqq _ _ _ _ typs typn)
@@ -551,7 +551,7 @@ Section TNNRCStratify.
       case_eq (stratify_aux e2 nnrcStmt (v::bound_vars)); intros ? ? eqq2
       ; rewrite eqq2 in *.
       simpl in *.
-      eauto.
+      qeauto.
     - match_case_in eqq; intros ? ? eqq1; rewrite eqq1 in eqq.
       apply incl_app_iff in inclb; destruct inclb as [inclb1 inclb2].
       apply incl_remove in inclb2.
@@ -559,13 +559,13 @@ Section TNNRCStratify.
         as [τdefs2 [typs' typn']]; simpl; trivial.
       unfold nnrc_type in *; simpl in *.
       invcs typn'.
-      econstructor; [eauto | ].
+      econstructor; [qeauto | ].
       destruct (mk_expr_from_vars_preserves_types_bk H5)
         as [τdefs1 [ts1 tp1]].
       case_eq (stratify_aux e2 nnrcStmt (v::bound_vars)); intros ? ? eqq2
       ; rewrite eqq2 in *.
       simpl in *.
-      apply (nnrc_core_type_remove_almost_disjoint_env ((v, τ₁)::nil) (rev τdefs2) Γ); simpl; eauto.
+      apply (nnrc_core_type_remove_almost_disjoint_env ((v, τ₁)::nil) (rev τdefs2) Γ); simpl; qeauto.
       intros x inn1 inn2.
       rewrite domain_rev, <- in_rev in inn1.
       rewrite <- nnrc_to_nnrc_base_free_vars_same in inn2.
@@ -582,13 +582,13 @@ Section TNNRCStratify.
         as [τdefs2 [typs' typn']]; simpl; trivial.
       unfold nnrc_type in *; simpl in *.
       invcs typn'.
-      econstructor; [eauto | | ].
+      econstructor; [qeauto | | ].
       + destruct (mk_expr_from_vars_preserves_types_bk H5)
           as [τdefs1 [ts1 tp1]].
         case_eq (stratify_aux e2 nnrcStmt bound_vars); intros ? ? eqq2
         ; rewrite eqq2 in *.
         simpl in *.
-        apply (nnrc_core_type_remove_almost_disjoint_env nil (rev τdefs2) Γ); simpl; eauto.
+        apply (nnrc_core_type_remove_almost_disjoint_env nil (rev τdefs2) Γ); simpl; qeauto.
         intros x inn1 inn2.
         rewrite domain_rev, <- in_rev in inn1.
         rewrite <- nnrc_to_nnrc_base_free_vars_same in inn2.
@@ -603,7 +603,7 @@ Section TNNRCStratify.
         case_eq (stratify_aux e3 nnrcStmt bound_vars); intros ? ? eqq3
         ; rewrite eqq3 in *.
         simpl in *.
-        apply (nnrc_core_type_remove_almost_disjoint_env nil (rev τdefs2) Γ); simpl; eauto.
+        apply (nnrc_core_type_remove_almost_disjoint_env nil (rev τdefs2) Γ); simpl; qeauto.
         intros x inn1 inn2.
         rewrite domain_rev, <- in_rev in inn1.
         rewrite <- nnrc_to_nnrc_base_free_vars_same in inn2.
@@ -622,13 +622,13 @@ Section TNNRCStratify.
         as [τdefs2 [typs' typn']]; simpl; trivial.
       unfold nnrc_type in *; simpl in *.
       invcs typn'.
-      econstructor; [eauto | | ].
+      econstructor; [qeauto | | ].
       + destruct (mk_expr_from_vars_preserves_types_bk H7)
           as [τdefs1 [ts1 tp1]].
         case_eq (stratify_aux e2 nnrcStmt (v::bound_vars)); intros ? ? eqq2
         ; rewrite eqq2 in *.
         simpl in *.
-        apply (nnrc_core_type_remove_almost_disjoint_env ((v, τl)::nil) (rev τdefs2) Γ); simpl; eauto.
+        apply (nnrc_core_type_remove_almost_disjoint_env ((v, τl)::nil) (rev τdefs2) Γ); simpl; qeauto.
         intros x inn1 inn2.
         rewrite domain_rev, <- in_rev in inn1.
         rewrite <- nnrc_to_nnrc_base_free_vars_same in inn2.
@@ -643,7 +643,7 @@ Section TNNRCStratify.
         case_eq (stratify_aux e3 nnrcStmt (v0::bound_vars)); intros ? ? eqq3
         ; rewrite eqq3 in *.
         simpl in *.
-        apply (nnrc_core_type_remove_almost_disjoint_env ((v0,τr)::nil) (rev τdefs2) Γ); simpl; eauto.
+        apply (nnrc_core_type_remove_almost_disjoint_env ((v0,τr)::nil) (rev τdefs2) Γ); simpl; qeauto.
         intros x inn1 inn2.
         rewrite domain_rev, <- in_rev in inn1.
         rewrite <- nnrc_to_nnrc_base_free_vars_same in inn2.
@@ -660,7 +660,7 @@ Section TNNRCStratify.
       destruct typn' as [? [? [? [? [subl type]]]]]; subst.
       cut (nnrc_type Γc Γ (NNRCGroupBy s l e) (GroupBy_type s l x x0 x1)); trivial.
       apply type_NNRCGroupBy; trivial.
-      unfold nnrc_type; eauto.
+      unfold nnrc_type; qeauto.
   Qed.
 
   Lemma mk_expr_from_vars_stratify_aux_preserves_types_bk
@@ -674,7 +674,7 @@ Section TNNRCStratify.
     destruct (mk_expr_from_vars_preserves_types_bk typ)
       as [τdefs1 [ts1 tp1]].
     case_eq (stratify_aux e required_kind bound_vars); intros ? ? eqq; rewrite eqq in *.
-    eapply stratify_aux_preserves_types_bk; eauto.
+    eapply stratify_aux_preserves_types_bk; qeauto.
   Qed.
 
   Theorem stratify_preserves_types_bk
@@ -684,7 +684,7 @@ Section TNNRCStratify.
   Proof.
     unfold stratify.
     intros typ.
-    eapply mk_expr_from_vars_stratify_aux_preserves_types_bk; eauto.
+    eapply mk_expr_from_vars_stratify_aux_preserves_types_bk; qeauto.
     reflexivity.
   Qed.
 
@@ -696,14 +696,9 @@ Section TNNRCStratify.
   Proof.
     split; intros.
     - apply stratify_preserves_types_fw; trivial.
-    - eapply stratify_preserves_types_bk; eauto.
+    - eapply stratify_preserves_types_bk; qeauto.
   Qed.
   
 End TNNRCStratify.
 
-(* 
- *** Local Variables: ***
- *** coq-load-path: (("../../../coq" "Qcert")) ***
- *** End: ***
- *)
 

--- a/compiler/core/NNRCMR/Lang/NNRCMR.v
+++ b/compiler/core/NNRCMR/Lang/NNRCMR.v
@@ -282,7 +282,7 @@ Section NNRCMR.
     | RedSingleton => (mr.(mr_output), Vlocal)
     end.
 
-  Definition map_well_localized map d :=
+  Definition map_well_localized map (d:ddata) :=
     match map, d with
     | MapDist _, Ddistr _ => True
     | MapDistFlatten _, Ddistr _ => True

--- a/compiler/core/NNRCMR/Optim/NNRCMRRewrite.v
+++ b/compiler/core/NNRCMR/Optim/NNRCMRRewrite.v
@@ -220,7 +220,7 @@ Section NNRCMRRewrite.
   (* Scalar Map *)
 
   Definition is_scalar_map map :=
-    match map with
+    match (map:map_fun) with
     | MapScalar _ => true
     | _ => false
     end.
@@ -264,7 +264,7 @@ Section NNRCMRRewrite.
 
   
   (* Java equivalent: MROptimizer.is_flatten_collect *)
-  Definition is_flatten_collect red :=
+  Definition is_flatten_collect (red:reduce_fun) :=
     match red with
     | RedId => false
     | RedCollect reduce => is_flatten_function reduce
@@ -275,7 +275,7 @@ Section NNRCMRRewrite.
   (* Id Reduce *)
 
   (* Java equivalent: MROptimizer.is_id_reduce *)  
-  Definition is_id_reduce red :=
+  Definition is_id_reduce (red:reduce_fun) :=
     match red with
     | RedId => true
     | RedCollect reduce => false
@@ -293,7 +293,7 @@ Section NNRCMRRewrite.
   (* Collect Reduce *)
 
   (* Java equivalent: MROptimizer.is_id_collect *)  
-  Definition is_id_collect red :=
+  Definition is_id_collect (red:reduce_fun) :=
     match red with
     | RedId => false
     | RedCollect reduce => is_id_function reduce
@@ -319,7 +319,7 @@ Section NNRCMRRewrite.
 
   (* singleton *)
   (* Java equivalent: MROptimizer.is_singleton_reduce *)
-  Definition is_singleton_reduce red :=
+  Definition is_singleton_reduce (red:reduce_fun) :=
     match red with
     | RedId => false
     | RedCollect _ => false
@@ -338,7 +338,7 @@ Section NNRCMRRewrite.
 
 
   (* uncoll reduce *)
-  Definition is_uncoll_collect red :=
+  Definition is_uncoll_collect (red:reduce_fun) :=
     match red with
     | RedId => false
     | RedCollect reduce => is_uncoll_function_arg reduce
@@ -346,7 +346,7 @@ Section NNRCMRRewrite.
     | RedSingleton => false
     end.
 
-  Definition suppress_uncoll_in_collect_reduce red :=
+  Definition suppress_uncoll_in_collect_reduce (red:reduce_fun) :=
     match red with
     | RedId => None
     | RedCollect f =>

--- a/compiler/core/NNRCMR/Optim/NNRCMRRewrite.v
+++ b/compiler/core/NNRCMR/Optim/NNRCMRRewrite.v
@@ -1397,7 +1397,7 @@ Section NNRCMRRewrite.
       mrl.(mr_last).
 
   (* Java equivalent: MROptimizer.mr_chain_cleanup *)
-  Fixpoint mr_chain_cleanup l (to_keep: list var) :=
+  Definition mr_chain_cleanup l (to_keep: list var) :=
     let (to_keep', res) :=
         List.fold_right
           (fun r (acc: list var * list mr) =>

--- a/compiler/core/NNRS/Lang/NNRS.v
+++ b/compiler/core/NNRS/Lang/NNRS.v
@@ -31,6 +31,8 @@ Require Import Decidable.
 Require Import Utils.
 Require Import DataRuntime.
 
+Declare Scope nnrs_scope.
+
 Section NNRS.
   Section Syntax.
 
@@ -283,4 +285,4 @@ Tactic Notation "nnrs_stmt_cases" tactic(first) ident(c) :=
   | Case_aux c "NNRSIf"%string
   | Case_aux c "NNRSEither"%string].
 
-Delimit Scope nnrs with nnrs_scope.
+Delimit Scope nnrs_scope with nnrs.

--- a/compiler/core/NNRS/Lang/NNRSCrossShadow.v
+++ b/compiler/core/NNRS/Lang/NNRSCrossShadow.v
@@ -22,6 +22,7 @@ Require Import String.
 Require Import List.
 Require Import Permutation.
 Require Import ListSet.
+Require Import BinInt.
 Require Import Arith.
 Require Import EquivDec.
 Require Import Morphisms.
@@ -1607,8 +1608,6 @@ Section NNRSCrossShadow.
           match_destr.
           destruct p as [[??]?].
           destruct p; trivial.
-          unfold var in *.
-          apply (IHl p0 m m0 domσ domψc domψd).
         + destruct d; trivial.
           revert σ ψc ψd domσ domψc domψd c0.
           induction l

--- a/compiler/core/NNRS/Lang/NNRSCrossShadow.v
+++ b/compiler/core/NNRS/Lang/NNRSCrossShadow.v
@@ -1772,10 +1772,10 @@ Section NNRSCrossShadow.
            nnrs_stmt_cross_shadow_free_under_free_env_mdenv
            nnrs_stmt_cross_shadow_free_under_bound_env_mdenv
            nnrs_stmt_cross_shadow_free_under_free_mcenv_mdenv
-           nnrs_stmt_cross_shadow_free_under_bound_mcenv_mdenv.
+           nnrs_stmt_cross_shadow_free_under_bound_mcenv_mdenv : qcert.
       
       intros cs.
-      apply nnrs_stmt_uncross_shadow_under_alt_id; eauto.
+      apply nnrs_stmt_uncross_shadow_under_alt_id; qeauto.
     Qed.
 
     Theorem nnrs_uncross_shadow_id sep (s:nnrs) :

--- a/compiler/core/NNRS/Lang/NNRSNorm.v
+++ b/compiler/core/NNRS/Lang/NNRSNorm.v
@@ -255,8 +255,8 @@ Section NNRSNorm.
   
 End NNRSNorm.
 
-Hint Resolve nnrs_expr_eval_normalized.
-Hint Resolve nnrs_stmt_eval_normalized.
+Hint Resolve nnrs_expr_eval_normalized : qcert.
+Hint Resolve nnrs_stmt_eval_normalized : qcert.
 
 Arguments nnrs_expr_eval_normalized {fruntime h σc σ e o}.
 Arguments nnrs_stmt_eval_normalized {fruntime h σc σ ψc ψd s σ' ψc' ψd'}.

--- a/compiler/core/NNRS/Lang/NNRSSem.v
+++ b/compiler/core/NNRS/Lang/NNRSSem.v
@@ -80,7 +80,7 @@ Section NNRSSem.
         [ σ ⊢ NNRSGroupBy g sl e ⇓ (dcoll d₂) ]
 
     where
-    "[ σ ⊢ e ⇓ d ]" := (nnrs_expr_sem σ e d) : nnrs
+    "[ σ ⊢ e ⇓ d ]" := (nnrs_expr_sem σ e d) : nnrs_scope
     .
 
     Reserved Notation  "[ s₁ , σ₁ , ψc₁ , ψd₁ ⇓ σ₂ , ψc₂ , ψd₂ ]".
@@ -150,19 +150,19 @@ Section NNRSSem.
              [ s, σ₂ , ψc₂ , ψd₂ ⇓[v<-dl] σ₃, ψc₃, ψd₃] ->
              [ s, σ₁ , ψc₁ , ψd₁ ⇓[v<-d::dl] σ₃, ψc₃, ψd₃]
     where
-    "[ s , σ₁ , ψc₁ , ψd₁ ⇓ σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs
-                                                                                                  and "[ s , σ₁ , ψc₁ , ψd₁ ⇓[ v <- dl ] σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem_iter v dl s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs.
+    "[ s , σ₁ , ψc₁ , ψd₁ ⇓ σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs_scope
+                                                                                                  and "[ s , σ₁ , ψc₁ , ψd₁ ⇓[ v <- dl ] σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem_iter v dl s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs_scope.
 
-    Notation "[ s , σ₁ , ψc₁ , ψd₁ ⇓ σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs.
-    Notation "[ s , σ₁ , ψc₁ , ψd₁ ⇓[ v <- dl ] σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem_iter v dl s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs.
+    Notation "[ s , σ₁ , ψc₁ , ψd₁ ⇓ σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs_scope.
+    Notation "[ s , σ₁ , ψc₁ , ψd₁ ⇓[ v <- dl ] σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem_iter v dl s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs_scope.
 
   End Denotation.
 
   Reserved Notation "[ σc ⊢ q ⇓ d  ]".
 
-  Notation "[ σc ; σ ⊢ e ⇓ d ]" := (nnrs_expr_sem σc σ e d) : nnrs.
-  Notation "[ σc ⊢ s , σ₁ , ψc₁ , ψd₁ ⇓ σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem σc s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs.
-  Notation "[ σc ⊢ s , σ₁ , ψc₁ , ψd₁ ⇓[ v <- dl ] σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem_iter σc v dl s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs.
+  Notation "[ σc ; σ ⊢ e ⇓ d ]" := (nnrs_expr_sem σc σ e d) : nnrs_scope.
+  Notation "[ σc ⊢ s , σ₁ , ψc₁ , ψd₁ ⇓ σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem σc s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs_scope.
+  Notation "[ σc ⊢ s , σ₁ , ψc₁ , ψd₁ ⇓[ v <- dl ] σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem_iter σc v dl s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs_scope.
 
   Inductive nnrs_sem : bindings -> nnrs -> option data -> Prop
     :=
@@ -170,18 +170,18 @@ Section NNRSSem.
         [ σc ⊢ (fst q), nil , nil, ((snd q),None)::nil ⇓ nil, nil, ((snd q), o)::nil ] ->
         [ σc ⊢ q ⇓ o  ]
   where
-  "[ σc ⊢ q ⇓ o  ]" := (nnrs_sem σc q o ) : nnrs.
+  "[ σc ⊢ q ⇓ o  ]" := (nnrs_sem σc q o ) : nnrs_scope.
 
   Definition nnrs_sem_top (σc:bindings) (q:nnrs) (d:data) : Prop
     := [ (rec_sort σc) ⊢ q ⇓ Some d  ].
 
-  Notation "[ σc ⊢ q ⇓ d  ]" := (nnrs_sem σc q d ) : nnrs.
+  Notation "[ σc ⊢ q ⇓ d  ]" := (nnrs_sem σc q d ) : nnrs_scope.
 
   Section Core.
     Program Definition nnrs_core_sem σc (q:nnrs_core) (d:option data) : Prop
       := nnrs_sem σc q d.
 
-    Notation "[ σc ⊢ q ⇓ᶜ d  ]" := (nnrs_core_sem σc q d ) : nnrs.
+    Notation "[ σc ⊢ q ⇓ᶜ d  ]" := (nnrs_core_sem σc q d ) : nnrs_scope.
 
     Definition nnrs_core_sem_top (σc:bindings) (q:nnrs_core) (d:data) : Prop
       := [ (rec_sort σc) ⊢ q ⇓ᶜ Some d  ].
@@ -364,12 +364,12 @@ Section NNRSSem.
 
 End NNRSSem.
 
-Notation "[ h , σc ; σ ⊢ e ⇓ d ]" := (nnrs_expr_sem h σc σ e d) : nnrs.
-Notation "[ h , σc ⊢ s , σ₁ , ψc₁ , ψd₁ ⇓ σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem h σc s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs.
-Notation "[ h , σc ⊢ s , σ₁ , ψc₁ , ψd₁ ⇓[ v <- dl ] σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem_iter h σc v dl s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs.
-Notation "[ h , σc ⊢ q ⇓ d  ]" := (nnrs_sem h σc q d ) : nnrs.
+Notation "[ h , σc ; σ ⊢ e ⇓ d ]" := (nnrs_expr_sem h σc σ e d) : nnrs_scope.
+Notation "[ h , σc ⊢ s , σ₁ , ψc₁ , ψd₁ ⇓ σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem h σc s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs_scope.
+Notation "[ h , σc ⊢ s , σ₁ , ψc₁ , ψd₁ ⇓[ v <- dl ] σ₂ , ψc₂ , ψd₂ ]" := (nnrs_stmt_sem_iter h σc v dl s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ ) : nnrs_scope.
+Notation "[ h , σc ⊢ q ⇓ d  ]" := (nnrs_sem h σc q d ) : nnrs_scope.
 
-Notation "[ h , σc ⊢ q ⇓ᶜ d  ]" := (nnrs_core_sem h σc q d ) : nnrs.
+Notation "[ h , σc ⊢ q ⇓ᶜ d  ]" := (nnrs_core_sem h σc q d ) : nnrs_scope.
 
 Arguments nnrs_stmt_sem_env_stack {fruntime h σc s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂}.
 Arguments nnrs_stmt_sem_mcenv_stack {fruntime h σc s σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂}.

--- a/compiler/core/NNRS/Lang/NNRSSemEval.v
+++ b/compiler/core/NNRS/Lang/NNRSSemEval.v
@@ -42,6 +42,8 @@ Section NNRSSemEval.
   Local Open Scope nnrs.
   Local Open Scope string.
 
+  Hint Constructors nnrs_expr_sem : qcert.
+          
   Lemma nnrs_expr_sem_eval σc σ e d :
     [ h , σc ; σ ⊢ e ⇓ d ] <-> nnrs_expr_eval h σc σ e = Some d.
   Proof.
@@ -62,20 +64,19 @@ Section NNRSSemEval.
           simpl; rewrite H5; simpl; trivial.
       }
     - {
-        Hint Constructors nnrs_expr_sem.
-        nnrs_expr_cases (induction e) Case; intros σ d₀ sem; invcs sem; simpl; trivial; eauto 3.
+        nnrs_expr_cases (induction e) Case; intros σ d₀ sem; invcs sem; simpl; trivial; eauto 3 with qcert.
         - Case "NNRSVar".
           apply some_olift in H0.
           destruct H0 as [??]; unfold id in *; subst.
-          eauto.
+          qeauto.
         - Case "NNRSBinop".
           apply some_olift2 in H0.
           destruct H0 as [?[?? [??]]].
-          eauto.
+          qeauto.
         - Case "NNRSUnop".
           apply some_olift in H0.
           destruct H0 as [??]; unfold id in *; subst.
-          eauto.
+          qeauto.
         - Case "NNRSGroupBy".
           match_case_in H0;
             [intros ? eqq | intros eqq]; rewrite eqq in H0;
@@ -84,7 +85,7 @@ Section NNRSSemEval.
           apply some_olift in H0.
           destruct H0 as [??]; unfold id in *; subst.
           invcs e1.
-          eauto.
+          qeauto.
       }
   Qed.
 
@@ -155,53 +156,53 @@ Section NNRSSemEval.
           simpl; trivial.
       }
     - {
-        Hint Constructors nnrs_stmt_sem.
-        Hint Constructors nnrs_stmt_sem_iter.
-        Hint Resolve nnrs_stmt_sem_env_cons_same.
-        Hint Resolve nnrs_stmt_sem_mcenv_cons_same.
+        Hint Constructors nnrs_stmt_sem : qcert.
+        Hint Constructors nnrs_stmt_sem_iter : qcert.
+        Hint Resolve nnrs_stmt_sem_env_cons_same : qcert.
+        Hint Resolve nnrs_stmt_sem_mcenv_cons_same : qcert.
 
         nnrs_stmt_cases (induction s) Case; simpl; intros σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ sem; repeat destr sem.
         - Case "NNRSSeq".
-          eauto.
+          qeauto.
         - Case "NNRSLet".
           invcs sem.
           apply nnrs_expr_sem_eval in eqq.
-          eauto.
+          qeauto.
         - Case "NNRSLetMut".
           invcs sem.
           apply IHs1 in eqq.
           apply nnrs_stmt_sem_mdenv_cons_same in eqq.
-          eauto.
+          qeauto.
         - Case "NNRSLetMutColl".
           invcs sem.
           apply IHs1 in eqq.
           apply nnrs_stmt_sem_mcenv_cons_same in eqq.
-          eauto.
+          qeauto.
         - Case "NNRSAssign".
           invcs sem.
           apply nnrs_expr_sem_eval in eqq.
-          eauto.
+          qeauto.
         - Case "NNRSPush".
           invcs sem.
           apply nnrs_expr_sem_eval in eqq.
-          eauto.
+          qeauto.
         - Case "NNRSFor".
           destruct d; try discriminate.
           apply nnrs_expr_sem_eval in eqq.
           econstructor; eauto.
           clear eqq.
           revert σ₁ ψc₁ ψd₁ σ₂ ψc₂ ψd₂ sem.
-          induction l; intros σ₁  ψc₁ ψd₁ σ₂ ψc₂ ψd₂ sem; invcs sem; eauto 1.
+          induction l; intros σ₁  ψc₁ ψd₁ σ₂ ψc₂ ψd₂ sem; invcs sem; eauto 1 with qcert.
           repeat destr H0.
-          eauto.
+          qeauto.
         - Case "NNRSIf".
           apply nnrs_expr_sem_eval in eqq.
           destruct d; try discriminate.
-          destruct b; eauto.
+          destruct b; qeauto.
         - Case "NNRSEither".
           apply nnrs_expr_sem_eval in eqq.
           destruct d; try discriminate;
-            repeat destr sem; invcs sem; eauto.
+            repeat destr sem; invcs sem; qeauto.
       }
   Qed.
 

--- a/compiler/core/NNRS/Lang/NNRSSize.v
+++ b/compiler/core/NNRS/Lang/NNRSSize.v
@@ -13,7 +13,7 @@
  *)
 
 Require Import String.
-Require Import Omega.
+Require Import Lia.
 Require Import EquivDec.
 Require Import Decidable.
 Require Import Utils.
@@ -52,12 +52,12 @@ Section NNRSSize.
 
     Lemma nnrs_expr_size_nzero (n:nnrs_expr) : nnrs_expr_size n <> 0.
     Proof.
-      induction n; simpl; omega.
+      induction n; simpl; lia.
     Qed.
 
     Lemma nnrs_stmt_size_nzero (n:nnrs_stmt) : nnrs_stmt_size n <> 0.
     Proof.
-      induction n; simpl; omega.
+      induction n; simpl; lia.
     Qed.
 
     Corollary nnrs_size_nzero (q:nnrs) : nnrs_size q <> 0.

--- a/compiler/core/NNRS/Typing/TNNRS.v
+++ b/compiler/core/NNRS/Typing/TNNRS.v
@@ -805,7 +805,7 @@ Section TNNRS.
   End sem.
   
   (* we are only sensitive to the environment up to lookup *)
-  Global Instance nnrs_expr_type_lookup_equiv_prop {m:basic_model} :
+  Global Instance nnrs_expr_type_lookup_equiv_prop :
     Proper (eq ==> lookup_equiv ==> eq ==> eq ==> iff) nnrs_expr_type.
   Proof.
     cut (Proper (eq ==> lookup_equiv ==> eq ==> eq ==> impl) nnrs_expr_type);

--- a/compiler/core/NNRS/Typing/TNNRS.v
+++ b/compiler/core/NNRS/Typing/TNNRS.v
@@ -26,6 +26,9 @@ Require Import NNRSSem.
 Require Import NNRSSemEval.
 Require Import NNRSVars.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section TNNRS.
   (** Typing rules for NNRS *)
   Context {m:basic_model}.

--- a/compiler/core/NNRS/Typing/TNNRS.v
+++ b/compiler/core/NNRS/Typing/TNNRS.v
@@ -102,10 +102,10 @@ Section TNNRS.
         [ Γ ⊢ e ▷ Coll (Rec k τl pf) ] ->
         [ Γ ⊢ NNRSGroupBy g sl e ▷ GroupBy_type g sl k τl pf ]
     where
-    "[ Γ ⊢ e ▷ τ ]" := (nnrs_expr_type Γ e τ) : nnrs
+    "[ Γ ⊢ e ▷ τ ]" := (nnrs_expr_type Γ e τ) : nnrs_scope
     .
 
-    Notation "[ Γ  ⊢ e ▷ τ ]" := (nnrs_expr_type Γ e τ) : nnrs.
+    Notation "[ Γ  ⊢ e ▷ τ ]" := (nnrs_expr_type Γ e τ) : nnrs_scope.
 
     (* Observation: all the contexts are stacklike in their domain,
        and there is no reason to allow strong updates, since there is a phase
@@ -189,14 +189,14 @@ Section TNNRS.
         [  (x₂,Some τr)::Γ , Δc , Δd  ⊢ s₂ ]  ->
         [  Γ , Δc , Δd  ⊢ NNRSEither e x₁ s₁ x₂ s₂ ]
     where
-    "[ Γ , Δc , Δd  ⊢ s ]" := (nnrs_stmt_type Γ Δc  Δd s) : nnrs
+    "[ Γ , Δc , Δd  ⊢ s ]" := (nnrs_stmt_type Γ Δc  Δd s) : nnrs_scope
     .
 
-    Notation "[ Γ , Δc , Δd  ⊢ s ]" := (nnrs_stmt_type Γ Δc  Δd s) : nnrs.
+    Notation "[ Γ , Δc , Δd  ⊢ s ]" := (nnrs_stmt_type Γ Δc  Δd s) : nnrs_scope.
   End typ.
 
-  Notation "[ Γc ; Γ  ⊢ e ▷ τ ]" := (nnrs_expr_type Γc Γ e τ) : nnrs.
-  Notation "[ Γc ; Γ , Δc , Δd  ⊢ s ]" := (nnrs_stmt_type Γc Γ Δc  Δd s) : nnrs.
+  Notation "[ Γc ; Γ  ⊢ e ▷ τ ]" := (nnrs_expr_type Γc Γ e τ) : nnrs_scope.
+  Notation "[ Γc ; Γ , Δc , Δd  ⊢ s ]" := (nnrs_stmt_type Γc Γ Δc  Δd s) : nnrs_scope.
 
   Local Open Scope nnrs.
   
@@ -204,7 +204,7 @@ Section TNNRS.
     := let (s, ret) := si in
        [ Γc ; nil , nil , (ret, τ)::nil  ⊢ s ].
 
-  Notation "[ Γc ⊢ si ▷ τ ]" := (nnrs_type Γc si τ) : nnrs.
+  Notation "[ Γc ⊢ si ▷ τ ]" := (nnrs_type Γc si τ) : nnrs_scope.
 
   
   Lemma typed_nnrs_expr_yields_typed_data {σc Γc} {σ Γ} {e τ} :
@@ -823,7 +823,7 @@ Section TNNRS.
   Global Instance nnrs_stmt_type_lookup_equiv_prop :
     Proper (eq ==> lookup_equiv ==> lookup_equiv ==> lookup_equiv ==> eq ==> iff) nnrs_stmt_type.
   Proof.
-    Hint Constructors nnrs_stmt_type.
+    Hint Constructors nnrs_stmt_type : qcert.
     
     cut (Proper (eq ==> lookup_equiv ==> lookup_equiv ==> lookup_equiv ==> eq ==> impl) nnrs_stmt_type)
     ; unfold Proper, respectful, iff, impl; intros; subst;
@@ -860,8 +860,8 @@ Section TNNRS.
   Section unused.
     Local Open Scope nnrs.
 
-    Hint Constructors nnrs_expr_type.
-    Hint Constructors nnrs_stmt_type.
+    Hint Constructors nnrs_expr_type : qcert.
+    Hint Constructors nnrs_stmt_type : qcert.
 
     Section remove.
       
@@ -876,7 +876,7 @@ Section TNNRS.
         ; simpl; intros ll Γ τo inn typ
         ; invcs typ
         ; repeat rewrite in_app_iff in inn
-        ; eauto 3.
+        ; eauto 3 with qcert.
         - Case "NNRSVar"%string.
           econstructor.
           repeat rewrite lookup_app in *
@@ -896,7 +896,7 @@ Section TNNRS.
         [  Γc ; l++(v,τ)::Γ , Δc , Δd  ⊢ s ] ->
         [  Γc ; l++Γ , Δc , Δd  ⊢ s ].
       Proof.
-        Hint Resolve nnrs_expr_type_unused_remove_env.
+        Hint Resolve nnrs_expr_type_unused_remove_env : qcert.
         revert l Γ Δc Δd τ.
         nnrs_stmt_cases (induction s) Case
         ; simpl; intros l Γ Δc Δd τ inn typ
@@ -930,9 +930,9 @@ Section TNNRS.
             eapply IHs2; eauto.
             intuition; destruct (remove_nin_inv H1); eauto.
         - Case "NNRSAssign"%string.        
-          eauto.
+          qeauto.
         - Case "NNRSPush"%string.
-          eauto.
+          qeauto.
         - Case "NNRSFor"%string.
           econstructor.
           + eapply nnrs_expr_type_unused_remove_env;[|eauto]; tauto.
@@ -940,7 +940,7 @@ Section TNNRS.
             eapply IHs; eauto.
             intuition; destruct (remove_nin_inv H1); eauto.
         - Case "NNRSIf"%string.
-          econstructor; intuition eauto.
+          econstructor; intuition qeauto.
         - Case "NNRSEither"%string.
           econstructor.
           + eapply nnrs_expr_type_unused_remove_env;[|eauto]; tauto.
@@ -1035,7 +1035,7 @@ Section TNNRS.
         ; simpl; intros ll Γ τo inn typ
         ; invcs typ
         ; repeat rewrite in_app_iff in inn
-        ; eauto 3.
+        ; eauto 3 with qcert.
         - Case "NNRSVar"%string.
           econstructor.
           repeat rewrite lookup_app in *
@@ -1055,7 +1055,7 @@ Section TNNRS.
         [  Γc ; l++Γ , Δc , Δd  ⊢ s ] ->
         [  Γc ; l++(v,τ)::Γ , Δc , Δd  ⊢ s ].
       Proof.
-        Hint Resolve nnrs_expr_type_unused_add_env.
+        Hint Resolve nnrs_expr_type_unused_add_env : qcert.
         revert l Γ Δc Δd τ.
         nnrs_stmt_cases (induction s) Case
         ; simpl; intros l Γ Δc Δd τ inn typ
@@ -1089,9 +1089,9 @@ Section TNNRS.
             eapply IHs2; eauto.
             intuition; destruct (remove_nin_inv H1); eauto.
         - Case "NNRSAssign"%string.        
-          eauto.
+          qeauto.
         - Case "NNRSPush"%string.
-          eauto.
+          qeauto.
         - Case "NNRSFor"%string.
           econstructor.
           + eapply nnrs_expr_type_unused_add_env;[|eauto]; tauto.
@@ -1099,7 +1099,7 @@ Section TNNRS.
             eapply IHs; eauto.
             intuition; destruct (remove_nin_inv H1); eauto.
         - Case "NNRSIf"%string.
-          econstructor; intuition eauto.
+          econstructor; intuition qeauto.
         - Case "NNRSEither"%string.
           econstructor.
           + eapply nnrs_expr_type_unused_add_env;[|eauto]; tauto.
@@ -1213,10 +1213,10 @@ Section TNNRS.
     forall τ',
       [Γc; l1++(v, Some τ') :: Γ ⊢ e ▷ τ].
   Proof.
-    Hint Constructors nnrs_expr_type.
+    Hint Constructors nnrs_expr_type : qcert.
     revert τ.
     induction e; intros τ typ nin τ'
-    ; invcs typ; eauto.
+    ; invcs typ; qeauto.
     econstructor.
     repeat rewrite lookup_app in *.
     match_destr; simpl in *.
@@ -1230,13 +1230,13 @@ Section TNNRS.
     forall τ,
       [Γc; l1++(v, Some τ) :: Γ, Δc, Δd ⊢ s].
   Proof.
-    Hint Constructors nnrs_stmt_type.
+    Hint Constructors nnrs_stmt_type : qcert.
     revert l1 Γ Δc Δd.
     nnrs_stmt_cases (induction s) Case
     ; simpl; intros l1 Γ Δc Δd typ nin τ
     ; invcs typ.
     - Case "NNRSSeq"%string.
-      eauto.
+      qeauto.
     - Case "NNRSLet"%string.
       econstructor.
       + apply nnrs_expr_type_env_in_none_some; eauto.
@@ -1331,6 +1331,6 @@ Section TNNRS.
 
 End TNNRS.
 
-Notation "[ Γc ; Γ  ⊢ e ▷ τ ]" := (nnrs_expr_type Γc Γ e τ) : nnrs.
-Notation "[ Γc ; Γ , Δc , Δd  ⊢ s ]" := (nnrs_stmt_type Γc Γ Δc  Δd s) : nnrs.
-Notation "[ Γc ⊢ si ▷ τ ]" := (nnrs_type Γc si τ) : nnrs.
+Notation "[ Γc ; Γ  ⊢ e ▷ τ ]" := (nnrs_expr_type Γc Γ e τ) : nnrs_scope.
+Notation "[ Γc ; Γ , Δc , Δd  ⊢ s ]" := (nnrs_stmt_type Γc Γ Δc  Δd s) : nnrs_scope.
+Notation "[ Γc ⊢ si ▷ τ ]" := (nnrs_type Γc si τ) : nnrs_scope.

--- a/compiler/core/NNRS/Typing/TNNRSRename.v
+++ b/compiler/core/NNRS/Typing/TNNRSRename.v
@@ -34,8 +34,8 @@ Section TNNRSRename.
   Context {m:basic_model}.
   Local Open Scope nnrs.
 
-  Hint Constructors nnrs_expr_type.
-  Hint Constructors nnrs_stmt_type.
+  Hint Constructors nnrs_expr_type : qcert.
+  Hint Constructors nnrs_stmt_type : qcert.
 
 
   Lemma nnrs_stmt_must_assign_rename_env s v v1 v2 :
@@ -105,7 +105,7 @@ Section TNNRSRename.
     ; intros τo ??? typ
     ; invcs typ
     ; repeat rewrite in_app_iff in *
-    ; eauto 3.
+    ; eauto 3 with qcert.
     - econstructor.
       repeat rewrite lookup_app in *.
       destruct (equiv_dec v0 v); unfold equiv, complement in *
@@ -160,7 +160,7 @@ Section TNNRSRename.
     [ Γc ; (l++(v,τ)::Γ) , Δc , Δd  ⊢ s ] ->
     [ Γc ; (l++(v',τ)::Γ) , Δc , Δd  ⊢ nnrs_stmt_rename_env s v v' ].
   Proof.
-    Hint Resolve nnrs_expr_type_rename_env_in.
+    Hint Resolve nnrs_expr_type_rename_env_in : qcert.
 
     revert l Γ Δc Δd τ
     ; nnrs_stmt_cases (induction s) Case
@@ -169,18 +169,18 @@ Section TNNRSRename.
     ; repeat rewrite in_app_iff in ninb
     ; invcs typ.
     - Case "NNRSSeq"%string.
-      intuition eauto.
+      intuition qeauto.
     - Case "NNRSLet"%string.
       match_destr; unfold equiv, complement in *.
       + subst.
-        econstructor; eauto.
+        econstructor; qeauto.
         apply (nnrs_stmt_type_unused_remove_env Γc ((v,Some τ0)::l)) in H6
         ; simpl; try tauto.
         apply (nnrs_stmt_type_unused_add_env Γc ((v,Some τ0)::l))
         ; simpl; trivial.
         intuition.
         destruct (remove_nin_inv H2); eauto.
-      + econstructor; eauto.
+      + econstructor; qeauto.
         specialize (IHs ((v0, Some τ0) :: l)); simpl in IHs.
         eapply IHs; eauto
         ; intuition.
@@ -230,10 +230,10 @@ Section TNNRSRename.
         eapply IHs2; intuition.
         destruct (remove_nin_inv H1); eauto.
     - Case "NNRSAssign"%string.
-      eauto.
+      qeauto.
     - Case "NNRSPush"%string.
-      eauto.
-    - econstructor; eauto.
+      qeauto.
+    - econstructor; qeauto.
       match_destr; unfold equiv, complement in *.
       + subst.
         apply (nnrs_stmt_type_unused_remove_env Γc ((v, Some τ0) :: l)) in H6
@@ -245,9 +245,9 @@ Section TNNRSRename.
         eapply IHs; intuition.
         destruct (remove_nin_inv H1); eauto.
     - Case "NNRSIf"%string.
-      econstructor; intuition eauto.
+      econstructor; intuition qeauto.
     - Case "NNRSEither"%string.
-      econstructor; eauto.
+      econstructor; qeauto.
       + match_destr; unfold equiv, complement in *.
         * subst.
           apply (nnrs_stmt_type_unused_remove_env Γc ((v,Some τl)::l)) in H8
@@ -289,7 +289,7 @@ Section TNNRSRename.
     ; repeat rewrite in_app_iff in nine
     ; repeat rewrite in_app_iff in ninb
     ; invcs typ
-    ; intuition eauto.
+    ; intuition qeauto.
     - Case "NNRSLetMut"%string.
       match_destr; unfold equiv, complement in *.
       + subst.
@@ -352,7 +352,7 @@ Section TNNRSRename.
     ; repeat rewrite in_app_iff in nine
     ; repeat rewrite in_app_iff in ninb
     ; invcs typ
-    ; intuition eauto.
+    ; intuition qeauto.
     - Case "NNRSLetMut"%string.
       econstructor; intuition eauto.
       apply nnrs_stmt_must_assign_rename_mc; trivial.
@@ -407,7 +407,7 @@ Section TNNRSRename.
     ; intros τo ??? typ
     ; invcs typ
     ; repeat rewrite in_app_iff in *
-    ; eauto 3.
+    ; eauto 3 with qcert.
     - econstructor.
       repeat rewrite lookup_app in *.
       destruct (equiv_dec v0 v); unfold equiv, complement in *
@@ -439,7 +439,7 @@ Section TNNRSRename.
     [ Γc ; (l++(v',τ)::Γ) , Δc , Δd  ⊢ nnrs_stmt_rename_env s v v' ] ->
     [ Γc ; (l++(v,τ)::Γ) , Δc , Δd  ⊢ s ].
   Proof.
-    Hint Resolve nnrs_expr_type_rename_env_in_inv.
+    Hint Resolve nnrs_expr_type_rename_env_in_inv : qcert.
 
     revert l Γ Δc Δd τ
     ; nnrs_stmt_cases (induction s) Case
@@ -448,18 +448,18 @@ Section TNNRSRename.
     ; repeat rewrite in_app_iff in ninb
     ; invcs typ.
     - Case "NNRSSeq"%string.
-      intuition eauto.
+      intuition qeauto.
     - Case "NNRSLet"%string.
       match_destr_in H6; unfold equiv, complement in *.
       + subst.
-        econstructor; eauto.
+        econstructor; qeauto.
         apply (nnrs_stmt_type_unused_add_env Γc ((v,Some τ0)::l))
         ; simpl; try tauto.
         apply (nnrs_stmt_type_unused_remove_env Γc ((v,Some τ0)::l)) in H6
         ; simpl; try tauto.
         intuition.
         destruct (remove_nin_inv H2); eauto.
-      + econstructor; eauto.
+      + econstructor; qeauto.
         specialize (IHs ((v0, Some τ0) :: l)); simpl in IHs.
         eapply IHs; eauto
         ; intuition.
@@ -512,10 +512,10 @@ Section TNNRSRename.
         eapply IHs2; intuition.
         destruct (remove_nin_inv H1); eauto.
     - Case "NNRSAssign"%string.
-      eauto.
+      qeauto.
     - Case "NNRSPush"%string.
-      eauto.
-    - econstructor; eauto.
+      qeauto.
+    - econstructor; qeauto.
       match_destr_in H6; unfold equiv, complement in *.
       + subst.
         apply (nnrs_stmt_type_unused_add_env Γc ((v,  Some τ0) :: l));
@@ -528,9 +528,9 @@ Section TNNRSRename.
         eapply IHs; intuition.
         destruct (remove_nin_inv H1); eauto.
     - Case "NNRSIf"%string.
-      econstructor; intuition eauto.
+      econstructor; intuition qeauto.
     - Case "NNRSEither"%string.
-      econstructor; eauto.
+      econstructor; qeauto.
       + match_destr_in H8; unfold equiv, complement in *.
         * subst.
           apply (nnrs_stmt_type_unused_remove_env Γc ((v,Some τl)::l)) in H8
@@ -571,7 +571,7 @@ Section TNNRSRename.
     ; repeat rewrite in_app_iff in nine
     ; repeat rewrite in_app_iff in ninb
     ; invcs typ
-    ; intuition eauto.
+    ; intuition qeauto.
     - Case "NNRSLetMut"%string.
       match_destr_in H6; unfold equiv, complement in *.
       + subst.
@@ -636,7 +636,7 @@ Section TNNRSRename.
     ; repeat rewrite in_app_iff in nine
     ; repeat rewrite in_app_iff in ninb
     ; invcs typ
-    ; intuition eauto.
+    ; intuition qeauto.
     - Case "NNRSLetMut"%string.
       econstructor; intuition eauto.
       eapply nnrs_stmt_must_assign_rename_mc; eauto.

--- a/compiler/core/NNRSimp/Lang/NNRSimp.v
+++ b/compiler/core/NNRSimp/Lang/NNRSimp.v
@@ -30,7 +30,9 @@ Require Import EquivDec.
 Require Import Decidable.
 Require Import Utils.
 Require Import DataRuntime.
-  
+
+Declare Scope nnrs_imp_scope.
+
 Section NNRSimp.
 
   Section Syntax.
@@ -266,43 +268,43 @@ Tactic Notation "nnrs_imp_stmt_cases" tactic(first) ident(c) :=
   | Case_aux c "NNRSimpIf"%string
   | Case_aux c "NNRSimpEither"%string].
 
-Delimit Scope nnrs_imp with nnrs_imp_scope.
+Delimit Scope nnrs_imp_scope with nnrs_imp.
 
 (* begin hide *)
-Notation "‵‵ c" := (NNRSimpConst (dconst c))  (at level 0) : nnrs_imp.                           (* ‵ = \backprime *)
-Notation "‵ c" := (NNRSimpConst c)  (at level 0) : nnrs_imp.                                     (* ‵ = \backprime *)
-Notation "‵{||}" := (NNRSimpConst (dcoll nil))  (at level 0) : nnrs_imp.                         (* ‵ = \backprime *)
-Notation "‵[||]" := (NNRSimpConst (drec nil)) (at level 50) : nnrs_imp.                          (* ‵ = \backprime *)
+Notation "‵‵ c" := (NNRSimpConst (dconst c))  (at level 0) : nnrs_imp_scope.                           (* ‵ = \backprime *)
+Notation "‵ c" := (NNRSimpConst c)  (at level 0) : nnrs_imp_scope.                                     (* ‵ = \backprime *)
+Notation "‵{||}" := (NNRSimpConst (dcoll nil))  (at level 0) : nnrs_imp_scope.                         (* ‵ = \backprime *)
+Notation "‵[||]" := (NNRSimpConst (drec nil)) (at level 50) : nnrs_imp_scope.                          (* ‵ = \backprime *)
 
-Notation "r1 ∧ r2" := (NNRSimpBinop OpAnd r1 r2) (right associativity, at level 65): nnrs_imp.    (* ∧ = \wedge *)
-Notation "r1 ∨ r2" := (NNRSimpBinop OpOr r1 r2) (right associativity, at level 70): nnrs_imp.     (* ∨ = \vee *)
-Notation "r1 ≐ r2" := (NNRSimpBinop OpEqual r1 r2) (right associativity, at level 70): nnrs_imp.     (* ≐ = \doteq *)
-Notation "r1 ≤ r2" := (NNRSimpBinop OpLe r1 r2) (no associativity, at level 70): nnrs_imp.     (* ≤ = \leq *)
-Notation "r1 ⋃ r2" := (NNRSimpBinop OpBagUnion r1 r2) (right associativity, at level 70): nnrs_imp.  (* ⋃ = \bigcup *)
-Notation "r1 − r2" := (NNRSimpBinop OpBagDiff r1 r2) (right associativity, at level 70): nnrs_imp.  (* − = \minus *)
-Notation "r1 ⋂min r2" := (NNRSimpBinop OpBagMin r1 r2) (right associativity, at level 70): nnrs_imp. (* ♯ = \sharp *)
-Notation "r1 ⋃max r2" := (NNRSimpBinop OpBagMax r1 r2) (right associativity, at level 70): nnrs_imp. (* ♯ = \sharp *)
-Notation "p ⊕ r"   := ((NNRSimpBinop OpRecConcat) p r) (at level 70) : nnrs_imp.                     (* ⊕ = \oplus *)
-Notation "p ⊗ r"   := ((NNRSimpBinop OpRecMerge) p r) (at level 70) : nnrs_imp.                (* ⊗ = \otimes *)
+Notation "r1 ∧ r2" := (NNRSimpBinop OpAnd r1 r2) (right associativity, at level 65): nnrs_imp_scope.    (* ∧ = \wedge *)
+Notation "r1 ∨ r2" := (NNRSimpBinop OpOr r1 r2) (right associativity, at level 70): nnrs_imp_scope.     (* ∨ = \vee *)
+Notation "r1 ≐ r2" := (NNRSimpBinop OpEqual r1 r2) (right associativity, at level 70): nnrs_imp_scope.     (* ≐ = \doteq *)
+Notation "r1 ≤ r2" := (NNRSimpBinop OpLe r1 r2) (no associativity, at level 70): nnrs_imp_scope.     (* ≤ = \leq *)
+Notation "r1 ⋃ r2" := (NNRSimpBinop OpBagUnion r1 r2) (right associativity, at level 70): nnrs_imp_scope.  (* ⋃ = \bigcup *)
+Notation "r1 − r2" := (NNRSimpBinop OpBagDiff r1 r2) (right associativity, at level 70): nnrs_imp_scope.  (* − = \minus *)
+Notation "r1 ⋂min r2" := (NNRSimpBinop OpBagMin r1 r2) (right associativity, at level 70): nnrs_imp_scope. (* ♯ = \sharp *)
+Notation "r1 ⋃max r2" := (NNRSimpBinop OpBagMax r1 r2) (right associativity, at level 70): nnrs_imp_scope. (* ♯ = \sharp *)
+Notation "p ⊕ r"   := ((NNRSimpBinop OpRecConcat) p r) (at level 70) : nnrs_imp_scope.                     (* ⊕ = \oplus *)
+Notation "p ⊗ r"   := ((NNRSimpBinop OpRecMerge) p r) (at level 70) : nnrs_imp_scope.                (* ⊗ = \otimes *)
 
-Notation "¬( r1 )" := (NNRSimpUnop OpNeg r1) (right associativity, at level 70): nnrs_imp.        (* ¬ = \neg *)
-Notation "ε( r1 )" := (NNRSimpUnop OpDistinct r1) (right associativity, at level 70): nnrs_imp.   (* ε = \epsilon *)
-Notation "♯count( r1 )" := (NNRSimpUnop OpCount r1) (right associativity, at level 70): nnrs_imp. (* ♯ = \sharp *)
-Notation "♯flatten( d )" := (NNRSimpUnop OpFlatten d) (at level 50) : nnrs_imp.                   (* ♯ = \sharp *)
-Notation "‵{| d |}" := ((NNRSimpUnop OpBag) d)  (at level 50) : nnrs_imp.                        (* ‵ = \backprime *)
-Notation "‵[| ( s , r ) |]" := ((NNRSimpUnop (OpRec s)) r) (at level 50) : nnrs_imp.              (* ‵ = \backprime *)
-Notation "¬π[ s1 ]( r )" := ((NNRSimpUnop (OpRecRemove s1)) r) (at level 50) : nnrs_imp.          (* ¬ = \neg and π = \pi *)
-Notation "π[ s1 ]( r )" := ((NNRSimpUnop (OpRecProject s1)) r) (at level 50) : nnrs_imp.          (* π = \pi *)
-Notation "p · r" := ((NNRSimpUnop (OpDot r)) p) (left associativity, at level 40): nnrs_imp.      (* · = \cdot *)
+Notation "¬( r1 )" := (NNRSimpUnop OpNeg r1) (right associativity, at level 70): nnrs_imp_scope.        (* ¬ = \neg *)
+Notation "ε( r1 )" := (NNRSimpUnop OpDistinct r1) (right associativity, at level 70): nnrs_imp_scope.   (* ε = \epsilon *)
+Notation "♯count( r1 )" := (NNRSimpUnop OpCount r1) (right associativity, at level 70): nnrs_imp_scope. (* ♯ = \sharp *)
+Notation "♯flatten( d )" := (NNRSimpUnop OpFlatten d) (at level 50) : nnrs_imp_scope.                   (* ♯ = \sharp *)
+Notation "‵{| d |}" := ((NNRSimpUnop OpBag) d)  (at level 50) : nnrs_imp_scope.                        (* ‵ = \backprime *)
+Notation "‵[| ( s , r ) |]" := ((NNRSimpUnop (OpRec s)) r) (at level 50) : nnrs_imp_scope.              (* ‵ = \backprime *)
+Notation "¬π[ s1 ]( r )" := ((NNRSimpUnop (OpRecRemove s1)) r) (at level 50) : nnrs_imp_scope.          (* ¬ = \neg and π = \pi *)
+Notation "π[ s1 ]( r )" := ((NNRSimpUnop (OpRecProject s1)) r) (at level 50) : nnrs_imp_scope.          (* π = \pi *)
+Notation "p · r" := ((NNRSimpUnop (OpDot r)) p) (left associativity, at level 40): nnrs_imp_scope.      (* · = \cdot *)
 
 (*
-Notation "'$$' v" := (NNRSimpGetConstant v%string) (at level 50, format "'$$' v") : nnrs_imp.
-Notation "'$' v" := (NNRSimpVar v%string) (at level 50, format "'$' v") : nnrs_imp.
-Notation "{| e1 | '$' x ∈ e2 |}" := (NNRSimpFor x%string e2 e1) (at level 50, format "{|  e1  '/ ' |  '$' x  ∈  e2  |}") : nnrs_imp.   (* ∈ = \in *)
-Notation "'let' '$' x ':=' e2 'in' e1" := (NNRSimpLet x%string e2 e1) (at level 50, format "'[hv' 'let'  '$' x  ':='  '[' e2 ']'  '/' 'in'  '[' e1 ']' ']'") : nnrs_imp.
-Notation "e1 ? e2 : e3" := (NNRSimpIf e1 e2 e3) (at level 50, format "e1  '[hv' ?  e2 '/' :  e3 ']'") : nnrs_imp.
+Notation "'$$' v" := (NNRSimpGetConstant v%string) (at level 50, format "'$$' v") : nnrs_imp_scope.
+Notation "'$' v" := (NNRSimpVar v%string) (at level 50, format "'$' v") : nnrs_imp_scope.
+Notation "{| e1 | '$' x ∈ e2 |}" := (NNRSimpFor x%string e2 e1) (at level 50, format "{|  e1  '/ ' |  '$' x  ∈  e2  |}") : nnrs_imp_scope.   (* ∈ = \in *)
+Notation "'let' '$' x ':=' e2 'in' e1" := (NNRSimpLet x%string e2 e1) (at level 50, format "'[hv' 'let'  '$' x  ':='  '[' e2 ']'  '/' 'in'  '[' e1 ']' ']'") : nnrs_imp_scope.
+Notation "e1 ? e2 : e3" := (NNRSimpIf e1 e2 e3) (at level 50, format "e1  '[hv' ?  e2 '/' :  e3 ']'") : nnrs_imp_scope.
  *)
 
-Notation "r1 ‵+ r2" := (NNRSimpBinop (OpNatBinary NatPlus) r1 r2) (right associativity, at level 65): nnrs_imp.
-Notation "r1 ‵* r2" := (NNRSimpBinop (OpNatBinary NatMult) r1 r2) (right associativity, at level 65): nnrs_imp.
-Notation "‵abs r" := (NNRSimpUnop (OpNatUnary NatAbs) r) (right associativity, at level 64): nnrs_imp.
+Notation "r1 ‵+ r2" := (NNRSimpBinop (OpNatBinary NatPlus) r1 r2) (right associativity, at level 65): nnrs_imp_scope.
+Notation "r1 ‵* r2" := (NNRSimpBinop (OpNatBinary NatMult) r1 r2) (right associativity, at level 65): nnrs_imp_scope.
+Notation "‵abs r" := (NNRSimpUnop (OpNatUnary NatAbs) r) (right associativity, at level 64): nnrs_imp_scope.

--- a/compiler/core/NNRSimp/Lang/NNRSimpEq.v
+++ b/compiler/core/NNRSimp/Lang/NNRSimpEq.v
@@ -159,7 +159,7 @@ Section NNRSimpEq.
         apply some_lift in eqq.
         destruct eqq as [???]; subst.
         intuition.
-        invcs H2; eauto.
+        invcs H2; qeauto.
       - rewrite H0; trivial; simpl.
         intuition; try discriminate.
     Qed.
@@ -231,9 +231,9 @@ Section NNRSimpEq.
   
 End NNRSimpEq.
 
-Notation "X ≡ᵉ Y" := (nnrs_imp_expr_eq X Y) (at level 90) : nnrs_imp. (* ≡ = \equiv *)
+Notation "X ≡ᵉ Y" := (nnrs_imp_expr_eq X Y) (at level 90) : nnrs_imp_scope. (* ≡ = \equiv *)
 
-Notation "X ≡ˢ Y" := (nnrs_imp_stmt_eq X Y) (at level 90) : nnrs_imp. (* ≡ = \equiv *)
+Notation "X ≡ˢ Y" := (nnrs_imp_stmt_eq X Y) (at level 90) : nnrs_imp_scope. (* ≡ = \equiv *)
 
-Notation "X ≡ˢⁱ Y" := (nnrs_imp_eq X Y) (at level 90) : nnrs_imp. (* ≡ = \equiv *)
+Notation "X ≡ˢⁱ Y" := (nnrs_imp_eq X Y) (at level 90) : nnrs_imp_scope. (* ≡ = \equiv *)
 

--- a/compiler/core/NNRSimp/Lang/NNRSimpNorm.v
+++ b/compiler/core/NNRSimp/Lang/NNRSimpNorm.v
@@ -201,8 +201,8 @@ Section NNRSimpNorm.
   
 End NNRSimpNorm.
 
-Hint Resolve nnrs_imp_expr_eval_normalized.
-Hint Resolve nnrs_imp_stmt_eval_normalized.
+Hint Resolve nnrs_imp_expr_eval_normalized : qcert.
+Hint Resolve nnrs_imp_stmt_eval_normalized : qcert.
 
 Arguments nnrs_imp_expr_eval_normalized {fruntime h σc σ e o}.
 Arguments nnrs_imp_stmt_eval_normalized {fruntime h σc σ s σ'}.

--- a/compiler/core/NNRSimp/Lang/NNRSimpSem.v
+++ b/compiler/core/NNRSimp/Lang/NNRSimpSem.v
@@ -76,7 +76,7 @@ Section NNRSimpSem.
         [ σ ⊢ NNRSimpGroupBy g sl e ⇓ (dcoll d₂) ]
 
     where
-    "[ σ ⊢ e ⇓ d ]" := (nnrs_imp_expr_sem σ e d) : nnrs_imp
+    "[ σ ⊢ e ⇓ d ]" := (nnrs_imp_expr_sem σ e d) : nnrs_imp_scope
     .
 
     Reserved Notation  "[ s₁ , σ₁ ⇓ σ₂  ]".
@@ -138,19 +138,19 @@ Section NNRSimpSem.
              [ s, σ₂ ⇓[v<-dl] σ₃ ] ->
              [ s, σ₁ ⇓[v<-d::dl] σ₃ ]
     where
-    "[ s , σ₁  ⇓ σ₂ ]" := (nnrs_imp_stmt_sem s σ₁ σ₂) : nnrs_imp
-                                                         and "[ s , σ₁ ⇓[ v <- dl ] σ₂  ]" := (nnrs_imp_stmt_sem_iter v dl s σ₁ σ₂ ) : nnrs_imp.
+    "[ s , σ₁  ⇓ σ₂ ]" := (nnrs_imp_stmt_sem s σ₁ σ₂) : nnrs_imp_scope
+                                                         and "[ s , σ₁ ⇓[ v <- dl ] σ₂  ]" := (nnrs_imp_stmt_sem_iter v dl s σ₁ σ₂ ) : nnrs_imp_scope.
 
-    Notation "[ s , σ₁ ⇓ σ₂ ]" := (nnrs_imp_stmt_sem s σ₁ σ₂ ) : nnrs_imp.
-    Notation "[ s , σ₁ ⇓[ v <- dl ] σ₂  ]" := (nnrs_imp_stmt_sem_iter v dl s σ₁ σ₂) : nnrs_imp.
+    Notation "[ s , σ₁ ⇓ σ₂ ]" := (nnrs_imp_stmt_sem s σ₁ σ₂ ) : nnrs_imp_scope.
+    Notation "[ s , σ₁ ⇓[ v <- dl ] σ₂  ]" := (nnrs_imp_stmt_sem_iter v dl s σ₁ σ₂) : nnrs_imp_scope.
 
   End Denotation.
 
   Reserved Notation "[ σc ⊢ q ⇓ d  ]".
 
-  Notation "[ σc ; σ ⊢ e ⇓ d ]" := (nnrs_imp_expr_sem σc σ e d) : nnrs_imp.
-  Notation "[ σc ⊢ s , σ₁ ⇓ σ₂ ]" := (nnrs_imp_stmt_sem σc s σ₁ σ₂ ) : nnrs_imp.
-  Notation "[ σc ⊢ s , σ₁ ⇓[ v <- dl ] σ₂ ]" := (nnrs_imp_stmt_sem_iter σc v dl s σ₁ σ₂) : nnrs_imp.
+  Notation "[ σc ; σ ⊢ e ⇓ d ]" := (nnrs_imp_expr_sem σc σ e d) : nnrs_imp_scope.
+  Notation "[ σc ⊢ s , σ₁ ⇓ σ₂ ]" := (nnrs_imp_stmt_sem σc s σ₁ σ₂ ) : nnrs_imp_scope.
+  Notation "[ σc ⊢ s , σ₁ ⇓[ v <- dl ] σ₂ ]" := (nnrs_imp_stmt_sem_iter σc v dl s σ₁ σ₂) : nnrs_imp_scope.
 
   Inductive nnrs_imp_sem : bindings -> nnrs_imp -> option data -> Prop
     :=
@@ -158,18 +158,18 @@ Section NNRSimpSem.
         [ σc ⊢ (fst q), ((snd q),None)::nil ⇓ ((snd q), o)::nil ] ->
         [ σc ⊢ q ⇓ o  ]
   where
-  "[ σc ⊢ q ⇓ o  ]" := (nnrs_imp_sem σc q o ) : nnrs_imp.
+  "[ σc ⊢ q ⇓ o  ]" := (nnrs_imp_sem σc q o ) : nnrs_imp_scope.
 
   Definition nnrs_imp_sem_top (σc:bindings) (q:nnrs_imp) (d:data) : Prop
     := [ (rec_sort σc) ⊢ q ⇓ Some d  ].
 
-  Notation "[ σc ⊢ q ⇓ d  ]" := (nnrs_imp_sem σc q d ) : nnrs_imp.
+  Notation "[ σc ⊢ q ⇓ d  ]" := (nnrs_imp_sem σc q d ) : nnrs_imp_scope.
 
   Section Core.
     Program Definition nnrs_imp_core_sem σc (q:nnrs_imp_core) (d:option data) : Prop
       := nnrs_imp_sem σc q d.
 
-    Notation "[ σc ⊢ q ⇓ᶜ d  ]" := (nnrs_imp_core_sem σc q d ) : nnrs_imp.
+    Notation "[ σc ⊢ q ⇓ᶜ d  ]" := (nnrs_imp_core_sem σc q d ) : nnrs_imp_scope.
 
     Definition nnrs_imp_core_sem_top (σc:bindings) (q:nnrs_imp_core) (d:data) : Prop
       := [ (rec_sort σc) ⊢ q ⇓ᶜ Some d  ].
@@ -234,12 +234,12 @@ Section NNRSimpSem.
 
 End NNRSimpSem.
 
-Notation "[ h , σc ; σ ⊢ e ⇓ d ]" := (nnrs_imp_expr_sem h σc σ e d) : nnrs_imp.
-Notation "[ h , σc ⊢ s , σ₁ ⇓ σ₂ ]" := (nnrs_imp_stmt_sem h σc s σ₁ σ₂ ) : nnrs_imp.
-Notation "[ h , σc ⊢ s , σ₁ ⇓[ v <- dl ] σ₂ ]" := (nnrs_imp_stmt_sem_iter h σc v dl s σ₁ σ₂) : nnrs_imp.
-Notation "[ h , σc ⊢ q ⇓ d  ]" := (nnrs_imp_sem h σc q d ) : nnrs_imp.
+Notation "[ h , σc ; σ ⊢ e ⇓ d ]" := (nnrs_imp_expr_sem h σc σ e d) : nnrs_imp_scope.
+Notation "[ h , σc ⊢ s , σ₁ ⇓ σ₂ ]" := (nnrs_imp_stmt_sem h σc s σ₁ σ₂ ) : nnrs_imp_scope.
+Notation "[ h , σc ⊢ s , σ₁ ⇓[ v <- dl ] σ₂ ]" := (nnrs_imp_stmt_sem_iter h σc v dl s σ₁ σ₂) : nnrs_imp_scope.
+Notation "[ h , σc ⊢ q ⇓ d  ]" := (nnrs_imp_sem h σc q d ) : nnrs_imp_scope.
 
-Notation "[ h , σc ⊢ q ⇓ᶜ d  ]" := (nnrs_imp_core_sem h σc q d ) : nnrs_imp.
+Notation "[ h , σc ⊢ q ⇓ᶜ d  ]" := (nnrs_imp_core_sem h σc q d ) : nnrs_imp_scope.
 
 Arguments nnrs_imp_stmt_sem_env_stack {fruntime h σc s σ₁ σ₂}.
 Arguments nnrs_imp_stmt_sem_env_cons_same {fruntime h σc s v₁ od₁ σ₁ v₂ od₂ σ₂}.

--- a/compiler/core/NNRSimp/Lang/NNRSimpSemEval.v
+++ b/compiler/core/NNRSimp/Lang/NNRSimpSemEval.v
@@ -63,20 +63,20 @@ Section NNRSimpSemEval.
           simpl; rewrite H5; simpl; trivial.
       }
     - {
-        Hint Constructors nnrs_imp_expr_sem.
-        nnrs_imp_expr_cases (induction e) Case; intros σ d₀ sem; invcs sem; simpl; trivial; eauto 3.
+        Hint Constructors nnrs_imp_expr_sem : qcert.
+        nnrs_imp_expr_cases (induction e) Case; intros σ d₀ sem; invcs sem; simpl; trivial; eauto 3 with qcert.
         - Case "NNRSimpVar".
           apply some_olift in H0.
           destruct H0 as [??]; unfold id in *; subst.
-          eauto.
+          qeauto.
         - Case "NNRSimpBinop".
           apply some_olift2 in H0.
           destruct H0 as [?[?? [??]]].
-          eauto.
+          qeauto.
         - Case "NNRSimpUnop".
           apply some_olift in H0.
           destruct H0 as [??]; unfold id in *; subst.
-          eauto.
+          qeauto.
         - Case "NNRSimpGroupBy".
           match_case_in H0;
             [intros ? eqq | intros eqq]; rewrite eqq in H0;
@@ -85,7 +85,7 @@ Section NNRSimpSemEval.
           apply some_olift in H0.
           destruct H0 as [??]; unfold id in *; subst.
           invcs e1.
-          eauto.
+          qeauto.
       }
   Qed.
 
@@ -151,22 +151,22 @@ Section NNRSimpSemEval.
           simpl; trivial.
       }
     - {
-        Hint Constructors nnrs_imp_stmt_sem.
-        Hint Constructors nnrs_imp_stmt_sem_iter.
-        Hint Resolve nnrs_imp_stmt_sem_env_cons_same.
+        Hint Constructors nnrs_imp_stmt_sem : qcert.
+        Hint Constructors nnrs_imp_stmt_sem_iter : qcert.
+        Hint Resolve nnrs_imp_stmt_sem_env_cons_same : qcert.
 
         nnrs_imp_stmt_cases (induction s) Case; simpl; intros σ₁ σ₂ sem; repeat destr sem.
         - Case "NNRSimpSkip".
-          invcs sem; eauto.
+          invcs sem; qeauto.
         - Case "NNRSimpSeq".
           apply some_olift in sem.
           destruct sem as [???].
-          eauto.
+          qeauto.
         - Case "NNRSimpAssign".
           invcs sem.
           apply nnrs_imp_expr_sem_eval in eqq.
           apply lookup_in_domain in eqq0.
-          eauto.
+          qeauto.
         - Case "NNRSimpLet".
           apply some_olift in sem.
           destruct sem as [? eqq1 eqq2].
@@ -177,27 +177,27 @@ Section NNRSimpSemEval.
           destruct p.
           invcs eqq2.
           apply nnrs_imp_expr_sem_eval in eqq1.
-          eauto.
+          qeauto.
         - Case "NNRSimpLet".
           invcs sem.
-          eauto.
+          qeauto.
         - Case "NNRSimpFor".
           destruct d; try discriminate.
           apply nnrs_imp_expr_sem_eval in eqq.
           econstructor; eauto.
           clear eqq.
           revert σ₁ σ₂ sem.
-          induction l; intros σ₁ σ₂ sem; invcs sem; eauto 1.
+          induction l; intros σ₁ σ₂ sem; invcs sem; eauto 1 with qcert.
           repeat destr H0.
-          eauto.
+          qeauto.
         - Case "NNRSimpIf".
           apply nnrs_imp_expr_sem_eval in eqq.
           destruct d; try discriminate.
-          destruct b; eauto.
+          destruct b; qeauto.
         - Case "NNRSimpEither".
           apply nnrs_imp_expr_sem_eval in eqq.
           destruct d; try discriminate;
-            repeat destr sem; invcs sem; eauto.
+            repeat destr sem; invcs sem; qeauto.
       }
   Qed.
 

--- a/compiler/core/NNRSimp/Lang/NNRSimpSize.v
+++ b/compiler/core/NNRSimp/Lang/NNRSimpSize.v
@@ -13,7 +13,7 @@
  *)
 
 Require Import String.
-Require Import Omega.
+Require Import Lia.
 Require Import EquivDec.
 Require Import Decidable.
 Require Import Utils.
@@ -52,12 +52,12 @@ Section NNRSimpSize.
 
     Lemma nnrs_imp_expr_size_nzero (n:nnrs_imp_expr) : nnrs_imp_expr_size n <> 0.
     Proof.
-      induction n; simpl; omega.
+      induction n; simpl; lia.
     Qed.
 
     Lemma nnrs_imp_stmt_size_nzero (n:nnrs_imp_stmt) : nnrs_imp_stmt_size n <> 0.
     Proof.
-      induction n; simpl; try destruct o; try omega.
+      induction n; simpl; try destruct o; try lia.
     Qed.
 
     Corollary nnrs_imp_size_nzero (q:nnrs_imp) : nnrs_imp_size q <> 0.

--- a/compiler/core/NNRSimp/Optim/NNRSimpOptimizer.v
+++ b/compiler/core/NNRSimp/Optim/NNRSimpOptimizer.v
@@ -31,6 +31,9 @@ Require Import NNRSimpRewrite.
 Require Import TNNRSimpRewrite.
 Require Import NNRSimpUnflatten.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section NNRSimpOptimizer.
   Local Open Scope nnrs_imp.
   Local Open Scope string.

--- a/compiler/core/NNRSimp/Optim/NNRSimpRewrite.v
+++ b/compiler/core/NNRSimp/Optim/NNRSimpRewrite.v
@@ -30,7 +30,7 @@ Require Import NNRSimpRuntime.
 
 Section NNRSimpRewrite.
   Local Open Scope nnrs_imp.
-
+  
   Context {fruntime:foreign_runtime}.
 
   Lemma distinct_nil_eq :
@@ -296,7 +296,7 @@ Section NNRSimpRewrite.
       generalize (nnrs_imp_expr_eval_unused h σc nil σ source)
       ; simpl; intros HH.
       repeat rewrite HH by tauto.
-      generalize (for_map_eval h σc x₁ (NNRSimpUnop OpBag expr) tmp₁ source nil σ []); simpl; intros HH2.
+      generalize (for_map_eval h σc x₁ (NNRSimpUnop OpBag expr) tmp₁ source nil σ nil); simpl; intros HH2.
       rewrite HH in HH2 by tauto.
       rewrite HH2 by tauto; clear HH2.
       unfold var in *.
@@ -322,7 +322,7 @@ Section NNRSimpRewrite.
              (fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
                 option (list (string * option data)) :=
                 match dl with
-                | [] => Some σ₁
+                | nil => Some σ₁
                 | d1 :: dl' =>
                     match
                       olift
@@ -370,7 +370,7 @@ Section NNRSimpRewrite.
                                  ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
                                      option (list (string * option data)) :=
                                      match dl with
-                                     | [] => Some σ₁
+                                     | nil => Some σ₁
                                      | d :: dl' =>
                                        match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d) :: σ₁) with
                                        | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -384,7 +384,7 @@ Section NNRSimpRewrite.
                  (lift_map
                     (fun dd : data =>
                        match
-                         olift (fun d : data => Some (dcoll [d]))
+                         olift (fun d : data => Some (dcoll (d::nil)))
                                (nnrs_imp_expr_eval h σc ((tmp₁, Some dd) :: σ) expr)
                        with
                        | Some (dcoll l0) => Some l0
@@ -407,7 +407,7 @@ Section NNRSimpRewrite.
          replace (lift_map
          (fun dd : data =>
           match
-            olift (fun d0 : data => Some (dcoll [d0]))
+            olift (fun d0 : data => Some (dcoll (d0::nil)))
               (nnrs_imp_expr_eval h σc ((tmp₁, Some dd) :: σ) expr)
           with
           | Some (dcoll l0) => Some l0
@@ -415,7 +415,7 @@ Section NNRSimpRewrite.
           end) l) with
              (lift_map
          (fun dd : data =>
-            lift (fun d0 : data => [d0])
+            lift (fun d0 : data => (d0::nil))
                  (nnrs_imp_expr_eval h σc ((tmp₁, Some dd) :: σ) expr)) l).
          2: { idtac.
               apply lift_map_ext; intros.
@@ -432,7 +432,7 @@ Section NNRSimpRewrite.
            ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
                option (list (string * option data)) :=
                match dl with
-               | [] => Some σ₁
+               | nil => Some σ₁
                | d0 :: dl' =>
                    match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                    | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -470,7 +470,7 @@ Section NNRSimpRewrite.
                   ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
                option (list (string * option data)) :=
                match dl with
-               | [] => Some σ₁
+               | nil => Some σ₁
                | d0 :: dl' =>
                    match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                    | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -514,13 +514,13 @@ Section NNRSimpRewrite.
          olift (fun σ => (olift
               (fun σ0 : list (string * option data) =>
                match σ0 with
-               | [] => None
+               | nil => None
                | xx :: σ' => Some (xx :: (x₁, Some (dcoll x)) :: σ')
                end) (nnrs_imp_stmt_eval h σc rest σ)))
               ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
                   option (list (string * option data)) :=
                   match dl with
-                  | [] => Some σ₁
+                  | nil => Some σ₁
                   | d0 :: dl' =>
                       match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                       | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -570,14 +570,14 @@ Section NNRSimpRewrite.
            (olift
               (fun σ0 : list (string * option data) =>
                  match σ0 with
-                 | [] => None
+                 | nil => None
                  | xx :: σ' => Some ((x₁, Some (dcoll x)) :: σ')
                  end)
          (olift (nnrs_imp_stmt_eval h σc rest)
               ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
                   option (list (string * option data)) :=
                   match dl with
-                  | [] => Some σ₁
+                  | nil => Some σ₁
                   | d0 :: dl' =>
                       match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                       | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -595,7 +595,7 @@ Section NNRSimpRewrite.
                 destruct (((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
           option (list (string * option data)) :=
           match dl with
-          | [] => Some σ₁
+          | nil => Some σ₁
           | d0 :: dl' =>
               match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
               | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -613,7 +613,7 @@ Section NNRSimpRewrite.
                                            ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
                                                option (list (string * option data)) :=
                 match dl with
-                | [] => Some σ₁
+                | nil => Some σ₁
                 | d0 :: dl' =>
                     match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                     | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -631,7 +631,7 @@ Section NNRSimpRewrite.
          ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
              option (list (string * option data)) :=
              match dl with
-             | [] => Some σ₁
+             | nil => Some σ₁
              | d0 :: dl' =>
                  match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                  | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -649,7 +649,7 @@ Section NNRSimpRewrite.
          ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
              option (list (string * option data)) :=
              match dl with
-             | [] => Some σ₁
+             | nil => Some σ₁
              | d0 :: dl' =>
                  match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                  | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -672,7 +672,7 @@ Section NNRSimpRewrite.
       ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
           option (list (string * option data)) :=
           match dl with
-          | [] => Some σ₁
+          | nil => Some σ₁
           | d1 :: dl' =>
               match
                 olift
@@ -714,7 +714,7 @@ Section NNRSimpRewrite.
       ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
           option (list (string * option data)) :=
           match dl with
-          | [] => Some σ₁
+          | nil => Some σ₁
           | d1 :: dl' =>
               match
                 olift
@@ -762,7 +762,7 @@ Section NNRSimpRewrite.
          (fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
             option (list (string * option data)) :=
             match dl with
-            | [] => Some σ₁
+            | nil => Some σ₁
             | d0 :: dl' =>
                 match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                 | Some (_ :: σ₂0) => for_fun dl' σ₂0
@@ -808,7 +808,7 @@ Section NNRSimpRewrite.
          replace (lift_map
          (fun dd : data =>
           match
-            olift (fun d0 : data => Some (dcoll [d0]))
+            olift (fun d0 : data => Some (dcoll (d0::nil)))
               (nnrs_imp_expr_eval h σc ((tmp₁, Some dd) :: σ) expr)
           with
           | Some (dcoll l0) => Some l0
@@ -816,7 +816,7 @@ Section NNRSimpRewrite.
           end) l) with
              (lift_map
          (fun dd : data =>
-            lift (fun d0 : data => [d0])
+            lift (fun d0 : data => (d0::nil))
                  (nnrs_imp_expr_eval h σc ((tmp₁, Some dd) :: σ) expr)) l).
          2: { idtac.
               apply lift_map_ext; intros.
@@ -833,7 +833,7 @@ Section NNRSimpRewrite.
            ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
                option (list (string * option data)) :=
                match dl with
-               | [] => Some σ₁
+               | nil => Some σ₁
                | d0 :: dl' =>
                    match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                    | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -871,7 +871,7 @@ Section NNRSimpRewrite.
                   ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
                option (list (string * option data)) :=
                match dl with
-               | [] => Some σ₁
+               | nil => Some σ₁
                | d0 :: dl' =>
                    match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                    | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -915,13 +915,13 @@ Section NNRSimpRewrite.
          olift (fun σ => (olift
               (fun σ0 : list (string * option data) =>
                match σ0 with
-               | [] => None
+               | nil => None
                | xx :: σ' => Some (xx :: (x₁, Some (dcoll x)) :: σ')
                end) (nnrs_imp_stmt_eval h σc rest σ)))
               ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
                   option (list (string * option data)) :=
                   match dl with
-                  | [] => Some σ₁
+                  | nil => Some σ₁
                   | d0 :: dl' =>
                       match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                       | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -971,14 +971,14 @@ Section NNRSimpRewrite.
            (olift
               (fun σ0 : list (string * option data) =>
                  match σ0 with
-                 | [] => None
+                 | nil => None
                  | xx :: σ' => Some ((x₁, Some (dcoll x)) :: σ')
                  end)
          (olift (nnrs_imp_stmt_eval h σc rest)
               ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
                   option (list (string * option data)) :=
                   match dl with
-                  | [] => Some σ₁
+                  | nil => Some σ₁
                   | d0 :: dl' =>
                       match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                       | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -996,7 +996,7 @@ Section NNRSimpRewrite.
                 destruct (((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
           option (list (string * option data)) :=
           match dl with
-          | [] => Some σ₁
+          | nil => Some σ₁
           | d0 :: dl' =>
               match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
               | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -1014,7 +1014,7 @@ Section NNRSimpRewrite.
                                            ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
                                                option (list (string * option data)) :=
                 match dl with
-                | [] => Some σ₁
+                | nil => Some σ₁
                 | d0 :: dl' =>
                     match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                     | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -1032,7 +1032,7 @@ Section NNRSimpRewrite.
          ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
              option (list (string * option data)) :=
              match dl with
-             | [] => Some σ₁
+             | nil => Some σ₁
              | d0 :: dl' =>
                  match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                  | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -1050,7 +1050,7 @@ Section NNRSimpRewrite.
          ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
              option (list (string * option data)) :=
              match dl with
-             | [] => Some σ₁
+             | nil => Some σ₁
              | d0 :: dl' =>
                  match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                  | Some (_ :: σ₂) => for_fun dl' σ₂
@@ -1073,7 +1073,7 @@ Section NNRSimpRewrite.
       ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
           option (list (string * option data)) :=
           match dl with
-          | [] => Some σ₁
+          | nil => Some σ₁
           | d1 :: dl' =>
               match
                 olift
@@ -1115,7 +1115,7 @@ Section NNRSimpRewrite.
       ((fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
           option (list (string * option data)) :=
           match dl with
-          | [] => Some σ₁
+          | nil => Some σ₁
           | d1 :: dl' =>
               match
                 olift
@@ -1163,7 +1163,7 @@ Section NNRSimpRewrite.
          (fix for_fun (dl : list data) (σ₁ : list (string * option data)) {struct dl} :
             option (list (string * option data)) :=
             match dl with
-            | [] => Some σ₁
+            | nil => Some σ₁
             | d0 :: dl' =>
                 match nnrs_imp_stmt_eval h σc body ((tmp₃, Some d0) :: σ₁) with
                 | Some (_ :: σ₂0) => for_fun dl' σ₂0

--- a/compiler/core/NNRSimp/Optim/NNRSimpRewrite.v
+++ b/compiler/core/NNRSimp/Optim/NNRSimpRewrite.v
@@ -399,8 +399,7 @@ Section NNRSimpRewrite.
            apply olift_ext; intros.
            generalize (nnrs_imp_expr_eval_unused h σc nil σ n)
            ; simpl; intros HH2.
-           repeat rewrite HH2 by tauto.
-           trivial.
+           repeat rewrite HH2; auto.
          }
          rewrite olift_commute.
          case_eq (nnrs_imp_expr_eval h σc σ n); simpl; trivial

--- a/compiler/core/NNRSimp/Optim/TNNRSimpRewrite.v
+++ b/compiler/core/NNRSimp/Optim/TNNRSimpRewrite.v
@@ -36,7 +36,7 @@ Section TNNRSimpRewrite.
 
   Context {m:basic_model}.
 
-  Hint Immediate type_NNRSimpSkip.
+  Hint Immediate type_NNRSimpSkip : qcert.
 
   Lemma distinct_nil_trew :
     NNRSimpUnop OpDistinct (‵{||}) ⇒ᵉ ‵{||}.
@@ -56,7 +56,7 @@ Section TNNRSimpRewrite.
     - apply for_nil_eq.
     - red; simpl; intros.
       repeat (match_destr; simpl; trivial).
-    - eauto.
+    - qeauto.
   Qed.
 
   (* {} ∪ e = e *)

--- a/compiler/core/NNRSimp/Optim/TNNRSimpRewrite.v
+++ b/compiler/core/NNRSimp/Optim/TNNRSimpRewrite.v
@@ -31,6 +31,9 @@ Require Import NNRSimpRewrite.
 Require Import NNRSimpUnflatten.
 Require Import TNNRSimpUnflatten.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section TNNRSimpRewrite.
   Local Open Scope nnrs_imp.
 

--- a/compiler/core/NNRSimp/Optim/TNNRSimpUnflatten.v
+++ b/compiler/core/NNRSimp/Optim/TNNRSimpUnflatten.v
@@ -35,7 +35,7 @@ Section TNNRSimpUnflatten.
 
   Context {m:basic_model}.
 
-  Hint Immediate type_NNRSimpSkip.
+  Hint Immediate type_NNRSimpSkip : qcert.
 
 
   Section eval.

--- a/compiler/core/NNRSimp/Typing/TNNRSimp.v
+++ b/compiler/core/NNRSimp/Typing/TNNRSimp.v
@@ -28,6 +28,9 @@ Require Import NNRSimpEval.
 Require Import NNRSimpSem.
 Require Import NNRSimpSemEval.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section TNNRSimp.
 
   (** Typing rules for NNRSimp *)

--- a/compiler/core/NNRSimp/Typing/TNNRSimp.v
+++ b/compiler/core/NNRSimp/Typing/TNNRSimp.v
@@ -1306,7 +1306,7 @@ Section TNNRSimp.
   End sem.
   
   (* we are only sensitive to the environment up to lookup *)
-  Global Instance nnrs_imp_expr_type_lookup_equiv_prop {m:basic_model} :
+  Global Instance nnrs_imp_expr_type_lookup_equiv_prop :
     Proper (eq ==> lookup_equiv ==> eq ==> eq ==> iff) nnrs_imp_expr_type.
   Proof.
     cut (Proper (eq ==> lookup_equiv ==> eq ==> eq ==> impl) nnrs_imp_expr_type);
@@ -1394,7 +1394,7 @@ Section TNNRSimp.
         unfold lookup_equiv_on in *; simpl; intros.
         match_destr.
         apply H0.
-        apply remove_in_neq; tauto.
+        now apply remove_in_neq.
     - Case "NNRSimpLet"%string.
       simpl in leo.
       econstructor; intuition eauto.
@@ -1402,7 +1402,7 @@ Section TNNRSimp.
       unfold lookup_equiv_on in *; simpl; intros.
       match_destr.
       apply leo.
-      apply remove_in_neq; tauto.
+      now apply remove_in_neq.
     - Case "NNRSimpFor"%string.
       apply lookup_equiv_on_dom_app in leo.
       econstructor; intuition eauto.
@@ -1411,7 +1411,7 @@ Section TNNRSimp.
         unfold lookup_equiv_on in *; simpl; intros.
         match_destr.
         apply H0.
-        apply remove_in_neq; tauto.
+        now apply remove_in_neq.
     - Case "NNRSimpIf"%string.
       apply lookup_equiv_on_dom_app in leo.
       destruct leo as [leo1 leo2].
@@ -1430,12 +1430,12 @@ Section TNNRSimp.
         unfold lookup_equiv_on in *; simpl; intros.
         match_destr.
         apply leo2.
-        apply remove_in_neq; tauto.
+        now apply remove_in_neq.
       + eapply IHs2; eauto.
         unfold lookup_equiv_on in *; simpl; intros.
         match_destr.
         apply leo3.
-        apply remove_in_neq; tauto.
+        now apply remove_in_neq.
   Qed.
 
   Lemma nnrs_imp_expr_type_has_free_vars {Γc Γ e τ} :

--- a/compiler/core/NNRSimp/Typing/TNNRSimp.v
+++ b/compiler/core/NNRSimp/Typing/TNNRSimp.v
@@ -110,7 +110,7 @@ Section TNNRSimp.
     apply (Forall2_In_l typ) in inn.
     destruct inn as [[??][?[? dt]]]; simpl in *; subst.
     specialize (dt _ (eq_refl _)).
-    eauto.
+    qeauto.
   Qed.
 
   Lemma pd_bindings_type_cut_down_to {σ Γ} :
@@ -157,10 +157,10 @@ Section TNNRSimp.
         [ Γ ⊢ e ▷ Coll (Rec k τl pf) ] ->
         [ Γ ⊢ NNRSimpGroupBy g sl e ▷ GroupBy_type g sl k τl pf ]
     where
-    "[ Γ ⊢ e ▷ τ ]" := (nnrs_imp_expr_type Γ e τ) : nnrs_imp
+    "[ Γ ⊢ e ▷ τ ]" := (nnrs_imp_expr_type Γ e τ) : nnrs_imp_scope
     .
 
-    Notation "[ Γ  ⊢ e ▷ τ ]" := (nnrs_imp_expr_type Γ e τ) : nnrs_imp.
+    Notation "[ Γ  ⊢ e ▷ τ ]" := (nnrs_imp_expr_type Γ e τ) : nnrs_imp_scope.
 
     (* Observation: all the contexts are stacklike in their domain,
        and there is no reason to allow strong updates, since there is a phase
@@ -206,16 +206,16 @@ Section TNNRSimp.
         [  (x₂,τr)::Γ  ⊢ s₂ ]  ->
         [  Γ  ⊢ NNRSimpEither e x₁ s₁ x₂ s₂ ]
     where
-    "[ Γ ⊢ s ]" := (nnrs_imp_stmt_type Γ s) : nnrs_imp
+    "[ Γ ⊢ s ]" := (nnrs_imp_stmt_type Γ s) : nnrs_imp_scope
     .
 
-    Notation "[ Γ ⊢ s ]" := (nnrs_imp_stmt_type Γ s) : nnrs_imp.
+    Notation "[ Γ ⊢ s ]" := (nnrs_imp_stmt_type Γ s) : nnrs_imp_scope.
   End typ.
 
-  Notation "[ Γc ; Γ  ⊢ e ▷ τ ]" := (nnrs_imp_expr_type Γc Γ e τ) : nnrs_imp.
-  Notation "[ Γc ; Γ  ⊢ s ]" := (nnrs_imp_stmt_type Γc Γ s) : nnrs_imp.
+  Notation "[ Γc ; Γ  ⊢ e ▷ τ ]" := (nnrs_imp_expr_type Γc Γ e τ) : nnrs_imp_scope.
+  Notation "[ Γc ; Γ  ⊢ s ]" := (nnrs_imp_stmt_type Γc Γ s) : nnrs_imp_scope.
 
-  Hint Immediate type_NNRSimpSkip.
+  Hint Immediate type_NNRSimpSkip : qcert.
   Local Open Scope nnrs_imp.
   
   Definition nnrs_imp_type Γc (si:nnrs_imp) τ
@@ -223,7 +223,7 @@ Section TNNRSimp.
        nnrs_imp_stmt_var_usage s ret <> VarMayBeUsedWithoutAssignment 
        /\ [ Γc ; (ret, τ)::nil  ⊢ s ].
 
-  Notation "[ Γc ⊢ si ▷ τ ]" := (nnrs_imp_type Γc si τ) : nnrs_imp.
+  Notation "[ Γc ⊢ si ▷ τ ]" := (nnrs_imp_type Γc si τ) : nnrs_imp_scope.
 
   Definition nnrs_imp_returns (si:nnrs_imp)
     := nnrs_imp_stmt_var_usage (fst si) (snd si) = VarMustBeAssigned.
@@ -1324,7 +1324,7 @@ Section TNNRSimp.
   Global Instance nnrs_imp_stmt_type_lookup_equiv_prop :
     Proper (eq ==> lookup_equiv  ==> eq ==> iff) nnrs_imp_stmt_type.
   Proof.
-    Hint Constructors nnrs_imp_stmt_type.
+    Hint Constructors nnrs_imp_stmt_type : qcert.
     
     cut (Proper (eq ==> lookup_equiv ==> eq ==> impl) nnrs_imp_stmt_type)
     ; unfold Proper, respectful, iff, impl; intros; subst;
@@ -1336,16 +1336,16 @@ Section TNNRSimp.
     rename H2 into typ.
     revert Γ₁ Γ₂ Γeqq typ.
     induction s; simpl; intros Γ₁ Γ₂ Γeqq typ
-    ; trivial
+    ; qtrivial
     ; invcs typ
     ; try solve [
-            econstructor; trivial
-            ; [try solve [rewrite <- Γeqq; eauto] | .. ]
+            econstructor; qtrivial
+            ; [try solve [rewrite <- Γeqq; qeauto] | .. ]
             ; first [eapply IHs | eapply IHs1 | eapply IHs2]
-            ; eauto; unfold lookup_equiv; simpl; intros; match_destr
+            ; qeauto; unfold lookup_equiv; simpl; intros; match_destr
           ].
-    econstructor; eauto
-    ; rewrite <- Γeqq; eauto.
+    - econstructor; eauto
+      ; rewrite <- Γeqq; eauto.
   Qed.
 
   Lemma nnrs_imp_expr_type_lookup_equiv_on {Γc Γ₁ e τ} :
@@ -1376,7 +1376,7 @@ Section TNNRSimp.
     ; intros Γ₁ typ Γ₂ leo
     ; invcs typ.
     - Case "NNRSimpSkip"%string.
-      trivial.
+      qtrivial.
     - Case "NNRSimpSeq"%string.
       apply lookup_equiv_on_dom_app in leo.
       econstructor; intuition eauto.
@@ -1714,6 +1714,6 @@ Section TNNRSimp.
 
 End TNNRSimp.
 
-Notation "[ Γc ; Γ  ⊢ e ▷ τ ]" := (nnrs_imp_expr_type Γc Γ e τ) : nnrs_imp.
-Notation "[ Γc ; Γ ⊢ s ]" := (nnrs_imp_stmt_type Γc Γ s) : nnrs_imp.
-Notation "[ Γc ⊢ si ▷ τ ]" := (nnrs_imp_type Γc si τ) : nnrs_imp.
+Notation "[ Γc ; Γ  ⊢ e ▷ τ ]" := (nnrs_imp_expr_type Γc Γ e τ) : nnrs_imp_scope.
+Notation "[ Γc ; Γ ⊢ s ]" := (nnrs_imp_stmt_type Γc Γ s) : nnrs_imp_scope.
+Notation "[ Γc ⊢ si ▷ τ ]" := (nnrs_imp_type Γc si τ) : nnrs_imp_scope.

--- a/compiler/core/NNRSimp/Typing/TNNRSimpEq.v
+++ b/compiler/core/NNRSimp/Typing/TNNRSimpEq.v
@@ -72,9 +72,9 @@ Section TNNRSimpEq.
              nnrs_imp_eval brand_relation_brands  σc si₁
              = nnrs_imp_eval brand_relation_brands  σc si₂).
 
-  Notation "e1 ⇒ᵉ e2" := (tnnrs_imp_expr_rewrites_to e1 e2) (at level 80) : nnrs_imp.
-  Notation "s1 ⇒ˢ s2" := (tnnrs_imp_stmt_rewrites_to s1 s2) (at level 80) : nnrs_imp.
-  Notation "si1 ⇒ˢⁱ si2" := (tnnrs_imp_rewrites_to si1 si2) (at level 80) : nnrs_imp.
+  Notation "e1 ⇒ᵉ e2" := (tnnrs_imp_expr_rewrites_to e1 e2) (at level 80) : nnrs_imp_scope.
+  Notation "s1 ⇒ˢ s2" := (tnnrs_imp_stmt_rewrites_to s1 s2) (at level 80) : nnrs_imp_scope.
+  Notation "si1 ⇒ˢⁱ si2" := (tnnrs_imp_rewrites_to si1 si2) (at level 80) : nnrs_imp_scope.
 
   (* They are all preorders *)
   Global Instance tnnrs_imp_expr_rewrites_to_pre : PreOrder tnnrs_imp_expr_rewrites_to.
@@ -574,7 +574,7 @@ Section TNNRSimpEq.
 
 End TNNRSimpEq.
 
-Notation "e1 ⇒ᵉ e2" := (tnnrs_imp_expr_rewrites_to e1 e2) (at level 80) : nnrs_imp.
-Notation "s1 ⇒ˢ s2" := (tnnrs_imp_stmt_rewrites_to s1 s2) (at level 80) : nnrs_imp.
-Notation "si1 ⇒ˢⁱ si2" := (tnnrs_imp_rewrites_to si1 si2) (at level 80) : nnrs_imp.
+Notation "e1 ⇒ᵉ e2" := (tnnrs_imp_expr_rewrites_to e1 e2) (at level 80) : nnrs_imp_scope.
+Notation "s1 ⇒ˢ s2" := (tnnrs_imp_stmt_rewrites_to s1 s2) (at level 80) : nnrs_imp_scope.
+Notation "si1 ⇒ˢⁱ si2" := (tnnrs_imp_rewrites_to si1 si2) (at level 80) : nnrs_imp_scope.
 

--- a/compiler/core/NNRSimp/Typing/TNNRSimpRename.v
+++ b/compiler/core/NNRSimp/Typing/TNNRSimpRename.v
@@ -36,22 +36,22 @@ Section TNNRSimpRename.
 
   Context {m:basic_model}.
 
-  Hint Constructors nnrs_imp_expr_type.
-  Hint Constructors nnrs_imp_stmt_type.
+  Hint Constructors nnrs_imp_expr_type : qcert.
+  Hint Constructors nnrs_imp_stmt_type : qcert.
 
   Lemma nnrs_imp_expr_type_rename_in_f Γc l Γ e (v v':var) τ (τo:rtype) :
     ~ In v (domain l) ->
     ~ In v' (domain l) ->
     ~ In v' (nnrs_imp_expr_free_vars e) ->
     [ Γc ; (l++(v,τ)::Γ)  ⊢ e ▷ τo ] ->
-    [ Γc ; (l++(v',τ)::Γ)  ⊢ nnrs_imp_expr_rename e v v' ▷ τo ]%nnrs_imp_scope.
+    [ Γc ; (l++(v',τ)::Γ)  ⊢ nnrs_imp_expr_rename e v v' ▷ τo ]%nnrs_imp.
   Proof.
     revert τo.
     nnrs_imp_expr_cases (induction e) Case; simpl; trivial
     ; intros τo ??? typ
     ; invcs typ
     ; repeat rewrite in_app_iff in *
-    ; eauto 3.
+    ; eauto 3 with qcert.
     -  Case "NNRSimpVar"%string.
        econstructor.
        repeat rewrite lookup_app in *.
@@ -79,7 +79,7 @@ Section TNNRSimpRename.
   Lemma nnrs_imp_expr_type_rename_f Γc Γ e (v v':var) τ (τo:rtype) :
     ~ In v' (nnrs_imp_expr_free_vars e) ->
     [ Γc ; ((v,τ)::Γ)  ⊢ e ▷ τo ] ->
-    [ Γc ; ((v',τ)::Γ)  ⊢ nnrs_imp_expr_rename e v v' ▷ τo ]%nnrs_imp_scope.
+    [ Γc ; ((v',τ)::Γ)  ⊢ nnrs_imp_expr_rename e v v' ▷ τo ]%nnrs_imp.
   Proof.
     intros.
     apply (nnrs_imp_expr_type_rename_in_f Γc nil Γ); simpl; tauto.
@@ -93,7 +93,7 @@ Section TNNRSimpRename.
     [ Γc ; (l++(v,τ)::Γ)   ⊢ s ] ->
     [ Γc ; (l++(v',τ)::Γ) ⊢ nnrs_imp_stmt_rename s v v' ].
   Proof.
-    Hint Resolve nnrs_imp_expr_type_rename_in_f.
+    Hint Resolve nnrs_imp_expr_type_rename_in_f : qcert.
 
     revert l Γ τ
     ; nnrs_imp_stmt_cases (induction s) Case
@@ -102,19 +102,19 @@ Section TNNRSimpRename.
     ; repeat rewrite in_app_iff in ninb
     ; invcs typ.
     - Case "NNRSimpSkip"%string.
-      eauto.
+      qeauto.
     - Case "NNRSimpSeq"%string.
-      intuition eauto.
+      intuition qeauto.
     - Case "NNRSimpAssign"%string.
       match_destr; unfold equiv, complement in *.
       + subst.
-        econstructor; eauto.
+        econstructor; qeauto.
         repeat rewrite lookup_app in *.
         repeat rewrite lookup_nin_none in * by trivial.
         simpl in *.
         match_destr_in H3; try contradiction.
         match_destr; try contradiction.
-      + econstructor; eauto.
+      + econstructor; qeauto.
         repeat rewrite lookup_app in *.
         simpl in *.
         match_destr_in H3; try contradiction.
@@ -123,16 +123,16 @@ Section TNNRSimpRename.
     - Case "NNRSimpLet"%string.
       match_destr; unfold equiv, complement in *.
       + subst.
-        econstructor; eauto.
+        econstructor; qeauto.
         apply (nnrs_imp_stmt_type_unused_remove Γc ((v,τ0)::l)) in H4
         ; simpl; try tauto.
         apply (nnrs_imp_stmt_type_unused_add Γc ((v, τ0)::l))
         ; simpl; trivial.
         intuition.
         destruct (remove_nin_inv H3); eauto.
-      + econstructor; eauto.
+      + econstructor; qeauto.
         specialize (IHs ((v0, τ0) :: l)); simpl in IHs.
-        eapply IHs; eauto
+        eapply IHs; qeauto
         ; intuition.
         destruct (remove_nin_inv H1); eauto.
     - Case "NNRSimpLet"%string.
@@ -154,22 +154,22 @@ Section TNNRSimpRename.
     - Case "NNRSimpFor"%string.
       match_destr; unfold equiv, complement in *.
       + subst.
-        econstructor; eauto.
+        econstructor; qeauto.
         apply (nnrs_imp_stmt_type_unused_remove Γc ((v,τ0)::l)) in H4
         ; simpl; try tauto.
         apply (nnrs_imp_stmt_type_unused_add Γc ((v, τ0)::l))
         ; simpl; trivial.
         intuition.
         destruct (remove_nin_inv H3); eauto.
-      + econstructor; eauto.
+      + econstructor; qeauto.
         specialize (IHs ((v0, τ0) :: l)); simpl in IHs.
         eapply IHs; eauto
         ; intuition.
         destruct (remove_nin_inv H1); eauto.
     - Case "NNRSimpIf"%string.
-      econstructor; intuition eauto.
+      econstructor; intuition qeauto.
     - Case "NNRSimpEither"%string.
-      econstructor; eauto.
+      econstructor; qeauto.
       + match_destr; unfold equiv, complement in *.
         * subst.
           apply (nnrs_imp_stmt_type_unused_remove Γc ((v,τl)::l)) in H6
@@ -210,7 +210,7 @@ Section TNNRSimpRename.
     ~ In v (domain l) ->
     ~ In v' (domain l) ->
     ~ In v' (nnrs_imp_expr_free_vars e) ->
-    [ Γc ; (l++(v',τ)::Γ)  ⊢ nnrs_imp_expr_rename e v v' ▷ τo ]%nnrs_imp_scope ->
+    [ Γc ; (l++(v',τ)::Γ)  ⊢ nnrs_imp_expr_rename e v v' ▷ τo ]%nnrs_imp ->
     [ Γc ; (l++(v,τ)::Γ)  ⊢ e ▷ τo ].
   Proof.
     revert τo.
@@ -218,7 +218,7 @@ Section TNNRSimpRename.
     ; intros τo ??? typ
     ; invcs typ
     ; repeat rewrite in_app_iff in *
-    ; eauto 3.
+    ; eauto 3 with qcert.
     - Case "NNRSimpVar"%string.
       econstructor.
       repeat rewrite lookup_app in *.
@@ -245,7 +245,7 @@ Section TNNRSimpRename.
 
   Lemma nnrs_imp_expr_type_rename_b Γc Γ e (v v':var) τ (τo:rtype) :
     ~ In v' (nnrs_imp_expr_free_vars e) ->
-    [ Γc ; ((v',τ)::Γ)  ⊢ nnrs_imp_expr_rename e v v' ▷ τo ]%nnrs_imp_scope ->
+    [ Γc ; ((v',τ)::Γ)  ⊢ nnrs_imp_expr_rename e v v' ▷ τo ]%nnrs_imp ->
     [ Γc ; ((v,τ)::Γ)  ⊢ e ▷ τo ].
   Proof.
     intros.
@@ -260,7 +260,7 @@ Section TNNRSimpRename.
     [ Γc ; (l++(v',τ)::Γ) ⊢ nnrs_imp_stmt_rename s v v' ] ->
     [ Γc ; (l++(v,τ)::Γ)   ⊢ s ].
   Proof.
-    Hint Resolve nnrs_imp_expr_type_rename_in_b.
+    Hint Resolve nnrs_imp_expr_type_rename_in_b : qcert.
 
     revert l Γ τ
     ; nnrs_imp_stmt_cases (induction s) Case
@@ -269,20 +269,20 @@ Section TNNRSimpRename.
     ; repeat rewrite in_app_iff in ninb
     ; invcs typ.
     - Case "NNRSimpSkip"%string.
-      eauto.
+      qeauto.
     - Case "NNRSimpSeq"%string.
-      intuition eauto.
+      intuition qeauto.
     - Case "NNRSimpAssign"%string.
       match_destr_in H3; unfold equiv, complement in *.
       + subst.
-        econstructor; eauto.
+        econstructor; qeauto.
         repeat rewrite lookup_app in *.
         repeat rewrite lookup_nin_none in * by trivial.
         simpl in *.
         match_destr_in H3; try contradiction.
         invcs H3.
         match_destr; try contradiction.
-      + econstructor; eauto.
+      + econstructor; qeauto.
         repeat rewrite lookup_app in *.
         simpl in *.
         match_destr_in H3; try contradiction.
@@ -292,7 +292,7 @@ Section TNNRSimpRename.
     - Case "NNRSimpLet"%string.
       destruct o; try discriminate.
       invcs H0.
-      econstructor; eauto.
+      econstructor; qeauto.
       match_destr_in H4; unfold equiv, complement in *.
       + subst.
         apply (nnrs_imp_stmt_type_unused_add Γc ((v, τ0)::l))
@@ -325,22 +325,22 @@ Section TNNRSimpRename.
     - Case "NNRSimpFor"%string.
       match_destr_in H4; unfold equiv, complement in *.
       + subst.
-        econstructor; eauto.
+        econstructor; qeauto.
         apply (nnrs_imp_stmt_type_unused_add Γc ((v, τ0)::l))
         ; simpl; try tauto.
         apply (nnrs_imp_stmt_type_unused_remove Γc ((v,τ0)::l)) in H4
         ; simpl; try tauto.
         intuition.
         destruct (remove_nin_inv H3); eauto.
-      + econstructor; eauto.
+      + econstructor; qeauto.
         specialize (IHs ((v0, τ0) :: l)); simpl in IHs.
         eapply IHs; eauto
         ; intuition.
         destruct (remove_nin_inv H1); eauto.
     - Case "NNRSimpIf"%string.
-      econstructor; intuition eauto.
+      econstructor; intuition qeauto.
     - Case "NNRSimpEither"%string.
-      econstructor; eauto.
+      econstructor; qeauto.
       + match_destr_in H6; unfold equiv, complement in *.
         * subst.
           apply (nnrs_imp_stmt_type_unused_add Γc ((v,τl)::l))
@@ -381,7 +381,7 @@ Section TNNRSimpRename.
     ~ In v (domain l) ->
     ~ In v' (domain l) ->
     ~ In v' (nnrs_imp_expr_free_vars e) ->
-    [ Γc ; (l++(v',τ)::Γ)  ⊢ nnrs_imp_expr_rename e v v' ▷ τo ]%nnrs_imp_scope <->
+    [ Γc ; (l++(v',τ)::Γ)  ⊢ nnrs_imp_expr_rename e v v' ▷ τo ]%nnrs_imp <->
     [ Γc ; (l++(v,τ)::Γ)  ⊢ e ▷ τo ].
   Proof.
     intros; split; intros.
@@ -391,7 +391,7 @@ Section TNNRSimpRename.
 
   Corollary nnrs_imp_expr_type_rename Γc Γ e (v v':var) τ (τo:rtype) :
     ~ In v' (nnrs_imp_expr_free_vars e) ->
-    [ Γc ; ((v',τ)::Γ)  ⊢ nnrs_imp_expr_rename e v v' ▷ τo ]%nnrs_imp_scope <->
+    [ Γc ; ((v',τ)::Γ)  ⊢ nnrs_imp_expr_rename e v v' ▷ τo ]%nnrs_imp <->
     [ Γc ; ((v,τ)::Γ)  ⊢ e ▷ τo ].
   Proof.
     intros; split; intros.

--- a/compiler/core/NRA/Context/NRAContext.v
+++ b/compiler/core/NRA/Context/NRAContext.v
@@ -33,6 +33,8 @@ Require Import DataRuntime.
 Require Import NRA.
 Require Import NRAEq.
 
+Declare Scope nra_ctxt_scope.
+
 Section NRAContext.
   Local Open Scope nra_scope.
 
@@ -721,9 +723,9 @@ Section NRAContext.
        apply Nat.lt_strorder.
      - specialize (H (rec_sort ps)).
        cut_to H.
-       + Hint Resolve rec_sort_perm.
-         rewrite ac_substs_perm with (c:=c1) (ps2:=(rec_sort ps)); auto.
-         rewrite ac_substs_perm with (c:=c2) (ps2:=(rec_sort ps)); auto.
+       + Hint Resolve rec_sort_perm : qcert.
+         rewrite ac_substs_perm with (c:=c1) (ps2:=(rec_sort ps)); qauto.
+         rewrite ac_substs_perm with (c:=c2) (ps2:=(rec_sort ps)); qauto.
        + apply (@rec_sort_pf nat ODT_nat).
        + rewrite drec_sort_equiv_domain. trivial.
    Qed.

--- a/compiler/core/NRA/Lang/NRA.v
+++ b/compiler/core/NRA/Lang/NRA.v
@@ -53,6 +53,8 @@ Require Import EquivDec.
 Require Import Utils.
 Require Import DataRuntime.
 
+Declare Scope nra_scope.
+
 Section NRA.
   Context {fruntime:foreign_runtime}.
   
@@ -909,7 +911,7 @@ Notation "h ⊢ Op @ₐ x ⊣ c" := (nra_eval h c Op x) (at level 10). (* \vdash
 Delimit Scope nra_scope with nra.
 
 Notation "'ID'" := (NRAID)  (at level 50) : nra_scope.
-Notation "TABLE⟨ s ⟩" := (NRAGetConstant s) (at level 50) : nra_core_scope.
+Notation "TABLE⟨ s ⟩" := (NRAGetConstant s) (at level 50) : nra_scope.
 Notation "‵‵ c" := (NRAConst (dconst c))  (at level 0) : nra_scope.                           (* ‵ = \backprime *)
 Notation "‵ c" := (NRAConst c)  (at level 0) : nra_scope.                                     (* ‵ = \backprime *)
 Notation "‵{||}" := (NRAConst (dcoll nil))  (at level 0) : nra_scope.                         (* ‵ = \backprime *)
@@ -943,7 +945,7 @@ Notation "σ⟨ p ⟩( r )" := (NRASelect p r) (at level 70) : nra_scope.       
 Notation "r1 ∥ r2" := (NRADefault r1 r2) (right associativity, at level 70): nra_scope.       (* ∥ = \parallel *)
 Notation "r1 ◯ r2" := (NRAApp r1 r2) (right associativity, at level 60): nra_scope.           (* ◯ = \bigcirc *)
 
-Hint Resolve nra_eval_normalized.
+Hint Resolve nra_eval_normalized : qcert.
 
 Tactic Notation "nra_cases" tactic(first) ident(c) :=
   first;

--- a/compiler/core/NRA/Lang/NRAEq.v
+++ b/compiler/core/NRA/Lang/NRAEq.v
@@ -90,7 +90,7 @@ Section NRAEq.
     rewrite H0, H1 by trivial.
     case_eq (h ⊢ y1 @ₐ x2 ⊣ c); case_eq (h ⊢ y0 @ₐ x2 ⊣ c); simpl; trivial.
     intros.
-    rewrite (H h); eauto.
+    rewrite (H h); qeauto.
   Qed.
 
   (* NRAUnop *)
@@ -100,10 +100,10 @@ Section NRAEq.
     intros; simpl.
     rewrite (H0 h c dn_c x1) by trivial.
     case_eq (h ⊢ y0 @ₐ x1 ⊣ c); simpl; trivial; intros.
-    rewrite (H h); eauto.
+    rewrite (H h); qeauto.
   Qed.
     
-  Hint Resolve data_normalized_dcoll_in.
+  Hint Resolve data_normalized_dcoll_in : qcert.
 
   (* NRAMap *)
   Global Instance proper_NRAMap : Proper (nra_eq ==> nra_eq ==> nra_eq) NRAMap.
@@ -115,7 +115,7 @@ Section NRAEq.
     destruct d; try reflexivity.
     simpl; f_equal.
     apply lift_map_ext.
-    eauto.
+    qeauto.
   Qed.
 
   (* NRAMapProduct *)
@@ -129,7 +129,7 @@ Section NRAEq.
     apply olift_ext; inversion 1; subst; intros.
     simpl. f_equal.
     apply omap_product_ext; intros.
-    eauto.
+    qeauto.
   Qed.
 
   (* NRAProduct *)
@@ -154,7 +154,7 @@ Section NRAEq.
     f_equal.
     apply lift_filter_ext; intros.
     rewrite H; trivial.
-    eauto.
+    qeauto.
   Qed.
 
   (* NRADefault *)
@@ -185,7 +185,7 @@ Section NRAEq.
   Proof.
     unfold Proper, respectful, nra_eq; intros; simpl.
     rewrite (H0 h c dn_c x1) by trivial. case_eq (h ⊢ y0 @ₐ x1 ⊣ c); intros; simpl; trivial.
-    rewrite (H h c dn_c d); eauto.
+    rewrite (H h c dn_c d); qeauto.
   Qed.
 
 End NRAEq.

--- a/compiler/core/NRA/Lang/NRAExt.v
+++ b/compiler/core/NRA/Lang/NRAExt.v
@@ -24,6 +24,8 @@ Require Import Utils.
 Require Import DataRuntime.
 Require Import NRA.
 
+Declare Scope nraext_scope.
+
 Section NRAExt.
   (* Algebra *)
 
@@ -229,7 +231,7 @@ Delimit Scope nraext_scope with nraext.
 Notation "h ⊢ EOp @ₓ x ⊣ c" := (nraext_eval h c EOp x) (at level 10): nraext_scope.
 
 Notation "'ID'" := (xNRAID)  (at level 50) : nraext_scope.                                           (* ◇ = \Diamond *)
-Notation "CGET⟨ s ⟩" := (xNRAGetConstant s) (at level 50) : nraext_core_scope.
+Notation "CGET⟨ s ⟩" := (xNRAGetConstant s) (at level 50) : nraext_scope.
 
 Notation "‵‵ c" := (xNRAConst (dconst c))  (at level 0) : nraext_scope.                           (* ‵ = \backprime *)
 Notation "‵ c" := (xNRAConst c)  (at level 0) : nraext_scope.                                     (* ‵ = \backprime *)

--- a/compiler/core/NRA/Lang/NRASize.v
+++ b/compiler/core/NRA/Lang/NRASize.v
@@ -12,7 +12,7 @@
  * limitations under the License.
  *)
 
-Require Import Omega.
+Require Import Lia.
 Require Import DataRuntime.
 Require Import NRA.
 
@@ -38,7 +38,7 @@ Section NRASize.
 
   Lemma nra_size_nzero (a:nra) : nra_size a <> 0.
   Proof.
-    induction a; simpl; omega.
+    induction a; simpl; lia.
   Qed.
 
   Fixpoint nra_depth (a:nra) : nat :=

--- a/compiler/core/NRA/Lang/NRASugar.v
+++ b/compiler/core/NRA/Lang/NRASugar.v
@@ -99,5 +99,4 @@ Section NRASugar.
   
 End NRASugar.
 
-Hint Resolve data_normalized_nra_context_data.  
-
+Hint Resolve data_normalized_nra_context_data : qcert.

--- a/compiler/core/NRA/Optim/NRAExtRewrite.v
+++ b/compiler/core/NRA/Optim/NRAExtRewrite.v
@@ -19,10 +19,12 @@ Require Import NRAEq.
 Require Import NRAExt.
 Require Import NRAExtEq.
 Require Import NRARewrite.
+Require Import String.
 
 Section NRAExtRewrite.
   Local Open Scope nra_scope.
   Local Open Scope nraext_scope.
+  Local Open Scope string.
 
   Context {fruntime:foreign_runtime}.
 

--- a/compiler/core/NRA/Optim/NRARewriteContext.v
+++ b/compiler/core/NRA/Optim/NRARewriteContext.v
@@ -23,7 +23,7 @@ Require Import EquivDec.
 Require Import Program.
 Require Import Arith.
 Require Import NPeano.
-Require Import Omega.
+Require Import Lia.
 Require Import List.
 Require Import Utils.
 Require Import DataRuntime.
@@ -51,7 +51,7 @@ Section NRARewriteContext.
   
   Lemma lt_nat_compat (x y:nat) : ~ x < y -> ~ y < x -> x = y.
   Proof.
-    omega.
+    lia.
   Qed.
 
   Lemma insertion_sort_equivlist_nat l l':

--- a/compiler/core/NRA/Optim/TNRARewrite.v
+++ b/compiler/core/NRA/Optim/TNRARewrite.v
@@ -59,7 +59,7 @@ Section TNRARewrite.
       inversion H3; clear H3; subst.
       eapply type_NRABinop; try eauto.
       eapply type_OpAnd; assumption.
-    - intros; rewrite and_comm; eauto.
+    - intros; rewrite and_comm; qeauto.
   Qed.
 
   (* σ{P1}(σ{P2}(P3)) == σ{P2 ∧ P1}(P3)) *)
@@ -162,7 +162,7 @@ Section TNRARewrite.
     assert ((σ⟨ ` op2 ∧ ` op1 ⟩( ` op)) ≡ₐ (σ⟨ ` op1 ∧ ` op2 ⟩( ` op))).
     rewrite (H1 (`op1) (`op2)).
     reflexivity.
-    rewrite H2 by eauto.
+    rewrite H2 by qeauto.
     reflexivity.
     apply (proj2_sig op).
     apply (proj2_sig op2).

--- a/compiler/core/NRA/Typing/TNRAEq.v
+++ b/compiler/core/NRA/Typing/TNRAEq.v
@@ -52,17 +52,17 @@ Section TNRAEq.
       intros; rewrite (H x0 c dt_x dt_c); rewrite (H0 x0 c dt_x dt_c); reflexivity.
   Qed.
 
-  Notation "t1 ⇝ t2 ⊣ τc" := (typed_nra τc t1 t2) (at level 80).                        (* ≡ = \equiv *)
-  Notation "X ≡τ Y" := (tnra_eq X Y) (at level 80).                             (* ≡ = \equiv *)
+  Notation "t1 ⇝ t2 ⊣ τc" := (typed_nra τc t1 t2) (at level 80) : nra_scope.                        (* ≡ = \equiv *)
+  Notation "X ≡τ Y" := (tnra_eq X Y) (at level 80) : nra_scope.                             (* ≡ = \equiv *)
 
-  Hint Resolve data_type_normalized.
-  Hint Resolve bindings_type_Forall_normalized.
+  Hint Resolve data_type_normalized : qcert.
+  Hint Resolve bindings_type_Forall_normalized : qcert.
 
   Lemma nra_eq_impl_tnra_eq {τc} {τin τout} (op1 op2: τin ⇝ τout ⊣ τc) :
     `op1 ≡ₐ `op2 -> op1 ≡τ op2.
   Proof.
     unfold tnra_eq, nra_eq; intros.
-    eapply H; eauto.
+    eapply H; eauto with qcert.
   Qed.
 
   Lemma nra_eq_pf_irrel {op} {τc} {τin τout} (pf1 pf2: op ▷ τin >=> τout ⊣ τc) :
@@ -81,14 +81,14 @@ Section TNRAEq.
                                          (dt_c:bindings_type c τc),
                                      brand_relation_brands ⊢ op1 @ₐ x ⊣ c = brand_relation_brands ⊢ op2 @ₐ x ⊣ c).
   
-  Notation "A ↦ₐ B ⊣ C ⊧ op1 ⇒ op2" := (@tnra_rewrites_to C A B op1 op2) (at level 80).
+  Notation "A ↦ₐ B ⊣ C ⊧ op1 ⇒ op2" := (@tnra_rewrites_to C A B op1 op2) (at level 80) : nra_scope.
 
   Lemma rewrites_typed_and_untyped {τc} {τin τout} (op1 op2:nra):
     (op1 ▷ τin >=> τout ⊣ τc -> op2 ▷ τin >=> τout ⊣ τc) -> op1 ≡ₐ op2 -> τin ↦ₐ τout ⊣ τc ⊧ op1 ⇒ op2.
   Proof.
     intros.
     unfold tnra_rewrites_to; simpl; intros.
-    split; eauto.
+    split; eauto with qcert.
   Qed.
 
   Lemma tnra_rewrites_eq_is_typed_eq {τc} {τin τout:rtype} (op1 op2:typed_nra τc τin τout):
@@ -113,9 +113,9 @@ Section TNRAEq.
 
 End TNRAEq.
 
-Notation "m ⊢ₐ A ↦ B ⊣ C ⊧ op1 ⇒ op2" := (@tnra_rewrites_to m C A B op1 op2) (at level 80).
+Notation "m ⊢ₐ A ↦ B ⊣ C ⊧ op1 ⇒ op2" := (@tnra_rewrites_to m C A B op1 op2) (at level 80) : nra_scope.
 
-Notation "t1 ⇝ t2 ⊣ tc" := (typed_nra tc t1 t2) (at level 80).
-Notation "X ≡τ Y" := (tnra_eq X Y) (at level 80).                             (* ≡ = \equiv *)
-Notation "X ≡τ' Y" := (tnra_eq (exist _ _ X) (exist _ _ Y)) (at level 80).    (* ≡ = \equiv *)
+Notation "t1 ⇝ t2 ⊣ tc" := (typed_nra tc t1 t2) (at level 80) : nra_scope.
+Notation "X ≡τ Y" := (tnra_eq X Y) (at level 80) : nra_scope.                             (* ≡ = \equiv *)
+Notation "X ≡τ' Y" := (tnra_eq (exist _ _ X) (exist _ _ Y)) (at level 80) : nra_scope.    (* ≡ = \equiv *)
 

--- a/compiler/core/NRA/Typing/TNRAUtil.v
+++ b/compiler/core/NRA/Typing/TNRAUtil.v
@@ -23,6 +23,9 @@ Require Import NRASugar.
 Require Import NRAExt.
 Require Import TNRA.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section TNRAUtil.
   Context {m:basic_model}.
   Context (τconstants:tbindings).

--- a/compiler/core/NRA/Typing/TNRAUtil.v
+++ b/compiler/core/NRA/Typing/TNRAUtil.v
@@ -87,8 +87,8 @@ Section TNRAUtil.
     apply ATnra_data_inv'.
   Qed.
 
-  Hint Constructors nra_type unary_op_type binary_op_type.
-  Hint Resolve ATdot ATnra_data.
+  Hint Constructors nra_type unary_op_type binary_op_type : qcert.
+  Hint Resolve ATdot ATnra_data : qcert.
   (*  type rule for unnest_two.  Since it is a bit complicated,
        the type derivation is presented here, inline with the definition
    *)
@@ -118,10 +118,10 @@ Section TNRAUtil.
                τin >=> Coll (Rec Closed τrem pf2) ⊣ τc.
   Proof.
     intros; subst.
-    econstructor; eauto.
+    econstructor; qeauto.
     Grab Existential Variables.
-    eauto.
-    unfold rec_concat_sort. eauto.
+    qeauto.
+    unfold rec_concat_sort. qeauto.
   Qed.
 
   Lemma ATRecEither s τc τl τr pf1 pf2:
@@ -130,7 +130,7 @@ Section TNRAUtil.
                 (Rec Closed ((s,τl)::nil) pf1)
                 (Rec Closed ((s,τr)::nil) pf2)).
   Proof.
-    econstructor; eauto.
+    econstructor; qeauto.
   Qed.
   
 Ltac nra_inverter := 

--- a/compiler/core/NRAEnv/Lang/NRAEnv.v
+++ b/compiler/core/NRAEnv/Lang/NRAEnv.v
@@ -49,6 +49,8 @@ Require Import DataRuntime.
 Require Import cNRAEnv.
 Require Import cNRAEnvEq.
 
+Declare Scope nraenv_scope.
+
 Section NRAEnv.
   Context {fruntime:foreign_runtime}.
   

--- a/compiler/core/NRAEnv/Lang/NRAEnvSize.v
+++ b/compiler/core/NRAEnv/Lang/NRAEnvSize.v
@@ -12,7 +12,7 @@
  * limitations under the License.
  *)
 
-Require Import Omega.
+Require Import Lia.
 Require Import DataRuntime.
 Require Import NRAEnv.
 
@@ -49,7 +49,7 @@ Section NRAEnvSize.
 
   Lemma nraenv_size_nzero (a:nraenv) : nraenv_size a <> 0.
   Proof.
-    induction a; simpl; omega.
+    induction a; simpl; lia.
   Qed.
   
   Fixpoint nraenv_depth (a:nraenv) : nat :=

--- a/compiler/core/NRAEnv/Optim/NRAEnvOptimizer.v
+++ b/compiler/core/NRAEnv/Optim/NRAEnvOptimizer.v
@@ -18,6 +18,7 @@ Require Import Setoid.
 Require Import EquivDec.
 Require Import Program.
 Require Import String.
+Require Import BinNums.
 Require Import List.
 Require Import ListSet.
 Require Import Utils.
@@ -719,7 +720,7 @@ Section NRAEnvOptimizer.
   (* nth 0 { P } ) ⇒ₓ left P *)
   Definition nth0_bag_fun {fruntime:foreign_runtime} (p: nraenv) :=
     match p with
-        NRAEnvBinop OpBagNth (NRAEnvUnop OpBag p) (NRAEnvConst (dnat 0)) => NRAEnvUnop OpLeft p
+        NRAEnvBinop OpBagNth (NRAEnvUnop OpBag p) (NRAEnvConst (dnat Z0)) => NRAEnvUnop OpLeft p
       | _ => p
     end.
 

--- a/compiler/core/NRAEnv/Optim/NRAEnvOptimizer.v
+++ b/compiler/core/NRAEnv/Optim/NRAEnvOptimizer.v
@@ -30,6 +30,9 @@ Require Import OptimizerLogger.
 Require Import NRAEnvRewrite.
 Require Import TNRAEnvRewrite.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section NRAEnvOptimizer.
   Open Scope nraenv_scope.
   

--- a/compiler/core/NRAEnv/Optim/NRAEnvRewrite.v
+++ b/compiler/core/NRAEnv/Optim/NRAEnvRewrite.v
@@ -34,14 +34,14 @@ Section ROptimEnv.
 
   (* Pulls equivalences from core algebra *)
 
-  Hint Resolve dnrec_sort_content.
+  Hint Resolve dnrec_sort_content : qcert.
   Lemma pull_nra_opt (p1 p2:nraenv_core) :
     (nra_of_nraenv_core p1) ≡ₐ (nra_of_nraenv_core p2) ->
     p1 ≡ₑ p2.
   Proof.
     unfold nra_eq, nraenv_core_eq; intros.
     repeat rewrite unfold_env_nra_sort.
-    rewrite H; eauto.
+    rewrite H; qeauto.
   Qed.
 
   (* P1 ∧ P2 ≡ P2 ∧ P1 *)

--- a/compiler/core/NRAEnv/Optim/NRAEnvRewrite.v
+++ b/compiler/core/NRAEnv/Optim/NRAEnvRewrite.v
@@ -12,6 +12,7 @@
  * limitations under the License.
  *)
 
+Require Import BinNums.
 Require Import List.
 Require Import String.
 Require Import ListSet.
@@ -127,7 +128,7 @@ Section ROptimEnv.
 
   (* nth 0 { P } ) ⇒ₓ left P *)
   Lemma envnth0_bag (p: nraenv_core) :
-    cNRAEnvBinop OpBagNth (‵{| p |}) ‵ (dnat 0) ≡ₑ
+    cNRAEnvBinop OpBagNth (‵{| p |}) ‵ (dnat Z0) ≡ₑ
     cNRAEnvUnop OpLeft p.
   Proof.
     unfold nraenv_core_eq; intros ? ? _ ? _ ? _; simpl.

--- a/compiler/core/NRAEnv/Optim/TNRAEnvRewrite.v
+++ b/compiler/core/NRAEnv/Optim/TNRAEnvRewrite.v
@@ -33,6 +33,9 @@ Require Import DataSystem.
 Require Import cNRAEnvSystem.
 Require Import NRAEnvRewrite.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section TNRAEnvRewrite.
 
   Local Open Scope nraenv_core_scope.

--- a/compiler/core/NRAEnv/Optim/TNRAEnvRewrite.v
+++ b/compiler/core/NRAEnv/Optim/TNRAEnvRewrite.v
@@ -51,7 +51,7 @@ Section TNRAEnvRewrite.
     unfold tnraenv_core_rewrites_to; intros; simpl.
     intuition; nraenv_core_inferer. generalize envand_comm; intros.
     unfold nraenv_core_eq in H.
-    simpl in H. apply H; eauto.
+    simpl in H. apply H; qeauto.
   Qed.
 
   Lemma tand_comm {τc τenv τin} (q₁ q₂ ql qr: m ⊧ τin ⇝ Bool ⊣ τc;τenv) :
@@ -146,7 +146,7 @@ Section TNRAEnvRewrite.
     - econstructor. elim H0; clear H0; intros. assumption.
       elim H0; clear H0; intros.
       assert ((q ⊗ ‵[||]) ▷ τin >=> Coll (Rec Closed τ₃ pf3) ⊣ τc;τenv).
-      econstructor; eauto; try econstructor; eauto.
+      econstructor; qeauto; try econstructor; eauto.
       apply dtrec_full; simpl; assumption.
       input_well_typed.
       dependent induction τout.
@@ -159,8 +159,8 @@ Section TNRAEnvRewrite.
               q ▷ τin >=> Rec Open τ₃ pf3 ⊣ τc;τenv ).
       inversion H0. rtype_equalizer; subst.
       inversion H6; clear H6; intros. subst.
-      econstructor; eauto.
-      econstructor; eauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
       inversion H4. subst.
       rewrite merge_bindings_nil_r in H.
       rewrite sort_sorted_is_id in H; try assumption.
@@ -208,7 +208,7 @@ Section TNRAEnvRewrite.
       inversion H; clear H; subst;
       simpl in *;
       destruct (is_list_sorted_ext StringOrder.lt_dec _ pf3 pf2);
-      split; [econstructor; eauto | 
+      split; [econstructor; qeauto | 
     intros;
         input_well_typed;
         dtype_inverter;
@@ -811,8 +811,8 @@ Section TNRAEnvRewrite.
     assert (q ▷ τin >=> Coll τ ⊣ τc;τenv) by nraenv_core_inferer.
     assert (q₁ ▷ τ >=> Bool ⊣ τc;τenv) by nraenv_core_inferer.
     assert (q₂ ▷ τ >=> Bool ⊣ τc;τenv) by nraenv_core_inferer.
-    assert (σ⟨ q₁ ∧ q₂ ⟩( q ) ▷ τin >=> Coll τ ⊣ τc;τenv) by eauto.
-    assert (σ⟨ q₂ ∧ q₁ ⟩( q ) ▷ τin >=> Coll τ ⊣ τc;τenv) by eauto.
+    assert (σ⟨ q₁ ∧ q₂ ⟩( q ) ▷ τin >=> Coll τ ⊣ τc;τenv) by qeauto.
+    assert (σ⟨ q₂ ∧ q₁ ⟩( q ) ▷ τin >=> Coll τ ⊣ τc;τenv) by qeauto.
     rewrite (tselect_and (exist _ q H1)
                          (exist _ (σ⟨ q₁ ⟩( σ⟨ q₂ ⟩( q ))) H0)
                          (exist _ (σ⟨ q₂ ∧ q₁ ⟩( q )) H5)
@@ -821,8 +821,8 @@ Section TNRAEnvRewrite.
                          (exist _ (σ⟨ q₂ ⟩( σ⟨ q₁ ⟩( q ))) H)
                          (exist _ (σ⟨ q₁ ∧ q₂ ⟩( q )) H4)
                          (exist _ q₂ H3) (exist _ q₁ H2)); try assumption; try reflexivity.
-    assert (q₁ ∧ q₂ ▷ τ >=> Bool ⊣ τc;τenv) by eauto.
-    assert (q₂ ∧ q₁ ▷ τ >=> Bool ⊣ τc;τenv) by eauto.
+    assert (q₁ ∧ q₂ ▷ τ >=> Bool ⊣ τc;τenv) by qeauto.
+    assert (q₂ ∧ q₁ ▷ τ >=> Bool ⊣ τc;τenv) by qeauto.
     rewrite (tselect_and_comm
                (exist _ q H1)
                (exist _ (σ⟨q₂ ∧ q₁ ⟩( q )) H5)
@@ -920,7 +920,7 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
-    econstructor; eauto.
+    econstructor; qeauto.
     intros.
     input_well_typed.
     dtype_inverter.
@@ -1034,7 +1034,7 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     input_well_typed.
     dtype_inverter.
     autorewrite with alg.
@@ -1699,7 +1699,7 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
-    econstructor; eauto.
+    econstructor; qeauto.
     intros.
     input_well_typed; simpl.
     dtype_inverter; simpl.
@@ -1925,7 +1925,7 @@ Section TNRAEnvRewrite.
     apply (rewrites_typed_with_untyped _ _ (map_full_over_select_id q₂ q₁ q)).
     intros.
     nraenv_core_inferer.
-    econstructor; eauto.
+    econstructor; qeauto.
   Qed.
 
   Lemma tmap_over_map_split p₁ p₂ p₃ :
@@ -1948,8 +1948,8 @@ Section TNRAEnvRewrite.
       apply (merge_idem _ τ₂ _ pf1 pf4); assumption.
       rewrite H0 in H; inversion H.
       nraenv_core_inferer.
-      econstructor; eauto.
-      econstructor; eauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
       assert (Rec Closed τ₃ pf2 = Rec Closed τ₃ pf3).
       apply rtype_fequal; reflexivity.
       rewrite <- H1; assumption.
@@ -1975,8 +1975,8 @@ Section TNRAEnvRewrite.
         apply (merge_idem _ τ₂ _ pf1 pf4); assumption.
         rewrite H0 in H; inversion H.
         nraenv_core_inferer.
-        econstructor; eauto.
-        econstructor; eauto.
+        econstructor; qeauto.
+        econstructor; qeauto.
         assert (Rec Open τ₃ pf2 = Rec Open τ₃ pf3).
         apply rtype_fequal; reflexivity.
         rewrite <- H1; assumption.
@@ -2028,7 +2028,7 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros; simpl.
     nraenv_core_inferer.
-    econstructor; eauto.
+    econstructor; qeauto.
     intros.
     input_well_typed.
     reflexivity.
@@ -2041,7 +2041,7 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     input_well_typed; reflexivity.
   Qed.
 
@@ -2081,7 +2081,7 @@ Section TNRAEnvRewrite.
     intros.
     unfold tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     input_well_typed; reflexivity.
   Qed.
 
@@ -2158,7 +2158,7 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros; simpl.
     nraenv_core_inferer.
-    econstructor; eauto.
+    econstructor; qeauto.
     intros.
     input_well_typed.
     reflexivity.
@@ -2171,7 +2171,7 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     input_well_typed; reflexivity.
   Qed.
 
@@ -2183,8 +2183,8 @@ Section TNRAEnvRewrite.
     unfold tnraenv_core_rewrites_to; intros; simpl.
     nraenv_core_inferer.
     assert (q₁ ▷ τin >=> τout ⊣ τc;τenv)
-           by (eapply tnraenv_core_ignores_id_swap; eauto).
-    econstructor; eauto.
+           by (eapply tnraenv_core_ignores_id_swap; qeauto).
+    econstructor; qeauto.
     intros.
     input_well_typed.
     rewrite (nraenv_core_ignores_id_swap q₁ H _ _ env x dout) in eout1.
@@ -2239,7 +2239,7 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     input_well_typed.
     reflexivity.
   Qed.
@@ -2253,8 +2253,8 @@ Section TNRAEnvRewrite.
     intros.
     apply (rewrites_typed_with_untyped _ _ (appenv_over_map q q₁ q₂ H)).
     intros; nraenv_core_inferer.
-    econstructor; eauto.
-    econstructor; eauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
     apply (tnraenv_core_ignores_id_swap q H _ _ _ τenv' τenv H3).
   Qed.
 
@@ -2266,9 +2266,9 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; simpl; intros.
     nraenv_core_inferer.
-    econstructor; eauto.
-    - econstructor; eauto.
-      econstructor; eauto.
+    econstructor; qeauto.
+    - econstructor; qeauto.
+      econstructor; qeauto.
       apply (tnraenv_core_ignores_env_swap q₁ H _ _ _ _ _ H2).
     - intros.
       destruct (brand_relation_brands ⊢ₑ q₂ @ₑ x ⊣ c;x); try reflexivity; simpl.
@@ -2291,8 +2291,8 @@ Section TNRAEnvRewrite.
     intros.
     apply (rewrites_typed_with_untyped _ _ (appenv_over_select q q₁ q₂ H)).
     intros; nraenv_core_inferer.
-    econstructor; eauto.
-    econstructor; eauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
     apply (tnraenv_core_ignores_id_swap q H _ _ _ _ _ H3).
   Qed.
     
@@ -2303,7 +2303,7 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
-    econstructor; eauto.
+    econstructor; qeauto.
     intros.
     input_well_typed; reflexivity.
   Qed.
@@ -2315,8 +2315,8 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
-    econstructor; eauto.
-    - repeat econstructor; eauto.
+    econstructor; qeauto.
+    - repeat econstructor; qeauto.
       apply (tnraenv_core_ignores_id_swap q H _ τin τ1 τenv' τenv H3).
     - intros.
       input_well_typed; simpl.
@@ -2332,7 +2332,7 @@ Section TNRAEnvRewrite.
     intros.
     apply (rewrites_typed_with_untyped _ _ (appenv_over_app_ie p1 p2 p3 H)).
     intros; nraenv_core_inferer.
-    econstructor; eauto.
+    econstructor; qeauto.
     apply (tnraenv_core_ignores_env_swap p3 H _ _ _ _ _ H8).
   Qed.
     
@@ -2343,8 +2343,8 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
-    econstructor; eauto.
-    - econstructor; eauto.
+    econstructor; qeauto.
+    - econstructor; qeauto.
       apply (tnraenv_core_ignores_id_swap q₁ H _ τ1 τin τout τenv' H8).
     - intros.
       input_well_typed; simpl.
@@ -2361,7 +2361,7 @@ Section TNRAEnvRewrite.
     nraenv_core_inferer.
     assert (q₁ ▷ τin >=> τout ⊣ τc;τenv)
       by apply (tnraenv_core_ignores_env_swap q₁ H _ τin τout τenv' τenv H7).
-    econstructor; eauto.
+    econstructor; qeauto.
     intros.
     input_well_typed.
     rewrite (nraenv_core_ignores_env_swap q₁ H _ _ env dout x) in eout1.
@@ -2379,14 +2379,14 @@ Section TNRAEnvRewrite.
     intros.
     apply (rewrites_typed_with_untyped _ _ (appenv_over_env_merge_l q₁ q H)); intros.
     nraenv_core_inferer.
-    econstructor; eauto.
+    econstructor; qeauto.
     assert (q₁ ▷ τin >=> Rec Closed τ₂0 pf2 ⊣ τc;τenv)
       by apply (tnraenv_core_ignores_env_swap q₁ H _ τin (Rec Closed τ₂0 pf2) (Rec Closed τ₁0 pf1) τenv H10).
-    eauto.
-    econstructor; eauto.
+    qeauto.
+    econstructor; qeauto.
     assert (q₁ ▷ τin >=> Rec Open τ₂0 pf2 ⊣ τc;τenv)
       by apply (tnraenv_core_ignores_env_swap q₁ H _ τin (Rec Open τ₂0 pf2) (Rec Open τ₁0 pf1) τenv H10).
-    eauto.
+    qeauto.
   Qed.
 
   (* Needs to be worked on, generalized ... *)
@@ -2405,8 +2405,8 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
-    econstructor; eauto.
-    - repeat econstructor; eauto.
+    econstructor; qeauto.
+    - repeat econstructor; qeauto.
       apply (tnraenv_core_ignores_env_swap q₁ H _ τ₁ Bool τ₂ τenv H6).
     - intros.
       input_well_typed.
@@ -2449,7 +2449,7 @@ Section TNRAEnvRewrite.
     intros. nraenv_core_inferer.
     generalize (tnraenv_core_ignores_id_swap _ ig τc).
     econstructor;
-      (econstructor; [| eassumption]; eauto). 
+      (econstructor; [| eassumption]; qeauto). 
   Qed.
 
   (**********
@@ -2463,7 +2463,7 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros; simpl.
     nraenv_core_inferer.
-    econstructor; eauto.
+    econstructor; qeauto.
     intros.
     input_well_typed; simpl.
     dtype_inverter.
@@ -2476,7 +2476,7 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
-    econstructor; eauto.
+    econstructor; qeauto.
     intros.
     destruct (brand_relation_brands ⊢ₑ q₂ @ₑ x ⊣ c;env); try reflexivity; simpl.
     destruct (brand_relation_brands ⊢ₑ q₁ @ₑ x ⊣ c;d); reflexivity.
@@ -2490,8 +2490,8 @@ Section TNRAEnvRewrite.
   Proof.
     intros.
     unfold tnraenv_core_rewrites_to; simpl; intros.
-    nraenv_core_inferer; econstructor; eauto.
-    - repeat econstructor; eauto.
+    nraenv_core_inferer; econstructor; qeauto.
+    - repeat econstructor; qeauto.
       apply (tnraenv_core_ignores_id_swap q₁ H _ τin τenv0 τ₂ τenv0); assumption.
     - intros.
       input_well_typed.
@@ -2528,17 +2528,17 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros; simpl.
     nraenv_core_inferer.
-    econstructor; eauto.
+    econstructor; qeauto.
     - assert (is_list_sorted ODT_lt_dec (domain τ₃) = true)
         by (unfold merge_bindings in *;
              destruct (Compat.compatible τ₁0 [x]); try discriminate;
             inversion H3;
             apply (@rec_concat_sort_sorted string ODT_string _ τ₁0 [x] (rec_concat_sort τ₁0 [x])); reflexivity).
       rename H into pf3.
-      econstructor; eauto.
-      econstructor; eauto.
-      econstructor; eauto.
-      econstructor; eauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
       destruct τenv0; subst.
       destruct x0; try discriminate.
       assert (Rec Closed τ₃ pf3 = (exist (fun τ₀ : rtype₀ => wf_rtype₀ τ₀ = true) (Rec₀ k srl) e)).
@@ -2548,7 +2548,7 @@ Section TNRAEnvRewrite.
       destruct x; simpl in *.
       assert (tdot τ₃ s = Some s0) by (apply (edot_merge_bindings τ₁0 τ₃ s s0); assumption).
       apply type_OpDot; assumption.
-      econstructor; eauto.
+      econstructor; qeauto.
       assert (Rec Closed τ₃ pf3 = τenv0)
       by (apply rtype_fequal; simpl in *; assumption).
       rewrite <- H in *.
@@ -2578,18 +2578,18 @@ Section TNRAEnvRewrite.
   Proof.
     unfold tnraenv_core_rewrites_to; intros; simpl.
     nraenv_core_inferer.
-    econstructor; eauto.
+    econstructor; qeauto.
     - assert (is_list_sorted ODT_lt_dec (domain τ₃) = true)
         by (unfold merge_bindings in *;
              destruct (Compat.compatible τ₁0 [x]); try discriminate;
             inversion H3;
             apply (@rec_concat_sort_sorted string ODT_string _ τ₁0 [x] (rec_concat_sort τ₁0 [x])); reflexivity).
       rename H into pf3.
-      econstructor; eauto.
-      econstructor; eauto.
-      econstructor; eauto.
-      econstructor; eauto.
-      econstructor; eauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
       destruct τenv0; subst.
       destruct x0; try discriminate.
       assert (Rec Closed τ₃ pf3 = (exist (fun τ₀ : rtype₀ => wf_rtype₀ τ₀ = true) (Rec₀ k srl) e))
@@ -2598,7 +2598,7 @@ Section TNRAEnvRewrite.
       destruct x; simpl in *.
       assert (tdot τ₃ s = Some s0) by (apply (edot_merge_bindings τ₁0 τ₃ s s0); assumption).
       apply type_OpDot; assumption.
-      econstructor; eauto.
+      econstructor; qeauto.
       assert (Rec Closed τ₃ pf3 = τenv0)
       by (apply rtype_fequal; simpl in *; assumption).
       rewrite <- H in *.
@@ -2648,8 +2648,8 @@ Section TNRAEnvRewrite.
     nraenv_core_inferer.
     split.
     econstructor.
-    3: econstructor; [| eauto]; eauto.
-    2: econstructor; [|eauto]; econstructor.
+    3: econstructor; [| qeauto]; qeauto.
+    2: econstructor; [|qeauto]; econstructor.
     + econstructor.
       unfold rec_concat_sort.
       rewrite rproject_rec_sort_commute, rproject_app.
@@ -2714,7 +2714,7 @@ Section TNRAEnvRewrite.
     - apply rproject_over_rec_in; trivial.
     - intros.
       nraenv_core_inferer.
-      econstructor; eauto.
+      econstructor; qeauto.
       destruct (@in_dec string string_dec
               s sl); [| intuition].
       econstructor.
@@ -2730,11 +2730,11 @@ Section TNRAEnvRewrite.
     - apply rproject_over_rec_nin; trivial.
     - intros.
       nraenv_core_inferer.
-      econstructor; eauto.
-      econstructor; eauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
       destruct (@in_dec string string_dec
                         s sl); [| intuition]; [intuition | ].
-      simpl. econstructor; eauto.
+      simpl. econstructor; qeauto.
   Qed.
       
   Lemma trproject_over_concat_rec_r_nin sl s p₁ p₂ :
@@ -2744,7 +2744,7 @@ Section TNRAEnvRewrite.
     red; simpl; intros.
     nraenv_core_inferer.
     split.
-    - econstructor; [ | eauto].
+    - econstructor; [ | qeauto].
       revert pf2.
       unfold rec_concat_sort.
       rewrite rproject_rec_sort_commute, rproject_app.
@@ -2788,7 +2788,7 @@ Section TNRAEnvRewrite.
     red; intros.
     nraenv_core_inferer.
     split.
-    - econstructor; [ | eauto].
+    - econstructor; [ | qeauto].
       revert pf2.
       unfold rec_concat_sort.
       rewrite rproject_rec_sort_commute, rproject_app.
@@ -2837,8 +2837,8 @@ Section TNRAEnvRewrite.
       reflexivity.
     - intros.
       nraenv_core_inferer.
-      econstructor; eauto.
-      econstructor; eauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
       unfold rec_concat_sort.
       rewrite rproject_rec_sort_commute, rproject_app.
       simpl.
@@ -2846,8 +2846,8 @@ Section TNRAEnvRewrite.
       destruct (in_dec string_dec s1 sl); [| intuition ].
       reflexivity.
       Grab Existential Variables.
-      solve[eauto].
-      solve[eauto].
+      solve[qeauto].
+      solve[qeauto].
   Qed.
 
   Lemma trproject_over_rproject sl1 sl2 p :
@@ -2859,7 +2859,7 @@ Section TNRAEnvRewrite.
       nraenv_core_inferer.
       generalize pf3.
       rewrite (rproject_rproject τ1 sl1 sl2).
-      econstructor; eauto.
+      econstructor; qeauto.
       econstructor.
       apply sublist_set_inter.
       trivial.
@@ -2872,7 +2872,7 @@ Section TNRAEnvRewrite.
     - apply rproject_over_either.
     - intros.
       nraenv_core_inferer.
-      econstructor; eauto.
+      econstructor; qeauto.
   Qed.
 
   (****************
@@ -2939,7 +2939,7 @@ Section TNRAEnvRewrite.
        red; simpl; trivial.
     - intros.
       nraenv_core_inferer.
-      repeat (econstructor; simpl; eauto).
+      repeat (econstructor; simpl; qeauto).
   Qed.
 
   Lemma tcount_over_flat_map_either_nil_map p₁ p₂ p₃ :
@@ -2970,7 +2970,7 @@ Section TNRAEnvRewrite.
       inversion H2; rtype_equalizer; subst.
       nraenv_core_inferer.
       econstructor.
-      2: (repeat econstructor; simpl; eauto).
+      2: (repeat econstructor; simpl; qeauto).
       econstructor.
     - intros.
       nraenv_core_inferer.

--- a/compiler/core/NRAEnv/Optim/TNRAEnvRewrite.v
+++ b/compiler/core/NRAEnv/Optim/TNRAEnvRewrite.v
@@ -25,6 +25,7 @@ Require Import EquivDec.
 Require Import Program.
 Require Import Bool.
 Require Import String.
+Require Import BinNums.
 Require Import List.
 Require Import ListSet.
 Require Import Utils.
@@ -1905,7 +1906,7 @@ Section TNRAEnvRewrite.
   (* nth 0 { P } ) ⇒ₓ left P *)
 
   Lemma tenvnth0_bag_arrow q :
-    cNRAEnvBinop OpBagNth (‵{| q |}) ‵ (dnat 0) ⇒
+    cNRAEnvBinop OpBagNth (‵{| q |}) ‵ (dnat Z0) ⇒
     cNRAEnvUnop OpLeft q.
   Proof.
     apply (rewrites_typed_with_untyped _ _ (envnth0_bag q)).

--- a/compiler/core/NRAEnv/Typing/TNRAEnv.v
+++ b/compiler/core/NRAEnv/Typing/TNRAEnv.v
@@ -51,7 +51,7 @@ Section TNRAEnv.
       unfold GroupBy_type, nraenv_type.
       simpl; intros subl typ.
       unfold macro_cNRAEnvGroupBy.
-      repeat (econstructor; try eassumption; trivial).
+      repeat (econstructor; try eassumption; qtrivial).
       Unshelve.
       - simpl; reflexivity.
       - apply (is_list_sorted_sublist pf).
@@ -178,9 +178,9 @@ Notation "Op @▷ₓ d ⊣ C ; e" := (tnraenv_eval C Op e d) (at level 70).
 
 (* Used to prove type portion of typed directed rewrites *)
 
-Hint Unfold nraenv_type.
-Hint Constructors unary_op_type.
-Hint Constructors binary_op_type.
+Hint Unfold nraenv_type : qcert.
+Hint Constructors unary_op_type : qcert.
+Hint Constructors binary_op_type : qcert.
 
 (* inverts, then tries and solve *)
 Ltac nraenv_inferer :=

--- a/compiler/core/NRAEnv/Typing/TNRAEnvEq.v
+++ b/compiler/core/NRAEnv/Typing/TNRAEnvEq.v
@@ -58,14 +58,14 @@ Section TNRAEnvEq.
   Notation "t1 ⇝ₓ t2 ⊣ τc ; tenv" := (typed_nraenv τc tenv t1 t2) (at level 80).
   Notation "X ≡τₓ Y" := (tnraenv_eq X Y) (at level 80).               (* ≡ = \equiv *)
 
-  Hint Resolve data_type_normalized.
-  Hint Resolve bindings_type_Forall_normalized.
+  Hint Resolve data_type_normalized : qcert.
+  Hint Resolve bindings_type_Forall_normalized : qcert.
 
   Lemma nraenv_eq_impl_tnraenv_eq {m:basic_model} {τc τenv τin τout} (op1 op2: τin ⇝ₓ τout ⊣ τc;τenv) :
     `op1 ≡ₓ `op2 -> op1 ≡τₓ op2.
   Proof.
     unfold tnraenv_eq, nraenv_eq; intros.
-    eapply H; eauto.
+    eapply H; qeauto.
   Qed.
 
   Lemma nraenv_eq_pf_irrel {m:basic_model} {op} {τin τout τc τenv} (pf1 pf2: op ▷ₓ τin >=> τout ⊣ τc;τenv) :
@@ -99,7 +99,7 @@ Section TNRAEnvEq.
   Proof.
     intros.
     unfold tnraenv_rewrites_to; simpl; intros.
-    split; eauto.
+    split; qeauto.
   Qed.
 
   (* Rewrite implies type-based equivalence! *)

--- a/compiler/core/OQL/Lang/OQL.v
+++ b/compiler/core/OQL/Lang/OQL.v
@@ -19,6 +19,8 @@ Require Import EquivDec.
 Require Import Utils.
 Require Import DataRuntime.
 
+Declare Scope oql_scope.
+
 Section OQL.
   Context {fruntime:foreign_runtime}.
 

--- a/compiler/core/OQL/Typing/TOQL.v
+++ b/compiler/core/OQL/Typing/TOQL.v
@@ -31,7 +31,7 @@ Section TOQL.
     Section constt.
       Context (τconstants:tbindings).
 
-      Hint Resolve bindings_type_has_type.
+      Hint Resolve bindings_type_has_type : qcert.
 
       Inductive oql_expr_type : tbindings -> oql_expr -> rtype -> Prop :=
       | OTConst {τ} tenv c :

--- a/compiler/core/Tests/CompilerTest.v
+++ b/compiler/core/Tests/CompilerTest.v
@@ -160,7 +160,7 @@ Section CompilerUntypedTest.
     Proof.
       simpl.
       apply (@dtbrand' _ _ _ CPModel).
-      - eauto.
+      - qeauto.
       - rewrite (@canon_brands_singleton (@brand_model_relation _ CPModel)).
         rewrite brands_type_singleton. simpl.
         apply (@dtrec_full _ _ _ CPModel).
@@ -198,44 +198,44 @@ Section CompilerUntypedTest.
   Lemma Example1'_wt τ :
     TCAMP.camp_type tinp1 nil Example1' τ tout1.
   Proof.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
-    econstructor; eauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
     rewrite brands_type_singleton. simpl.
-    repeat econstructor; eauto.
-    repeat econstructor; eauto.
-    repeat econstructor; eauto.
-    repeat econstructor; eauto.
-    repeat econstructor; eauto.
-    repeat econstructor; eauto.
-    repeat econstructor; eauto.
-    repeat econstructor; eauto.
-    repeat econstructor; eauto.
-    repeat econstructor; eauto.
+    repeat econstructor; qeauto.
+    repeat econstructor; qeauto.
+    repeat econstructor; qeauto.
+    repeat econstructor; qeauto.
+    repeat econstructor; qeauto.
+    repeat econstructor; qeauto.
+    repeat econstructor; qeauto.
+    repeat econstructor; qeauto.
+    repeat econstructor; qeauto.
+    repeat econstructor; qeauto.
     Grab Existential Variables.
-    eauto. eauto. eauto. eauto. eauto.
+    qeauto. qeauto. qeauto. qeauto. qeauto.
   Qed.
 
   (*
@@ -259,15 +259,15 @@ Section CompilerUntypedTest.
     unfold algopt5, camp_to_nraenv_core.
     unfold CAMPtocNRAEnv.camp_to_nraenv_core_top.
     unfold CAMPtocNRAEnv.nraenv_core_of_camp.
-    econstructor; eauto.
-    econstructor; eauto.
+    econstructor; qeauto.
+    econstructor; qeauto.
     2: {
     apply (@nraenv_core_of_camp_type_preserve).
     apply Example1'_wt.
     }
-    repeat econstructor; eauto.
+    repeat econstructor; qeauto.
     Grab Existential Variables.
-    eauto.
+    qeauto.
   Qed.
 
 End CompilerTypedTest.

--- a/compiler/core/Tests/HelloWorld.v
+++ b/compiler/core/Tests/HelloWorld.v
@@ -12,6 +12,7 @@
  * limitations under the License.
  *)
 
+Require Import BinInt.
 Require Import String.
 Require Import List.
 Require Import Qcert.Driver.CompLang.

--- a/compiler/core/Tests/LambdaNRATest.v
+++ b/compiler/core/Tests/LambdaNRATest.v
@@ -14,6 +14,7 @@
 
 Require Import String.
 Require Import List.
+Require Import BinInt.
 Require Import Arith.
 Require Import EquivDec.
 Require Import Morphisms.

--- a/compiler/core/Tests/NRAEnvTest.v
+++ b/compiler/core/Tests/NRAEnvTest.v
@@ -18,6 +18,8 @@ Require Import List.
 Require Import Utils.
 Require Import DataRuntime.
 
+Declare Scope data_scope.
+
 Delimit Scope data_scope with data.
 
 Notation "⊥" := (dunit) : data_scope. (* null value *)

--- a/compiler/core/Tests/TCAMPTest.v
+++ b/compiler/core/Tests/TCAMPTest.v
@@ -72,7 +72,7 @@ Section TCAMPTest.
   Lemma R1typed :
     TCAMPRule.camp_rule_type (Brand (singleton "Entity")) (Coll String) R1.
   Proof.
-    Hint Resolve TCAMPSugar.PTCast.
+    Hint Resolve TCAMPSugar.PTCast : qcert.
     
     unfold R1.
     unfold TCAMPRule.camp_rule_type; simpl.

--- a/compiler/core/Translation/Lang/CAMPtoNRA.v
+++ b/compiler/core/Translation/Lang/CAMPtoNRA.v
@@ -14,7 +14,7 @@
 
 Require Import String.
 Require Import List.
-Require Import Omega.
+Require Import Lia.
 Require Import Utils.
 Require Import DataRuntime.
 Require Import NRARuntime.
@@ -385,7 +385,7 @@ Section CAMPtoNRA.
     Lemma camp_trans_size p :
       nra_size (nra_of_camp p) <= 41 * camp_size p.
     Proof.
-      induction p; simpl; omega.
+      induction p; simpl; lia.
     Qed.
 
   End size.

--- a/compiler/core/Translation/Lang/CAMPtoNRAEnv.v
+++ b/compiler/core/Translation/Lang/CAMPtoNRAEnv.v
@@ -14,7 +14,7 @@
 
 Require Import String.
 Require Import List.
-Require Import Omega.
+Require Import Lia.
 Require Import Utils.
 Require Import DataRuntime.
 Require Import NRARuntime.
@@ -159,7 +159,7 @@ Section CAMPtoNRAEnv.
     Lemma camp_trans_size p :
       nraenv_size (nraenv_of_camp p) <= 13 * camp_size p.
     Proof.
-      induction p; simpl; omega.
+      induction p; simpl; lia.
     Qed.
 
   End size.

--- a/compiler/core/Translation/Lang/CAMPtocNRAEnv.v
+++ b/compiler/core/Translation/Lang/CAMPtocNRAEnv.v
@@ -14,7 +14,7 @@
 
 Require Import String.
 Require Import List.
-Require Import Omega.
+Require Import Lia.
 Require Import Utils.
 Require Import DataRuntime.
 Require Import NRARuntime.
@@ -224,7 +224,7 @@ Section CAMPtocNRAEnv.
     Lemma camp_trans_size p :
       nraenv_core_size (nraenv_core_of_camp p) <= 13 * camp_size p.
     Proof.
-      induction p; simpl; omega.
+      induction p; simpl; lia.
     Qed.
 
   End size.

--- a/compiler/core/Translation/Lang/ImpEJsontoJavaScriptAst.v
+++ b/compiler/core/Translation/Lang/ImpEJsontoJavaScriptAst.v
@@ -15,6 +15,7 @@
 Require Import String.
 Require Import List.
 Require Import Bool.
+Require Import BinInt.
 Require Import Arith.
 Require Import Utils.
 Require Import EJsonRuntime.
@@ -267,7 +268,7 @@ Section ImpEJsontoJavaScriptAst.
         end.
 
     Definition imp_ejson_table_to_topdecls (cname:string) (q: list imp_ejson) : list topdecl :=
-      classdecl cname (concat (map imp_ejson_to_method q))::nil.
+      classdecl cname (List.concat (map imp_ejson_to_method q))::nil.
 
     Definition imp_ejson_table_to_class (cname:string) (q: imp_ejson) : topdecl :=
       match q with

--- a/compiler/core/Translation/Lang/NNRCMRtoDNNRC.v
+++ b/compiler/core/Translation/Lang/NNRCMRtoDNNRC.v
@@ -54,7 +54,7 @@ Section NNRCMRtoDNNRC.
        let xn = en in
        e
    *)
-  Fixpoint gen_apply_fun_n (annot:A) (f: list var * nnrc)  (eff: list (var * dlocalization)) : option (@dnnrc_base _ A plug_type) :=
+  Definition gen_apply_fun_n (annot:A) (f: list var * nnrc)  (eff: list (var * dlocalization)) : option (@dnnrc_base _ A plug_type) :=
     let (form, e) := f in
     match zip form eff with
     | Some l =>

--- a/compiler/core/Translation/Lang/NNRCMRtoNNRC.v
+++ b/compiler/core/Translation/Lang/NNRCMRtoNNRC.v
@@ -23,6 +23,7 @@ Require Import NNRCRuntime.
 Require Import NNRCMRRuntime.
 Require Import ForeignToReduceOps.
 
+Import ListNotations.
 Local Open Scope list_scope.
 
 Section NNRCMRtoNNRC.
@@ -47,7 +48,7 @@ Section NNRCMRtoNNRC.
        let xn = en in
        e
    *)
-  Fixpoint gen_apply_fun_n (f: list var * nnrc)  (eff: list (var * dlocalization)) : option nnrc :=
+  Definition gen_apply_fun_n (f: list var * nnrc)  (eff: list (var * dlocalization)) : option nnrc :=
     let (form, e) := f in
     lift (List.fold_right
             (fun t k =>

--- a/compiler/core/Translation/Lang/NNRCtoJava.v
+++ b/compiler/core/Translation/Lang/NNRCtoJava.v
@@ -14,6 +14,7 @@
 
 Require Import List.
 Require Import String.
+Require Import BinInt.
 Require Import Ascii.
 Require Import Peano_dec.
 Require Import EquivDec.

--- a/compiler/core/Translation/Lang/NNRCtoNNRCMR.v
+++ b/compiler/core/Translation/Lang/NNRCtoNNRCMR.v
@@ -14,6 +14,7 @@
 
 Require Import Arith.
 Require Import ZArith.
+Require Import Lia.
 Require Import String.
 Require Import List.
 Require Import EquivDec.
@@ -885,29 +886,29 @@ Section NNRCtoNNRCMR.
       (n, nil, vars_loc) (* XXX TODO? To check with Louis *)
     end.
   Next Obligation.
-      simpl; omega.
+      simpl; lia.
   Defined.
   Next Obligation.
-      simpl; omega.
+      simpl; lia.
   Defined.
   Next Obligation.
-      simpl; omega.
+      simpl; lia.
   Defined.
   Next Obligation.
-      simpl; omega.
+      simpl; lia.
   Defined.
   Next Obligation.
     rewrite nnrc_rename_lazy_size.
-    simpl; omega.
+    simpl; lia.
   Defined.
   Next Obligation.
-      simpl; omega.
+      simpl; lia.
   Defined.
   Next Obligation.
-      simpl; omega.
+      simpl; lia.
   Defined.
   Next Obligation.
-      simpl; omega.
+      simpl; lia.
   Defined.
 
 

--- a/compiler/core/Translation/Lang/NNRCtoNNRS.v
+++ b/compiler/core/Translation/Lang/NNRCtoNNRS.v
@@ -15,6 +15,7 @@
 Require Import String.
 Require Import List.
 Require Import Bool.
+Require Import BinInt.
 Require Import Arith.
 Require Import EquivDec.
 Require Import Morphisms.

--- a/compiler/core/Translation/Lang/NNRStoNNRSimp.v
+++ b/compiler/core/Translation/Lang/NNRStoNNRSimp.v
@@ -29,6 +29,9 @@ Require Import NNRSimpRuntime.
 Require Import NNRSCrossShadow.
 Require Import Fresh.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section NNRStoNNRSimp.
 
   Context {fruntime:foreign_runtime}.

--- a/compiler/core/Translation/Lang/NNRStoNNRSimp.v
+++ b/compiler/core/Translation/Lang/NNRStoNNRSimp.v
@@ -683,7 +683,7 @@ Section NNRStoNNRSimp.
         trivial.
       + match_option_in HH; try contradiction.
     - apply all_disjoint3_iff; simpl.
-      eauto.
+      qeauto.
   Qed.
 
   Theorem nnrs_to_nnrs_imp_top_correct (sep:string) (s:nnrs) :

--- a/compiler/core/Translation/Lang/NRAEnvtoNNRC.v
+++ b/compiler/core/Translation/Lang/NRAEnvtoNNRC.v
@@ -16,7 +16,7 @@ Require Import String.
 Require Import List.
 Require Import EquivDec.
 Require Import Compare_dec.
-Require Import Omega.
+Require Import Lia.
 Require Import Utils.
 Require Import DataRuntime.
 Require Import NRAEnvRuntime.
@@ -647,32 +647,32 @@ Section NRAEnvtoNNRC.
       Transparent fresh_var2.
       revert vid venv.
       induction op; simpl in *; intros; trivial.
-      - omega.
-      - omega.
-      - omega.
-      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); omega.
-      - specialize (IHop vid venv); omega.
+      - lia.
+      - lia.
+      - lia.
+      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); lia.
+      - specialize (IHop vid venv); lia.
       - specialize (IHop1 (fresh_var "tmap$" (vid :: venv :: nil)) venv);
-          specialize (IHop2 vid venv); omega.
+          specialize (IHop2 vid venv); lia.
       - repeat match_destr.
-        specialize (IHop1 (fresh_var "tmc$" (vid :: venv :: nil)) venv); specialize (IHop2 vid venv); omega.
-      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); omega.
-      - specialize (IHop1 (fresh_var "tsel$" (vid :: venv :: nil)) venv); specialize (IHop2 vid venv); omega.
-      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); omega.
-      - specialize (IHop1 (fresh_var "teitherL$" (vid :: venv :: nil)) venv); specialize (IHop2 (fresh_var "teitherR$" (fresh_var "teitherL$" (vid :: venv :: nil) :: vid :: venv :: nil)) venv); omega.
-      - specialize (IHop2 vid venv); specialize (IHop1 vid venv); omega.
-      - specialize (IHop1 (fresh_var "tapp$" (vid :: venv :: nil)) venv); specialize (IHop2 vid venv); omega.
-      - omega.
-      - specialize (IHop1 vid (fresh_var "tappe$" (vid :: venv :: nil))); specialize (IHop2 vid venv); omega.
-      - specialize (IHop vid (fresh_var "tmape$" (vid :: venv :: nil))); omega.
+        specialize (IHop1 (fresh_var "tmc$" (vid :: venv :: nil)) venv); specialize (IHop2 vid venv); lia.
+      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); lia.
+      - specialize (IHop1 (fresh_var "tsel$" (vid :: venv :: nil)) venv); specialize (IHop2 vid venv); lia.
+      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); lia.
+      - specialize (IHop1 (fresh_var "teitherL$" (vid :: venv :: nil)) venv); specialize (IHop2 (fresh_var "teitherR$" (fresh_var "teitherL$" (vid :: venv :: nil) :: vid :: venv :: nil)) venv); lia.
+      - specialize (IHop2 vid venv); specialize (IHop1 vid venv); lia.
+      - specialize (IHop1 (fresh_var "tapp$" (vid :: venv :: nil)) venv); specialize (IHop2 vid venv); lia.
+      - lia.
+      - specialize (IHop1 vid (fresh_var "tappe$" (vid :: venv :: nil))); specialize (IHop2 vid venv); lia.
+      - specialize (IHop vid (fresh_var "tmape$" (vid :: venv :: nil))); lia.
       - specialize (IHop1 (fresh_var "tmap$" (vid :: venv :: nil)) venv);
-          specialize (IHop2 vid venv); omega.
+          specialize (IHop2 vid venv); lia.
       - specialize (IHop1 (fresh_var "tsel$" (vid :: venv :: nil)) venv);
-          specialize (IHop2 vid venv); specialize (IHop3 vid venv); try omega.
-      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); omega.
-      - specialize (IHop vid venv); omega.
-      - specialize (IHop vid venv); omega.
-      - specialize (IHop vid venv); omega.
+          specialize (IHop2 vid venv); specialize (IHop3 vid venv); try lia.
+      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); lia.
+      - specialize (IHop vid venv); lia.
+      - specialize (IHop vid venv); lia.
+      - specialize (IHop vid venv); lia.
     Qed.
 
   End size.

--- a/compiler/core/Translation/Lang/NRAEnvtoNNRC.v
+++ b/compiler/core/Translation/Lang/NRAEnvtoNNRC.v
@@ -265,15 +265,15 @@ Section NRAEnvtoNNRC.
     nnrc_core_eval h cenv env (nnrc_to_nnrc_base (nraenv_to_nnrc op vid venv))
     = nnrc_core_eval h cenv env (nraenv_core_to_nnrc_core (nraenv_to_nraenv_core op) vid venv).
   Proof.
-    Hint Resolve nnrc_core_eval_unop_eq nnrc_core_eval_binop_eq.
-    Hint Resolve nnrc_core_eval_for_eq nnrc_core_eval_if_eq.
-    Hint Resolve nnrc_core_eval_let_eq nnrc_core_eval_either_eq.
+    Hint Resolve nnrc_core_eval_unop_eq nnrc_core_eval_binop_eq : qcert.
+    Hint Resolve nnrc_core_eval_for_eq nnrc_core_eval_if_eq : qcert.
+    Hint Resolve nnrc_core_eval_let_eq nnrc_core_eval_either_eq : qcert.
     revert vid venv cenv env; induction op; intros
     ; simpl nraenv_to_nraenv_core
     ; simpl nraenv_core_to_nnrc_core
     ; simpl nnrc_to_nnrc_base
     ; simpl nraenv_to_nnrc
-    ; eauto 8.
+    ; eauto 8 with qcert.
     - apply nnrc_core_eval_group_by_eq; auto.
     - apply unnest_from_nraenv_and_nraenv_core_eq; auto.
   Qed.

--- a/compiler/core/Translation/Lang/NRAtocNNRC.v
+++ b/compiler/core/Translation/Lang/NRAtocNNRC.v
@@ -138,7 +138,7 @@ Section NRAtocNNRC.
     nnrc_core_eval h cenv env (nra_to_nnrc_core op vid) = h ⊢ op @ₐ did ⊣ cenv.
   Proof.
     Opaque fresh_var.
-    Hint Resolve fresh_var_fresh1 fresh_var_fresh2 fresh_var_fresh3 fresh_var2_distinct.
+    Hint Resolve fresh_var_fresh1 fresh_var_fresh2 fresh_var_fresh3 fresh_var2_distinct : qcert.
     revert did env vid.
     nra_cases (induction op) Case; intros; simpl.
     - Case "NRAGetConstant"%string.

--- a/compiler/core/Translation/Lang/NRAtocNNRC.v
+++ b/compiler/core/Translation/Lang/NRAtocNNRC.v
@@ -14,7 +14,7 @@
 
 Require Import String.
 Require Import List.
-Require Import Omega.
+Require Import Lia.
 Require Import EquivDec.
 Require Import Compare_dec.
 Require Import Program.
@@ -26,7 +26,9 @@ Require Import NNRC NNRCSize.
 
 Section NRAtocNNRC.
   Context {fruntime:foreign_runtime}.
-
+  Import ListNotations.
+  Local Open Scope list_scope.
+  
   (** Translation from NRA to Named Nested Relational Calculus *)
 
   Fixpoint nra_to_nnrc_core (op:nra) (var:var) : nnrc :=
@@ -159,7 +161,7 @@ Section NRAtocNNRC.
       rewrite (map_sem_correct h op1 cenv l env); try reflexivity; intros.
       auto.
     - Case "NRAMapProduct"%string.
-      generalize (fresh_var2_distinct  "tmc$" "tmc$" [vid]).
+      generalize (fresh_var2_distinct  "tmc$" "tmc$" (vid::nil)).
       simpl; intros dis.
       repeat (dest_eqdec; try congruence).
       rewrite (IHop2 did env vid H).
@@ -172,7 +174,7 @@ Section NRAtocNNRC.
       unfold omap_product in *; simpl.
       unfold oncoll_map_concat in *.
       rewrite <- IHl; clear IHl.
-      rewrite (IHop1 a (((fresh_var "tmc$" [vid], a)) :: env) (fresh_var "tmc$" [vid])) at 1; clear IHop1; trivial.
+      rewrite (IHop1 a (((fresh_var "tmc$" (vid::nil), a)) :: env) (fresh_var "tmc$" (vid::nil))) at 1; clear IHop1; trivial.
       destruct (h ⊢ op1 @ₐ a ⊣ cenv); try reflexivity.
       destruct d; try reflexivity.
       unfold omap_concat, orecconcat, rec_concat_sort.
@@ -254,7 +256,7 @@ Section NRAtocNNRC.
       case_eq (h ⊢ op1 @ₐ did ⊣ cenv); intros; try reflexivity.
       repeat (dest_eqdec; try congruence).
       simpl.
-      destruct (data_eq_dec d (dcoll [])); subst; simpl.
+      destruct (data_eq_dec d (dcoll nil)); subst; simpl.
       + rewrite (IHop2 did); trivial.
         simpl; match_destr.
         elim (fresh_var_fresh1 _ _ _ e0).
@@ -300,23 +302,23 @@ Section NRAtocNNRC.
     Proof.
       revert v.
       induction op; simpl in *; intros; trivial.
-      - omega.
-      - omega.
-      - omega.
-      - specialize (IHop1 v); specialize (IHop2 v); omega.
-      - specialize (IHop v); omega.
+      - lia.
+      - lia.
+      - lia.
+      - specialize (IHop1 v); specialize (IHop2 v); lia.
+      - specialize (IHop v); lia.
       - generalize (IHop1 (fresh_var "tmap$" [v]));
           generalize (IHop2 (fresh_var "tmap$" [v])).
-        specialize (IHop1 v); specialize (IHop2 v); omega.
+        specialize (IHop1 v); specialize (IHop2 v); lia.
       - generalize (IHop1 (fresh_var "tmc$" [v])); generalize (IHop2 v).
-        specialize (IHop1 v); specialize (IHop2 v); omega.
-      - specialize (IHop1 v); specialize (IHop2 v); omega.
+        specialize (IHop1 v); specialize (IHop2 v); lia.
+      - specialize (IHop1 v); specialize (IHop2 v); lia.
       - generalize (IHop1 (fresh_var "tsel$" [v])); generalize (IHop2 v).
-        specialize (IHop1 v); specialize (IHop2 v); omega.
-      - specialize (IHop1 v); specialize (IHop2 v); omega.
-      - specialize (IHop1 v); specialize (IHop2 v); omega.
-      - specialize (IHop1 v); specialize (IHop2 v); omega.
-      - specialize (IHop2 v); specialize (IHop1 (fresh_var "tapp$" [v])); omega.
+        specialize (IHop1 v); specialize (IHop2 v); lia.
+      - specialize (IHop1 v); specialize (IHop2 v); lia.
+      - specialize (IHop1 v); specialize (IHop2 v); lia.
+      - specialize (IHop1 v); specialize (IHop2 v); lia.
+      - specialize (IHop2 v); specialize (IHop1 (fresh_var "tapp$" [v])); lia.
     Qed.
 
   End Size.

--- a/compiler/core/Translation/Lang/OQLtoNRAEnv.v
+++ b/compiler/core/Translation/Lang/OQLtoNRAEnv.v
@@ -14,7 +14,7 @@
 
 Require Import String.
 Require Import List.
-Require Import Arith Omega.
+Require Import Arith Lia.
 Require Import EquivDec.
 Require Import Morphisms.
 Require Import Utils.

--- a/compiler/core/Translation/Lang/cNNRCtoCAMP.v
+++ b/compiler/core/Translation/Lang/cNNRCtoCAMP.v
@@ -15,13 +15,14 @@
 Require Import String.
 Require Import Bool.
 Require Import List.
+Require Import BinInt.
 Require Import EquivDec.
 Require Import Decidable.
 Require Import Morphisms.
 Require Import Datatypes.
 Require Import Permutation.
 Require Import Eqdep_dec.
-Require Import Omega.
+Require Import Lia.
 Require Import Utils.
 Require Import DataRuntime.
 Require Import CAMPRuntime.
@@ -215,7 +216,7 @@ Section cNNRCtoCAMP.
       unfold liftpr in *. 
       destruct (gather_successes (map f l)); auto.
       inversion H; subst.
-      specialize (IHl _ (eq_refl _)). simpl; omega.
+      specialize (IHl _ (eq_refl _)). simpl; lia.
   Qed.
 
   Lemma gather_successes_not_recoverable {A:Type} (l:list (presult A)) : 
@@ -236,7 +237,7 @@ Section cNNRCtoCAMP.
     inversion H0.
     assert (S (bcount l1) = (bcount l2)).
     apply of_nat_inv; assumption.
-    omega.
+    lia.
   Qed.
 
   Lemma camp_eval_mapall_cons h cenv p bind a l :
@@ -1991,7 +1992,7 @@ Section cNNRCtoCAMP.
     Lemma nnrcToCamp_ns_let_size n : 
       camp_size (nnrcToCamp_ns_let n) <= 25 * nnrc_size n.
     Proof.
-      induction n; simpl; try omega.
+      induction n; simpl; try lia.
     Qed.
 
     Theorem nnrcToCamp_let_size avoid n : 

--- a/compiler/core/Translation/Lang/cNNRCtoCAMP.v
+++ b/compiler/core/Translation/Lang/cNNRCtoCAMP.v
@@ -151,7 +151,6 @@ Section cNNRCtoCAMP.
   Lemma nnrc_to_camp_nodup {A env} : 
     NoDup (@domain _ A env) -> NoDup (domain (nnrc_to_camp_env env)).
   Proof.
-    Hint Constructors NoDup.
     induction env; simpl; intuition.
     inversion H; subst.
     constructor; auto.
@@ -171,9 +170,9 @@ Section cNNRCtoCAMP.
     Compat.compatible (rec_sort (nnrc_to_camp_env env)) ((loop_var v, a) :: nil) = true.
   Proof.
     intros.
-    eapply compatible_perm_proper_l; try eapply compatible_nin; eauto.
+    eapply compatible_perm_proper_l; try eapply compatible_nin; qeauto.
     - apply rec_sort_perm.
-      apply nnrc_to_camp_nodup; trivial.
+      apply nnrc_to_camp_nodup; qtrivial.
   Qed.
 
   (* our translation does not look at the data *)
@@ -350,17 +349,17 @@ Section cNNRCtoCAMP.
     (forall x, In x (domain env) -> ~ In x (nnrc_bound_vars n)) ->
     isRecoverableError (camp_eval h cenv (nnrcToCamp_ns n) (rec_sort (nnrc_to_camp_env env)) dunit) = false.
   Proof.
-    Hint Resolve op2tpr_not_recoverable.
+    Hint Resolve op2tpr_not_recoverable : qcert.
     intros Hiscore.
-    revert Hiscore env. induction n; intros; trivial.
+    revert Hiscore env. induction n; intros; qtrivial.
     - simpl in *.
       destruct ((edot
                  (rec_sort (nnrc_to_camp_env env))
-              (loop_var v))); simpl; trivial.
+              (loop_var v))); simpl; qtrivial.
     - simpl in *.
       destruct ((edot
                  (rec_sort (nnrc_to_camp_env env))
-              (loop_var v))); simpl; trivial.
+              (loop_var v))); simpl; qtrivial.
     - simpl in *.
       elim Hiscore; clear Hiscore; intros Hcore1 Hcore2;
         specialize (IHn1 Hcore1); specialize (IHn2 Hcore2).
@@ -428,7 +427,7 @@ Section cNNRCtoCAMP.
       destruct (camp_eval h cenv (nnrcToCamp_ns n1) (rec_sort (nnrc_to_camp_env env)) dunit);
         unfold bindpr; [trivial|(elim IHn1; eauto)|idtac].
       destruct res; trivial. 
-      rewrite camp_eval_mapall; trivial.
+      rewrite camp_eval_mapall; qtrivial.
       rewrite isRecoverableError_liftpr.
       induction l; simpl; trivial.
       simpl in IHl.
@@ -436,35 +435,38 @@ Section cNNRCtoCAMP.
       rewrite (compatible_drec_sort_nin _ _ _ H0 H6).
       rewrite (drec_concat_sort_app_comm
                  (rec_sort (nnrc_to_camp_env env))
-                   ((loop_var v, a) :: nil)).
-      unfold rec_concat_sort.
-      simpl.
-      rewrite drec_sort_idempotent.
-      replace (insertion_sort_insert rec_field_lt_dec 
+                 ((loop_var v, a) :: nil)).
+      + unfold rec_concat_sort.
+        simpl.
+        rewrite drec_sort_idempotent.
+        replace (insertion_sort_insert rec_field_lt_dec 
             (loop_var v, a) (rec_sort (nnrc_to_camp_env env))) with
       (rec_sort (nnrc_to_camp_env ((v,a)::env))) by reflexivity.
       specialize (IHn2 ((v,a)::env)).
       rewrite (nnrcToCamp_data_indep _ _ _ dunit).
       destruct (camp_eval h cenv (nnrcToCamp_ns n2) (rec_sort (nnrc_to_camp_env ((v, a) :: env))) dunit); 
-        simpl in *; trivial.
-      cut (true = false); [intuition|idtac].
-      apply IHn2; eauto; intros ? [?|?] ?; subst; eauto.
-      rewrite isRecoverableError_liftpr. auto.
-      rewrite domain_app.
-      rewrite Permutation_app_comm.
-      simpl. constructor.
-        * intros nin. 
-          apply drec_sort_domain in nin.
-          unfold domain, nnrc_to_camp_env in nin.
-          rewrite map_map in nin.
-          rewrite in_map_iff in nin.
-          destruct nin as [x [xeq xin]].
-          simpl in *.
-          apply loop_var_inj in xeq. subst.
-          destruct x.
-          apply in_dom in xin.
-          simpl in *; intuition.
-        * rewrite <- rec_sort_perm; apply nnrc_to_camp_nodup; trivial.
+        simpl in *; qtrivial.
+        * unfold isRecoverableError in *.
+          match_destr_in IHl; intuition.
+          apply H7.
+          -- constructor; eauto.
+          -- intros ? [?|?]; subst; firstorder.
+        * rewrite isRecoverableError_liftpr; auto.
+      + rewrite domain_app.
+        rewrite Permutation_app_comm.
+        simpl. constructor; [| qeauto ].
+
+        intros nin. 
+        apply drec_sort_domain in nin.
+        unfold domain, nnrc_to_camp_env in nin.
+        rewrite map_map in nin.
+        rewrite in_map_iff in nin.
+        destruct nin as [x [xeq xin]].
+        simpl in *.
+        apply loop_var_inj in xeq. subst.
+        destruct x.
+        apply in_dom in xin.
+        simpl in *; intuition.
     - simpl in Hiscore.
       elim Hiscore; clear Hiscore; intros Hcore1 Hiscore;
       elim Hiscore; clear Hiscore; intros Hcore2 Hcore3;
@@ -503,7 +505,8 @@ Section cNNRCtoCAMP.
           rewrite (nnrcToCamp_data_indep _ _ _ dunit).
           match_destr.
           simpl in *. apply IHn2; auto.
-          intros ? [?|?]; subst; eauto.
+          -- constructor; qeauto.
+          -- intros ? [?|?]; subst; qeauto.
         * rewrite <- rec_sort_perm by (apply nnrc_to_camp_nodup; trivial).
           rewrite domain_app.
           rewrite Permutation_app_comm.
@@ -528,8 +531,9 @@ Section cNNRCtoCAMP.
           rewrite (nnrcToCamp_data_indep _ _ _ dunit).
           unfold isRecoverableError.
           match_destr.
-          simpl in *. apply IHn3; auto.
-          intros ? [?|?]; subst; eauto.
+          simpl in *. apply IHn3.
+          -- constructor; qeauto.
+          -- intros ? [?|?]; subst; qeauto.
         * rewrite <- rec_sort_perm by (apply nnrc_to_camp_nodup; trivial).
           rewrite domain_app.
           rewrite Permutation_app_comm.
@@ -551,7 +555,9 @@ Section cNNRCtoCAMP.
     isRecoverableError (camp_eval h cenv (nnrcToCamp_ns n) nil dunit) = false.
   Proof.
     intros.
-    generalize (nnrcToCamp_norecoverable_ns h cenv n nil); simpl; auto.
+    apply (nnrcToCamp_norecoverable_ns h cenv n nil); simpl; trivial.
+    - constructor.
+    - tauto.
   Qed.
 
   Theorem nnrcToCamp_norecoverable_top h cenv avoid n :
@@ -651,8 +657,9 @@ Section cNNRCtoCAMP.
       simpl in H, H1; repeat rewrite andb_true_iff in H; 
         apply in_in_cons_app_false in H1; intuition.
       destruct (in_dec string_eqdec v (nnrc_bound_vars n2));
-       intuition.
-      rewrite IHn1; trivial.
+        intuition.
+      simpl in Hiscore.
+      rewrite IHn1; qauto.
       destruct (camp_eval h cenv (nnrcToCamp_ns n1) (rec_sort (nnrc_to_camp_env env))  dunit);
         [intuition|intuition|idtac].
       unfold pr2op at 1.
@@ -662,7 +669,7 @@ Section cNNRCtoCAMP.
       f_equal.
       induction l; simpl; trivial.
       rewrite IHl. simpl.
-      rewrite IHn2; trivial.
+      rewrite IHn2; qtrivial.
       + unfold merge_bindings at 2.
         rewrite (compatible_drec_sort_nin _ _ _ H0 H6).
         simpl.
@@ -694,6 +701,7 @@ Section cNNRCtoCAMP.
       + simpl in Hiscore; intuition.
       + simpl; constructor; trivial.
       + simpl in *. eauto; intros ? [?|?] ?; subst; eauto.
+      + qtrivial.
       + simpl in Hiscore; intuition.
     - simpl in *; repeat rewrite andb_true_iff in *.
       elim Hiscore; clear Hiscore; intros Hcore1 Hiscore;
@@ -765,7 +773,7 @@ Section cNNRCtoCAMP.
     cNNRC.nnrc_core_eval h cenv nil n = pr2op (camp_eval h cenv (nnrcToCamp_ns n) nil dunit).
   Proof.
     intros.
-    apply nnrcToCamp_sem_correct_ns; simpl; auto.
+    apply nnrcToCamp_sem_correct_ns; simpl; qauto.
   Qed.
 
   Theorem nnrcToCamp_sem_correct_top h cenv avoid n :
@@ -827,13 +835,14 @@ Section cNNRCtoCAMP.
       intuition; apply H in H1; eauto.
     Qed.
 
+    Hint Resolve in_app_or in_or_app : qcert.
+
     Lemma fresh_bindings_pbinop l b p₁ p₂:
       fresh_bindings l (pbinop b p₁ p₂) <->
       (fresh_bindings l p₁ /\ fresh_bindings l p₂).
     Proof.
-      Hint Resolve in_app_or in_or_app.
-      unfold fresh_bindings; simpl; intuition; eauto.
-      apply in_app_or in H2; intuition; eauto.
+      unfold fresh_bindings; simpl; intuition; qeauto.
+      apply in_app_or in H2; intuition; qeauto.
     Qed.
 
     Lemma fresh_bindings_punop l u p:
@@ -851,9 +860,8 @@ Section cNNRCtoCAMP.
       fresh_bindings l (pletIt p₁ p₂) <->
       (fresh_bindings l p₁ /\ fresh_bindings l p₂).
     Proof.
-      Hint Resolve in_app_or in_or_app.
-      unfold fresh_bindings; simpl; intuition; eauto.
-      apply in_app_or in H2; intuition; eauto.
+      unfold fresh_bindings; simpl; intuition; qeauto.
+      apply in_app_or in H2; intuition; qeauto.
     Qed.
     
     Lemma fresh_bindings_pmap l p :
@@ -867,18 +875,16 @@ Section cNNRCtoCAMP.
       fresh_bindings l (mapall p) <->
       (fresh_bindings l p).
     Proof.
-      Hint Resolve in_app_or in_or_app.
-      unfold fresh_bindings; simpl; intuition; eauto.
-      apply in_app_or in H1; intuition; eauto.
+      unfold fresh_bindings; simpl; intuition; qeauto.
+      apply in_app_or in H1; intuition; qeauto.
     Qed.
 
     Lemma fresh_bindings_pletEnv l p₁ p₂ :
       fresh_bindings l (pletEnv p₁ p₂) <->
       (fresh_bindings l p₁ /\ fresh_bindings l p₂).
     Proof.
-      Hint Resolve in_app_or in_or_app.
-      unfold fresh_bindings; simpl; intuition; eauto.
-      apply in_app_or in H2; intuition; eauto.
+      unfold fresh_bindings; simpl; intuition; qeauto.
+      apply in_app_or in H2; intuition; qeauto.
     Qed.
 
     Lemma fresh_bindings_pvar l f :
@@ -894,9 +900,8 @@ Section cNNRCtoCAMP.
       fresh_bindings l (porElse p₁ p₂) <->
       (fresh_bindings l p₁ /\ fresh_bindings l p₂).
     Proof.
-      Hint Resolve in_app_or in_or_app.
-      unfold fresh_bindings; simpl; intuition; eauto.
-      apply in_app_or in H2; intuition; eauto.
+      unfold fresh_bindings; simpl; intuition; qeauto.
+      apply in_app_or in H2; intuition; qeauto.
     Qed.
 
     Lemma fresh_bindings_passert l p :
@@ -911,9 +916,8 @@ Section cNNRCtoCAMP.
       fresh_bindings l (pand p₁ p₂) <->
       (fresh_bindings l p₁ /\ fresh_bindings l p₂).
     Proof.
-      Hint Resolve in_app_or in_or_app.
-      unfold fresh_bindings; simpl; intuition; eauto.
-      apply in_app_or in H2; intuition; eauto.
+      unfold fresh_bindings; simpl; intuition; qeauto.
+      apply in_app_or in H2; intuition; qeauto.
     Qed.
 
     Lemma fresh_bindings_plookup l f :
@@ -934,8 +938,8 @@ Section cNNRCtoCAMP.
       <-> (fresh_bindings l₁ p /\ 
            fresh_bindings l₂ p).
     Proof.
-      unfold fresh_bindings; intuition; eauto.
-      apply in_app_or in H. intuition; eauto. 
+      unfold fresh_bindings; intuition; qeauto.
+      apply in_app_or in H. intuition; qeauto. 
     Qed.
 
     Lemma fresh_bindings_cons a l p :
@@ -1043,7 +1047,7 @@ Section cNNRCtoCAMP.
       (camp_eval h cenv (nnrcToCamp_ns n)
                  (rec_sort b) d).
     Proof.
-      Hint Resolve loop_let_var_distinct.
+      Hint Resolve loop_let_var_distinct : qcert.
       revert b x xv d.
       induction n; intros; trivial; simpl in H0;
         autorewrite with fresh_bindings in H0.
@@ -1077,41 +1081,41 @@ Section cNNRCtoCAMP.
         rewrite IHn1; trivial.
         destruct (camp_eval h cenv (nnrcToCamp_ns n1) (rec_sort b) d); simpl; trivial.
         destruct (in_dec string_eqdec v (nnrc_bound_vars n2)); try discriminate.
-        repeat rewrite merge_bindings_single_nin; trivial.
-        rewrite drec_concat_sort_pullout; auto.
-        rewrite IHn2; trivial.
-        simpl.
-        rewrite drec_sort_drec_sort_concat.
-        rewrite rec_sorted_id; eauto.
-        unfold rec_concat_sort in *.
-        * autorewrite with fresh_bindings; simpl; intuition.
-          unfold fresh_bindings; simpl; intuition.
-          eelim loop_let_var_distinct; eauto.
-        * intros.
-          unfold rec_concat_sort in *.
-          rewrite drec_sort_equiv_domain in H10.
-          rewrite domain_app in H10. simpl in H10.
-          rewrite in_app_iff in H10. simpl in H10.
-          destruct H10 as [?|[?|?]]; [eauto|idtac|trivial].
-          subst. apply n.
-          apply in_map_iff in H15.
-          destruct H15 as [vv [vveq vvin]].
-          apply loop_var_inj in vveq; subst. intuition.
-        * cut (NoDup (domain (b ++ (loop_var v, res) :: nil))); intros.
-          unfold rec_concat_sort; rewrite <- rec_sort_perm; trivial.
-          rewrite domain_app.
-          rewrite Permutation_app_comm.
-          simpl.
-          constructor; auto.
-        * unfold rec_concat_sort.
-          rewrite drec_sort_equiv_domain.
-          rewrite domain_app, in_app_iff.
-          simpl.
-          intuition.
-        * constructor; simpl. intuition.
-          constructor; simpl; intuition.
-        * intro nin. rewrite drec_sort_equiv_domain in nin. auto.
-        * intro nin. unfold rec_concat_sort in nin.
+        repeat rewrite merge_bindings_single_nin; qtrivial.
+        + rewrite drec_concat_sort_pullout; qauto.
+          * rewrite IHn2; qtrivial.
+            -- simpl.
+               rewrite drec_sort_drec_sort_concat.
+               rewrite rec_sorted_id; qeauto.
+            -- unfold rec_concat_sort in *.
+               autorewrite with fresh_bindings; simpl; intuition.
+               unfold fresh_bindings; simpl; intuition.
+               eelim loop_let_var_distinct; qeauto.
+            -- intros.
+               unfold rec_concat_sort in *.
+               rewrite drec_sort_equiv_domain in H10.
+               rewrite domain_app in H10. simpl in H10.
+               rewrite in_app_iff in H10. simpl in H10.
+               destruct H10 as [?|[?|?]]; [eauto|idtac|trivial].
+               subst. apply n.
+               apply in_map_iff in H15.
+               destruct H15 as [vv [vveq vvin]].
+               apply loop_var_inj in vveq; subst. intuition.
+            -- cut (NoDup (domain (b ++ (loop_var v, res) :: nil))); intros.
+               unfold rec_concat_sort; rewrite <- rec_sort_perm; trivial.
+               rewrite domain_app.
+               rewrite Permutation_app_comm.
+               simpl.
+               constructor; auto.
+            -- unfold rec_concat_sort.
+               rewrite drec_sort_equiv_domain.
+               rewrite domain_app, in_app_iff.
+               simpl.
+               intuition.
+          * constructor; simpl. intuition.
+            constructor; simpl; intuition.
+        + intro nin. rewrite drec_sort_equiv_domain in nin. auto.
+        + intro nin. unfold rec_concat_sort in nin.
           rewrite drec_sort_equiv_domain in nin.
           rewrite domain_app, in_app_iff in nin.
           simpl in nin.
@@ -1146,40 +1150,40 @@ Section cNNRCtoCAMP.
         red; intros.
         simpl.
         destruct (in_dec string_eqdec v (nnrc_bound_vars n2)); try discriminate.
-        repeat rewrite merge_bindings_single_nin; trivial.
-        rewrite drec_concat_sort_pullout; auto.
-        rewrite IHn2; trivial.
-        rewrite drec_sort_drec_sort_concat.
-        rewrite rec_sorted_id; eauto.
-        * unfold rec_concat_sort.
-          autorewrite with fresh_bindings; simpl; intuition.
-          unfold fresh_bindings; simpl; intuition.
-          eelim loop_let_var_distinct; eauto.
-        * unfold rec_concat_sort.
-          intros. 
-          rewrite drec_sort_equiv_domain in H12.
-          rewrite domain_app in H12. simpl in H12.
-          rewrite in_app_iff in H12. simpl in H12.
-          destruct H12 as [?|[?|?]]; [eauto|idtac|trivial].
-          subst. rewrite in_map_iff. destruct 1 as [?[injj ?]].
-          apply loop_var_inj in injj; subst. intuition.
-          eauto.
-        * unfold rec_concat_sort.
-          cut (NoDup (domain (b ++ (loop_var v, x0) :: nil))); intros.
-          rewrite <- rec_sort_perm; trivial.
-          rewrite domain_app.
-          rewrite Permutation_app_comm.
-          simpl.
-          constructor; auto.
-        * unfold rec_concat_sort.
-          rewrite drec_sort_equiv_domain.
-          rewrite domain_app, in_app_iff.
-          simpl.
-          intuition.
-        * constructor; simpl. intuition.
-          constructor; simpl; intuition.
-        * intro nin. rewrite drec_sort_equiv_domain in nin. auto.
-        * intro nin. unfold rec_concat_sort in nin.
+        repeat rewrite merge_bindings_single_nin; qtrivial.
+        + rewrite drec_concat_sort_pullout; auto.
+          * rewrite IHn2; qtrivial.
+            -- rewrite drec_sort_drec_sort_concat.
+               rewrite rec_sorted_id; eauto.
+            -- unfold rec_concat_sort.
+               autorewrite with fresh_bindings; simpl; intuition.
+               unfold fresh_bindings; simpl; intuition.
+               eelim loop_let_var_distinct; eauto.
+            -- unfold rec_concat_sort.
+               intros. 
+               rewrite drec_sort_equiv_domain in H12.
+               rewrite domain_app in H12. simpl in H12.
+               rewrite in_app_iff in H12. simpl in H12.
+               destruct H12 as [?|[?|?]]; [eauto|idtac|trivial].
+               subst. rewrite in_map_iff. destruct 1 as [?[injj ?]].
+               apply loop_var_inj in injj; subst. intuition.
+               eauto.
+            -- unfold rec_concat_sort.
+               cut (NoDup (domain (b ++ (loop_var v, x0) :: nil))); intros.
+               rewrite <- rec_sort_perm; trivial.
+               rewrite domain_app.
+               rewrite Permutation_app_comm.
+               simpl.
+               constructor; auto.
+            -- unfold rec_concat_sort.
+               rewrite drec_sort_equiv_domain.
+               rewrite domain_app, in_app_iff.
+               simpl.
+               intuition.
+          * constructor; simpl. intuition.
+            constructor; simpl; intuition.
+        + intro nin. rewrite drec_sort_equiv_domain in nin. auto.
+        + intro nin. unfold rec_concat_sort in nin.
           rewrite drec_sort_equiv_domain in nin.
           rewrite domain_app, in_app_iff in nin.
           simpl in nin.
@@ -1465,9 +1469,9 @@ Section cNNRCtoCAMP.
             simpl; trivial.
           inversion e.
           rewrite merge_bindings_nil_r.
-          rewrite sort_sorted_is_id; trivial.
-          rewrite edot_fresh_concat_right_single; trivial.
-      - case_eq (gather_successes (map (camp_eval h cenv p bind) l)); simpl; trivial; intros.
+          rewrite sort_sorted_is_id; qtrivial.
+          rewrite edot_fresh_concat_right_single; qtrivial.
+      - case_eq (gather_successes (map (camp_eval h cenv p bind) l)); simpl; qtrivial; intros.
         rewrite merge_bindings_single_nin by trivial.
         rewrite edot_fresh_concat_right_single by trivial.
         simpl.
@@ -1475,7 +1479,7 @@ Section cNNRCtoCAMP.
                               (dnat (Z.pos (Pos.of_succ_nat (bcount res0))))).
         trivial; simpl.
         + rewrite merge_bindings_nil_r.
-          rewrite sort_sorted_is_id; trivial.
+          rewrite sort_sorted_is_id; qtrivial.
           rewrite edot_fresh_concat_right_single; trivial. simpl.
           rewrite merge_bindings_single_nin by trivial.
           rewrite edot_fresh_concat_right_single; trivial.
@@ -1484,8 +1488,8 @@ Section cNNRCtoCAMP.
           destruct (data_eq_dec (dnat (Z.of_nat (bcount l)))
                                 (dnat (Z.of_nat (bcount res0)))); simpl; trivial.
           * rewrite merge_bindings_nil_r.
-            rewrite sort_sorted_is_id; trivial.
-            rewrite edot_fresh_concat_right_single; trivial.
+            rewrite sort_sorted_is_id; qtrivial.
+            rewrite edot_fresh_concat_right_single; qtrivial.
           * inversion e.
             assert (bcount l = bcount res0)
               by apply (pos_succ_nat_inv (bcount l) (bcount res0) H6).
@@ -1579,7 +1583,7 @@ Section cNNRCtoCAMP.
       (forall x, In x (domain b) -> ~ In x (map loop_var (nnrc_bound_vars n))) ->
       camp_eval h cenv (nnrcToCamp_ns_let n) b d = camp_eval h cenv (nnrcToCamp_ns n) b d.
     Proof.
-      Hint Resolve drec_sort_sorted fresh_bindings_let_to_naive.
+      Hint Resolve drec_sort_sorted fresh_bindings_let_to_naive : qcert.
 
       revert b d. 
       induction n; intros; trivial; simpl in H0;
@@ -1598,7 +1602,7 @@ Section cNNRCtoCAMP.
         assert (vnin:~ In (loop_var v) (domain b)) by eauto.
         destruct (camp_eval h cenv (nnrcToCamp_ns n1) b d); simpl; trivial.
         + repeat rewrite merge_bindings_single_nin by trivial.
-          apply IHn2; trivial; intros.
+          apply IHn2; qtrivial; intros.
           * apply (drec_concat_sort_sorted (odt:=ODT_string)).
           * unfold fresh_bindings in *; intros ? nin.
             unfold rec_concat_sort in nin.
@@ -1610,7 +1614,7 @@ Section cNNRCtoCAMP.
               intuition.
             apply (H7 _ H9). simpl; intuition.
             eapply loop_let_var_distinct; eauto.
-          * eauto 2.
+          * eauto 2 with qcert.
           * unfold rec_concat_sort in H0.
             rewrite drec_sort_equiv_domain in H0.
             rewrite domain_app, in_app_iff in H0.
@@ -1653,7 +1657,7 @@ Section cNNRCtoCAMP.
               intuition.
             apply (H5 _ H8). simpl; intuition.
             eapply loop_let_var_distinct; eauto.
-          * eauto 2.
+          * eauto 2 with qcert.
           * unfold rec_concat_sort in H0.
             rewrite drec_sort_equiv_domain in H0.
             rewrite domain_app, in_app_iff in H0.
@@ -1725,8 +1729,8 @@ Section cNNRCtoCAMP.
             unfold fresh_bindings; intros.
             simpl in *; intuition.
             rewrite <- H15 in H14.
-            eelim (fresh_let_var_fresh); eauto.
-          * eauto 2.
+            eelim (fresh_let_var_fresh); qeauto.
+          * eauto 2 with qcert.
           * intros.
             rewrite drec_sort_drec_sort_concat in H4.
             unfold rec_concat_sort in H4.
@@ -1766,8 +1770,8 @@ Section cNNRCtoCAMP.
             intuition. eauto.
             simpl in H15; intuition.
             rewrite <- H4 in *.
-            eelim (fresh_let_var_fresh); eauto.   
-          * eauto 2.
+            eelim (fresh_let_var_fresh); qeauto.
+          * eauto 2 with qcert.
           * intros.
             rewrite drec_sort_drec_sort_concat in H4.
             unfold rec_concat_sort in H4.
@@ -1811,7 +1815,7 @@ Section cNNRCtoCAMP.
                 unfold fresh_bindings; simpl.
                 intros ?[?|?]?; trivial.
                 eapply loop_let_var_distinct; eauto.
-              - eauto 2.
+              - eauto 2 with qcert.
               - unfold rec_concat_sort. intros ? inn1' inn2'.
                 rewrite drec_sort_equiv_domain in inn1'.
                 rewrite domain_app, in_app_iff in inn1'.
@@ -1831,7 +1835,7 @@ Section cNNRCtoCAMP.
                unfold fresh_bindings; simpl.
                intros ?[?|?]?; trivial.
                eapply loop_let_var_distinct; eauto.
-             - eauto 2.
+             - eauto 2 with qcert.
              - unfold rec_concat_sort. intros ? inn1' inn2'.
                rewrite drec_sort_equiv_domain in inn1'.
                rewrite domain_app, in_app_iff in inn1'.
@@ -1869,7 +1873,7 @@ Section cNNRCtoCAMP.
       intros.
       rewrite (nnrcToCamp_sem_correct_ns _ cenv); auto.
       f_equal.
-      rewrite nnrcToCamp_ns_let_equiv; eauto 2.
+      rewrite nnrcToCamp_ns_let_equiv; eauto 2 with qcert.
       - erewrite nnrcToCamp_data_indep; reflexivity.
       - rewrite fresh_bindings_domain_drec_sort.
         apply fresh_bindings_from_nnrc.
@@ -1904,10 +1908,10 @@ Section cNNRCtoCAMP.
       = pr2op (camp_eval h cenv (nnrcToCamp_let (domain env) n)
                          (rec_sort (nnrc_to_camp_env env)) d).
     Proof.
-      Hint Resolve unshadow_avoid.
+      Hint Resolve unshadow_avoid : qcert.
       intro Hiscore.
       intros.
-      apply nnrcToCamp_let_correct_messy; unfold unshadow_simpl; auto.
+      apply nnrcToCamp_let_correct_messy; unfold unshadow_simpl; qauto.
       intros.
       unfold nnrc_to_camp_env, domain in H0.
       rewrite map_map in H0.
@@ -1933,7 +1937,7 @@ Section cNNRCtoCAMP.
       intros.
       rewrite (nnrcToCamp_sem_correct_top_ns _ cenv); auto.
       f_equal.
-      rewrite nnrcToCamp_ns_let_equiv; eauto 2.
+      rewrite nnrcToCamp_ns_let_equiv; eauto 2 with qcert.
       simpl; autorewrite with fresh_bindings; trivial.
     Qed.
 

--- a/compiler/core/Translation/Lang/cNRAEnvtocNNRC.v
+++ b/compiler/core/Translation/Lang/cNRAEnvtocNNRC.v
@@ -15,7 +15,7 @@
 Require Import String.
 Require Import List.
 Require Import EquivDec.
-Require Import Omega.
+Require Import Lia.
 Require Import Compare_dec.
 Require Import Utils.
 Require Import DataRuntime.
@@ -610,24 +610,24 @@ Section cNRAEnvtocNNRC.
       Transparent fresh_var2.
       revert vid venv.
       induction op; simpl in *; intros; trivial.
-      - omega.
-      - omega.
-      - omega.
-      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); omega.
-      - specialize (IHop vid venv); omega.
+      - lia.
+      - lia.
+      - lia.
+      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); lia.
+      - specialize (IHop vid venv); lia.
       - specialize (IHop1 (fresh_var "tmap$" (vid :: venv :: nil)) venv);
-          specialize (IHop2 vid venv); omega.
+          specialize (IHop2 vid venv); lia.
       - repeat match_destr.
-        specialize (IHop1 (fresh_var "tmc$" (vid :: venv :: nil)) venv); specialize (IHop2 vid venv); omega.
-      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); omega.
-      - specialize (IHop1 (fresh_var "tsel$" (vid :: venv :: nil)) venv); specialize (IHop2 vid venv); omega.
-      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); omega.
-      - specialize (IHop1 (fresh_var "teitherL$" (vid :: venv :: nil)) venv); specialize (IHop2 (fresh_var "teitherR$" (fresh_var "teitherL$" (vid :: venv :: nil) :: vid :: venv :: nil)) venv); omega.
-      - specialize (IHop2 vid venv); specialize (IHop1 vid venv); omega.
-      - specialize (IHop1 (fresh_var "tapp$" (vid :: venv :: nil)) venv); specialize (IHop2 vid venv); omega.
-      - omega.
-      - specialize (IHop1 vid (fresh_var "tappe$" (vid :: venv :: nil))); specialize (IHop2 vid venv); omega.
-      - specialize (IHop vid (fresh_var "tmape$" (vid :: venv :: nil))); omega.
+        specialize (IHop1 (fresh_var "tmc$" (vid :: venv :: nil)) venv); specialize (IHop2 vid venv); lia.
+      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); lia.
+      - specialize (IHop1 (fresh_var "tsel$" (vid :: venv :: nil)) venv); specialize (IHop2 vid venv); lia.
+      - specialize (IHop1 vid venv); specialize (IHop2 vid venv); lia.
+      - specialize (IHop1 (fresh_var "teitherL$" (vid :: venv :: nil)) venv); specialize (IHop2 (fresh_var "teitherR$" (fresh_var "teitherL$" (vid :: venv :: nil) :: vid :: venv :: nil)) venv); lia.
+      - specialize (IHop2 vid venv); specialize (IHop1 vid venv); lia.
+      - specialize (IHop1 (fresh_var "tapp$" (vid :: venv :: nil)) venv); specialize (IHop2 vid venv); lia.
+      - lia.
+      - specialize (IHop1 vid (fresh_var "tappe$" (vid :: venv :: nil))); specialize (IHop2 vid venv); lia.
+      - specialize (IHop vid (fresh_var "tmape$" (vid :: venv :: nil))); lia.
     Qed.
 
   End size.

--- a/compiler/core/Translation/Lang/cNRAEnvtocNNRC.v
+++ b/compiler/core/Translation/Lang/cNRAEnvtocNNRC.v
@@ -163,7 +163,7 @@ Section cNRAEnvtocNNRC.
     nnrc_core_eval h cenv env (nraenv_core_to_nnrc_core op vid venv) = h ⊢ₑ op @ₑ did ⊣ cenv;denv.
   Proof.
     Opaque fresh_var.
-    Hint Resolve fresh_var_fresh1 fresh_var_fresh2 fresh_var_fresh3 fresh_var2_distinct.
+    Hint Resolve fresh_var_fresh1 fresh_var_fresh2 fresh_var_fresh3 fresh_var2_distinct : qcert.
     revert did denv env vid venv.
     nraenv_core_cases (induction op) Case; intros; simpl.
     - Case "cNRAEnvGetConstant"%string.
@@ -196,7 +196,7 @@ Section cNRAEnvtocNNRC.
       unfold omap_product in *; simpl.
       unfold oncoll_map_concat in *.
       rewrite <- IHl; clear IHl.
-      rewrite (IHop1 a denv) at 1; clear IHop1; try assumption; simpl; auto 3.
+      rewrite (IHop1 a denv) at 1; clear IHop1; try assumption; simpl; auto 3 with qcert.
       + destruct (h ⊢ₑ op1 @ₑ a ⊣ cenv;denv); try reflexivity; simpl.
         destruct d; try reflexivity.
         unfold omap_concat, orecconcat, rec_concat_sort.
@@ -214,7 +214,7 @@ Section cNRAEnvtocNNRC.
         destruct o; try reflexivity.
         rewrite oflatten_through_match.
         reflexivity.
-      +match_destr; unfold Equivalence.equiv in *.
+      + match_destr; unfold Equivalence.equiv in *.
        prove_fresh_nin.
       + match_destr; unfold Equivalence.equiv in *.
         elim (fresh_var_fresh2 _ _ _ _ e1).
@@ -335,7 +335,7 @@ Section cNRAEnvtocNNRC.
     - Case "cNRAEnvAppEnv"%string.
       rewrite (IHop2 did denv env vid venv H); trivial.
       case (h ⊢ₑ op2 @ₑ did ⊣ cenv;denv); intros; trivial.
-      rewrite (IHop1 did d); simpl; try reflexivity; trivial; simpl.
+      rewrite (IHop1 did d); simpl; try reflexivity; qtrivial; simpl.
       + match_destr.
         elim (fresh_var_fresh1 _ _ _ e).
       + match_destr.
@@ -347,7 +347,7 @@ Section cNRAEnvtocNNRC.
       f_equal.
       apply lift_map_ext; intros.
       specialize (IHop did x ((fresh_var "tmape$" (vid :: venv :: nil), x) :: env) vid (fresh_var "tmape$" (vid :: venv :: nil))).
-      rewrite <- IHop; trivial; simpl.
+      rewrite <- IHop; qtrivial; simpl.
       + match_destr.
         elim (fresh_var_fresh1 _ _ _ e).
       + match_destr.
@@ -561,19 +561,22 @@ Section cNRAEnvtocNNRC.
         auto.
     Qed.
 
-    Hint Resolve nraenv_core_to_nnrc_core_is_core.
+    Hint Resolve nraenv_core_to_nnrc_core_is_core : qcert.
 
     Lemma nraenv_core_to_nnrc_base_top_is_core (q:nraenv_core) :
       nnrcIsCore (nraenv_core_to_nnrc_base_top q).
     Proof.
       simpl.
-      auto.
+      qauto.
     Qed.
 
-    Hint Resolve nraenv_core_to_nnrc_base_top_is_core.
+    Hint Resolve nraenv_core_to_nnrc_base_top_is_core : qcert.
 
     Program Definition nraenv_core_to_nnrc_core_top (q:nraenv_core) : nnrc_core :=
       exist _ (nraenv_core_to_nnrc_base_top q) _.
+    Next Obligation.
+      qauto.
+    Defined.
     
     Theorem nraenv_core_to_nnrc_core_top_correct (q:nraenv_core) (env:bindings) :
       nnrc_core_eval_top h (nraenv_core_to_nnrc_core_top q) env = nraenv_core_eval_top h q env.

--- a/compiler/core/Translation/Model/EJsonToJSON.v
+++ b/compiler/core/Translation/Model/EJsonToJSON.v
@@ -17,7 +17,6 @@ Require Import Ascii.
 Require Import String.
 Require Import ZArith.
 Require Import Bool.
-Require Import JsAst.JsNumber.
 Require Import Float.
 Require Import ToString.
 Require Import CoqLibAdd.

--- a/compiler/core/Translation/Operators/ForeignToEJsonRuntime.v
+++ b/compiler/core/Translation/Operators/ForeignToEJsonRuntime.v
@@ -15,6 +15,7 @@
 Require Import EquivDec.
 Require Import List.
 Require Import String.
+Require Import Ascii.
 Require Import Utils.
 Require Import DataRuntime.
 Require Import EJsonRuntime.
@@ -69,7 +70,6 @@ Section ForeignToEJsonRuntime.
           destruct (string_dec_from_neq H) as [d neq]
           ; repeat rewrite neq in *
           ; clear d neq.
-
 
     Lemma map_tostring_comm1 r :
       map

--- a/compiler/core/Translation/Typing/TCAMPtoNRA.v
+++ b/compiler/core/Translation/Typing/TCAMPtoNRA.v
@@ -95,8 +95,8 @@ Section TCAMPtoNRA.
     - reflexivity.
   Qed.
 
-  Hint Constructors nra_type unary_op_type binary_op_type.
-  Hint Resolve ATdot ATnra_match ATnra_data.
+  Hint Constructors nra_type unary_op_type binary_op_type : qcert.
+  Hint Resolve ATdot ATnra_match ATnra_data : qcert.
   
   (*  type rule for unnest_two.  Since it is a bit complicated,
        the type derivation is presented here, inline with the definition
@@ -110,10 +110,10 @@ Section TCAMPtoNRA.
                τin >=> Coll (Rec Closed τrem pf2) ⊣ τc.
   Proof.
     intros; subst.
-    econstructor; eauto.
+    econstructor; qeauto.
     Grab Existential Variables.
     eauto.
-    unfold rec_concat_sort; eauto.
+    unfold rec_concat_sort; qeauto.
   Qed.
 
   Lemma Coll_proj1 τ :
@@ -151,25 +151,25 @@ Section TCAMPtoNRA.
     camp_type τc Γ p τin τout ->
     nra_of_camp p ▷ (nra_context_type (Rec Closed Γ pf) τin) >=> Coll τout ⊣ τc.
   Proof.
-    Hint Resolve data_type_drec_nil.
+    Hint Resolve data_type_drec_nil : qcert.
     revert τc Γ pf τin τout.
     induction p; simpl; inversion 1; subst.
     (* PTconst *)
-    - eauto.
+    - qeauto.
     (* PTunop *)
-    - eauto. 
+    - qeauto. 
     (* PTbinop *)
     - econstructor.
-      + eapply (@type_NRABinop m τc (Rec Closed (("a1", τ₂₁)::("a2", τ₂₂)::nil) (eq_refl _))); eauto.
-      + econstructor; eauto.
+      + eapply (@type_NRABinop m τc (Rec Closed (("a1", τ₂₁)::("a2", τ₂₂)::nil) (eq_refl _))); qeauto.
+      + econstructor; qeauto.
     (* PTmap *)
-    - econstructor; eauto.
-      econstructor; eauto.
-      econstructor; eauto.
+    - econstructor; qeauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
       eapply ATunnest_two.
-      + econstructor; eauto.
-         econstructor; eauto.
-         econstructor; eauto.
+      + econstructor; qeauto.
+         econstructor; qeauto.
+         econstructor; qeauto.
          eapply ATdot; eauto.
          * econstructor; eauto.
          * reflexivity.
@@ -178,29 +178,28 @@ Section TCAMPtoNRA.
     (* PTassert *)
     - repeat econstructor; eauto.
     (* PTorElse *)
-    - eauto.
+    - qeauto.
     (* PTit *)
-    - eauto.
+    - qeauto.
     (* PTletIt *)
-    - econstructor; eauto.
-      econstructor; eauto.
+    - econstructor; qeauto.
+      econstructor; qeauto.
       eapply ATunnest_two.
-      + econstructor; eauto.
-         econstructor; eauto.
-         econstructor; eauto.
-         eapply ATdot; eauto.
+      + econstructor; qeauto.
+         econstructor; qeauto.
+         econstructor; qeauto.
+         eapply ATdot; qeauto.
          econstructor.
-         reflexivity.
       + reflexivity.
       + reflexivity.
     (* PTgetconstant *)
-    - repeat (econstructor; eauto).
+    - repeat (econstructor; qeauto).
     (* PTenv *)
     - rewrite (is_list_sorted_ext _ _ pf pf0).
-      repeat (econstructor; eauto).
+      repeat (econstructor; qeauto).
     (* PTletEnv *)
-    - econstructor; eauto.
-      econstructor; eauto.
+    - econstructor; qeauto.
+      econstructor; qeauto.
       + assert (Γeq:Γ'' = rec_concat_sort Γ Γ')
                   by (unfold merge_bindings in *; 
                        destruct (Compat.compatible Γ Γ'); congruence).
@@ -210,33 +209,33 @@ Section TCAMPtoNRA.
          * econstructor.
            2: {
            eapply ATunnest_two.
-           econstructor; eauto. econstructor; eauto.
-           econstructor. reflexivity. reflexivity.
+           econstructor; qeauto. econstructor; qeauto.
+           econstructor. 
            }
            simpl.
-           econstructor; eauto.
+           econstructor; qeauto.
            simpl.
-           econstructor; eauto; try (
+           econstructor; qeauto; try (
                                     econstructor; [|econstructor]; econstructor; reflexivity).
-           econstructor; eauto.
+           econstructor; qeauto.
            eapply type_NRABinop.
            eapply type_OpRecMerge_closed.
            eauto.
-           econstructor; eauto.
-           econstructor; eauto.
-           unfold tdot, edot; simpl. eauto.
-           econstructor; eauto.
-           econstructor; eauto. reflexivity.
+           econstructor; qeauto.
+           econstructor; qeauto.
+           unfold tdot, edot; simpl. qeauto.
+           econstructor; qeauto.
+           econstructor; qeauto. reflexivity.
          * reflexivity.
          * reflexivity.
     (* PTEither *)
-    - repeat (econstructor; eauto).
+    - repeat (econstructor; qeauto).
     (* PTEitherConcat *)
-    - repeat (econstructor; eauto).
+    - repeat (econstructor; qeauto).
       Grab Existential Variables.
-      eauto. eauto. eauto. eauto. eauto. 
-      eauto. eauto. eauto. eauto. eauto. 
-      eauto. eauto. eauto. eauto. eauto.
+      qeauto. qeauto. qeauto. qeauto. qeauto. 
+      qeauto. qeauto. qeauto. qeauto. qeauto. 
+      qeauto. qeauto. qeauto. qeauto. qeauto.
   Qed.
 
   Lemma nra_of_camp_type_preserve τc Γ pf p τin τout :
@@ -255,12 +254,12 @@ Section TCAMPtoNRA.
     nra_of_camp p ▷ (nra_context_type (Rec Closed nil eq_refl) τin) >=> Coll τout ⊣ τc ->
     nra_of_camp_top p ▷ τin >=> Coll τout ⊣ τc.
   Proof.
-    Hint Resolve normalize_normalizes.
-    Hint Resolve normalize_preserves_type.
+    Hint Resolve normalize_normalizes : qcert.
+    Hint Resolve normalize_preserves_type : qcert.
     intros.
-    econstructor; [eauto | ].
-    econstructor; [eauto | ].
-    econstructor; [eauto | ].
+    econstructor; [qeauto | ].
+    econstructor; [qeauto | ].
+    econstructor; [qeauto | ].
     econstructor.
     - apply (type_OpRecConcat (τ₁:=("PBIND", (Rec Closed nil eq_refl))::nil) (τ₂:=(("PDATA",τin)::nil))).
       econstructor.
@@ -270,7 +269,7 @@ Section TCAMPtoNRA.
         simpl.
         * apply bindings_type_has_type.
           econstructor.
-    - econstructor; [ | eauto 2].
+    - econstructor; [ | eauto 2 with qcert].
       econstructor.
     Grab Existential Variables.
     eauto. eauto.
@@ -286,7 +285,7 @@ Section TCAMPtoNRA.
     eapply nra_of_camp_type_preserve; eauto.
   Qed.
 
-  Hint Constructors camp_type.
+  Hint Constructors camp_type : qcert.
 
   (** Section dedicated to the reverse direction for type preservation *)
 

--- a/compiler/core/Translation/Typing/TCAMPtoNRAEnv.v
+++ b/compiler/core/Translation/Typing/TCAMPtoNRAEnv.v
@@ -27,7 +27,7 @@ Section TCAMPtoNRAEnv.
   Local Open Scope list_scope.
   Local Open Scope camp_scope.
 
-  Hint Constructors unary_op_type binary_op_type.
+  Hint Constructors unary_op_type binary_op_type : qcert.
 
   Context {m:basic_model}.
 
@@ -35,7 +35,7 @@ Section TCAMPtoNRAEnv.
     [τc&Γ] |= p ; τin ~> τout ->
     nraenv_of_camp p ▷ₓ τin >=> Coll τout ⊣ τc;(Rec Closed Γ pf).
   Proof.
-    Hint Resolve data_type_drec_nil.
+    Hint Resolve data_type_drec_nil : qcert.
     unfold nraenv_type.
     rewrite nraenv_of_camp_nraenv_core_of_camp_ident.
     apply nraenv_core_of_camp_type_preserve.

--- a/compiler/core/Translation/Typing/TCAMPtocNRAEnv.v
+++ b/compiler/core/Translation/Typing/TCAMPtocNRAEnv.v
@@ -27,7 +27,7 @@ Section TCAMPtocNRAEnv.
   Local Open Scope list_scope.
   Local Open Scope camp_scope.
 
-  Hint Constructors nraenv_core_type unary_op_type binary_op_type.
+  Hint Constructors nraenv_core_type unary_op_type binary_op_type : qcert.
 
   Context {m:basic_model}.
 
@@ -35,54 +35,54 @@ Section TCAMPtocNRAEnv.
     [τc&Γ] |= p ; τin ~> τout ->
     nraenv_core_of_camp p ▷ τin >=> Coll τout ⊣ τc;(Rec Closed Γ pf).
   Proof.
-    Hint Resolve data_type_drec_nil.
+    Hint Resolve data_type_drec_nil : qcert.
     revert Γ pf τin τout.
     induction p; simpl; inversion 1; subst.
     (* PTconst *)
     - unfold nraenv_match.
-      eauto.
+      qeauto.
     (* PTunop *)
-    - eauto. 
+    - qeauto. 
     (* PTbinop *)
     - econstructor.
-      + eapply (@type_cNRAEnvBinop m _ (Rec Closed Γ pf) (Rec Closed (("a1", τ₂₁)::("a2", τ₂₂)::nil) (eq_refl _))). eauto.
+      + eapply (@type_cNRAEnvBinop m _ (Rec Closed Γ pf) (Rec Closed (("a1", τ₂₁)::("a2", τ₂₂)::nil) (eq_refl _))). qeauto.
         apply (@type_cNRAEnvUnop m _ (Rec Closed Γ pf) (Rec Closed (("a1", τ₂₁) :: ("a2", τ₂₂) :: nil) eq_refl) (Rec Closed (("a1", τ₂₁) :: ("a2", τ₂₂) :: nil) eq_refl)).
         econstructor; reflexivity.
-        eauto.
+        qeauto.
         apply (@type_cNRAEnvUnop m _ (Rec Closed Γ pf) (Rec Closed (("a1", τ₂₁) :: ("a2", τ₂₂) :: nil) eq_refl) (Rec Closed (("a1", τ₂₁) :: ("a2", τ₂₂) :: nil) eq_refl)).
         econstructor; reflexivity.
-        econstructor; eauto.
-      + econstructor; eauto.
+        econstructor; qeauto.
+      + econstructor; qeauto.
     (* PTmap *)
-    - econstructor; eauto.
+    - econstructor; qeauto.
     (* PTassert *)
-    - repeat econstructor; eauto.
+    - repeat econstructor; qeauto.
     (* PTorElse *)
-    - eauto.
+    - qeauto.
     (* PTit *)
-    - econstructor; eauto.
+    - econstructor; qeauto.
     (* PTletIt *)
-    - econstructor; eauto.
+    - econstructor; qeauto.
     (* PTgetconstant *)
-    - repeat (econstructor; eauto).
+    - repeat (econstructor; qeauto).
     (* PTenv *)
     - rewrite (is_list_sorted_ext _ _ pf pf0).
-      repeat (econstructor; eauto).
+      repeat (econstructor; qeauto).
     (* PTletEnv *)
-    - econstructor; eauto.
-      econstructor; eauto.
+    - econstructor; qeauto.
+      econstructor; qeauto.
       assert (Γeq:Γ'' = rec_concat_sort Γ Γ')
         by (unfold merge_bindings in *; 
              destruct (Compat.compatible Γ Γ'); congruence).
       generalize (merge_bindings_sorted H4). subst. 
       intros.
-      econstructor; eauto.
+      econstructor; qeauto.
     (* PTEither *)
-    - repeat (econstructor; eauto).
+    - repeat (econstructor; qeauto).
     (* PTEither *)
-    - repeat (econstructor; eauto).
+    - repeat (econstructor; qeauto).
     Grab Existential Variables.
-    eauto. eauto. eauto.
+    qeauto. qeauto. qeauto.
   Qed.
 
   (** Some corollaries of the main Lemma *)
@@ -92,7 +92,7 @@ Section TCAMPtocNRAEnv.
     nraenv_core_of_camp_top p ▷ τin >=> Coll τout ⊣ τc;(Rec Closed nil eq_refl).
   Proof.
     intros.
-    repeat (econstructor; eauto).
+    repeat (econstructor; qeauto).
   Qed.
     
   Theorem alg_of_camp_top_type_preserve p τc τin τout :

--- a/compiler/core/Translation/Typing/TLambdaNRAtoNRAEnv.v
+++ b/compiler/core/Translation/Typing/TLambdaNRAtoNRAEnv.v
@@ -37,45 +37,45 @@ Section TLambdaNRAtoNRAEnv.
     ; invcs lnt
       ; autorewrite with lambda_nra lambda_nra_to_nraenv
       ; simpl.
-    - econstructor; eauto.
-    - econstructor; eauto.
-    - econstructor; eauto.
+    - econstructor; qeauto.
+    - econstructor; qeauto.
+    - econstructor; qeauto.
     - econstructor. fold nraenv_to_nraenv_core.
-      + eauto.
+      + qeauto.
       + apply IHe1; trivial.
       + apply IHe2; trivial.
     - econstructor; fold nraenv_to_nraenv_core.
-      + eauto.
+      + qeauto.
       + apply IHe; trivial.
     - econstructor; fold nraenv_to_nraenv_core
       ; [ | apply IHe2; eassumption].
       econstructor.
-      + econstructor; [ | eauto | eauto ]; eauto.
+      + econstructor; [ | qeauto | qeauto ]; qeauto.
       + apply TLLambda_inv in H1.
-        eapply IHe1; eauto.
+        eapply IHe1; qeauto.
     - econstructor; fold nraenv_to_nraenv_core
       ; [ | apply IHe2; eassumption | reflexivity].
       econstructor.
-      + econstructor; [ | eauto | eauto ]; eauto.
+      + econstructor; [ | qeauto | qeauto ]; qeauto.
       + apply TLLambda_inv in H1.
-        eapply IHe1; eauto.
+        eapply IHe1; qeauto.
     - econstructor; fold nraenv_to_nraenv_core.
-      + apply IHe1; eauto.
-      + apply IHe2; eauto.
+      + apply IHe1; qeauto.
+      + apply IHe2; qeauto.
       + reflexivity.
     - econstructor; fold nraenv_to_nraenv_core
       ; [ | apply IHe2; eassumption].
       econstructor.
-      + econstructor; [ | eauto | eauto ]; eauto.
+      + econstructor; [ | qeauto | qeauto ]; qeauto.
       + apply TLLambda_inv in H1.
-        eapply IHe1; eauto.
+        eapply IHe1; qeauto.
     Grab Existential Variables.
-    solve[eauto].
-    solve[eauto].
-    solve[eauto].
-    solve[eauto].
-    solve[eauto].
-    solve[eauto].
+    solve[qeauto].
+    solve[qeauto].
+    solve[qeauto].
+    solve[qeauto].
+    solve[qeauto].
+    solve[qeauto].
   Qed.
 
   Lemma tlambda_nra_ignores_input_type {τcenv} {Γrec} {τ₁ τ₂ τ} (e:lambda_nra) :
@@ -87,9 +87,9 @@ Section TLambdaNRAtoNRAEnv.
     ; invcs lnt
     ; autorewrite with lambda_nra lambda_nra_to_nraenv
     ; simpl
-    ; econstructor; fold nraenv_to_nraenv_core in *; eauto
-    ; try solve [eapply IHe; eauto | eapply IHe1; eauto | eapply IHe2; eauto].
-    - invcs H5; eauto.
+    ; econstructor; fold nraenv_to_nraenv_core in *; qeauto
+    ; try solve [eapply IHe; qeauto | eapply IHe1; qeauto | eapply IHe2; qeauto].
+    - invcs H5; qeauto.
   Qed.
   
   Theorem tlambda_nra_sem_correct_back
@@ -102,7 +102,7 @@ Section TLambdaNRAtoNRAEnv.
     ; invcs lnt
     ; autorewrite with lambda_nra lambda_nra_to_nraenv
     ; simpl
-    ; econstructor; fold nraenv_to_nraenv_core in *; eauto.
+    ; econstructor; fold nraenv_to_nraenv_core in *; qeauto.
     - invcs H5.
       invcs H1; rtype_equalizer; subst.
       trivial.

--- a/compiler/core/Translation/Typing/TNNRCtoNNRS.v
+++ b/compiler/core/Translation/Typing/TNNRCtoNNRS.v
@@ -76,33 +76,33 @@ Section TNNRCtoNNRS.
         nnrc_type Γc Γ e τ <-> [ Γc ; pd_tbindings_lift Γ  ⊢ ei ▷ τ ].
     Proof.
       unfold nnrc_type.
-      Hint Constructors nnrc_core_type.
-      Hint Constructors nnrs_expr_type.
+      Hint Constructors nnrc_core_type : qcert.
+      Hint Constructors nnrs_expr_type : qcert.
       
       revert ei.
       induction e; simpl; intros ei eqq Γc Γ τ; try discriminate.
       - invcs eqq.
-        split; intros typ; invcs typ; eauto.
+        split; intros typ; invcs typ; qeauto.
       - invcs eqq.
-        split; intros typ; invcs typ; eauto.
+        split; intros typ; invcs typ; qeauto.
         + constructor.
           rewrite lookup_pd_tbindings_lift.
           rewrite H1; simpl; trivial.
         + rewrite lookup_pd_tbindings_lift in H1.
           apply some_lift in H1.
           destruct H1 as [? ? eqq1]; invcs eqq1.
-          eauto.
-      - invcs eqq; split; intros typ; invcs typ; eauto.
+          qeauto.
+      - invcs eqq; split; intros typ; invcs typ; qeauto.
       - apply some_lift2 in eqq.
         destruct eqq as [? [??[??]]]; subst.
         split; intros typ; invcs typ
-        ; (econstructor; eauto 2
-           ; [eapply IHe1 | eapply IHe2]; eauto).        
+        ; (econstructor; eauto 2 with qcert
+           ; [eapply IHe1 | eapply IHe2]; qeauto).        
       - apply some_lift in eqq.
         destruct eqq as [? ? ?]; subst.
         split; intros typ; invcs typ
-        ; (econstructor; eauto 2
-           ; eapply IHe; eauto).        
+        ; (econstructor; eauto 2 with qcert
+           ; eapply IHe; qeauto).        
       - apply some_lift in eqq.
         destruct eqq as [? ? ?]; subst.
         split; intros typ.
@@ -158,13 +158,13 @@ Section TNNRCtoNNRS.
           [ Γc ; pd_tbindings_lift Γ , (add_term_mc term τ Δc) , (add_term_md term τ Δd) ⊢ si ].
     Proof.
       unfold nnrc_type.
-      Hint Resolve terminate_type.
-      Hint Constructors nnrc_core_type.
-      Hint Constructors nnrs_expr_type.
+      Hint Resolve terminate_type : qcert.
+      Hint Constructors nnrc_core_type : qcert.
+      Hint Constructors nnrs_expr_type : qcert.
       intros eqq Γc.
       revert fvs term si eqq.
       induction s; simpl; intros fvs term si eqq Γ τ typ Δc Δd
-      ; repeat match_option_in eqq; invcs eqq; try solve [invcs typ; eauto 3].
+      ; repeat match_option_in eqq; invcs eqq; try solve [invcs typ; eauto 3 with qcert].
       - invcs typ.
         apply terminate_type.
         econstructor.
@@ -266,23 +266,23 @@ Section TNNRCtoNNRS.
         nnrc_type Γc Γ s τ.
     Proof.
       unfold nnrc_type.
-      Hint Resolve terminate_type.
-      Hint Constructors nnrc_core_type.
-      Hint Constructors nnrs_expr_type.
+      Hint Resolve terminate_type : qcert.
+      Hint Constructors nnrc_core_type : qcert.
+      Hint Constructors nnrs_expr_type : qcert.
       intros eqq Γc.
       revert fvs term si eqq.
       nnrc_cases (induction s) Case
       ; simpl; intros fvs term si eqq Γ τ Δc Δd typ
       ; repeat match_option_in eqq; invcs eqq
       ; try apply terminate_type_add_term_inv in typ
-      ; try solve [invcs typ; eauto 3].
+      ; try solve [invcs typ; eauto 3 with qcert].
       - Case "NNRCVar"%string.
         invcs typ.
         rewrite lookup_pd_tbindings_lift in H1; simpl in H1.
         apply some_lift in H1.
         destruct H1 as [? ? eqq].
         invcs eqq.
-        eauto.
+        qeauto.
       - Case "NNRCBinop"%string.
         apply some_lift2 in eqq0.
         destruct eqq0 as [? [? eqq1 [eqq2 ?]]]; subst.

--- a/compiler/core/Translation/Typing/TNNRStoNNRSimp.v
+++ b/compiler/core/Translation/Typing/TNNRStoNNRSimp.v
@@ -618,7 +618,7 @@ Section TNNRStoNNRSimp.
     - Case "NNRSLetMut"%string.
       unfold equiv_decb in *.
       destruct (v0 == v); try discriminate.
-      match_destr_in eqq; tauto.
+      match_destr_in eqq; auto.
     - Case "NNRSAssign"%string.
       unfold equiv_decb in *.
       destruct (v0 == v); try discriminate.
@@ -892,7 +892,7 @@ Section TNNRStoNNRSimp.
         match_destr.
         apply notnone; rewrite in_app_iff.
         right.
-        apply remove_in_neq; tauto.
+        apply remove_in_neq; auto.
     - Case "NNRSLetMut"%string.
       destruct sf as [ninΓ [ninΔc [ninΔd [sf1 sf2]]]].
       invcs H3.
@@ -911,7 +911,7 @@ Section TNNRStoNNRSimp.
             match_destr.
             apply notnone; rewrite in_app_iff.
             right.
-            apply remove_in_neq; tauto.
+            apply remove_in_neq; auto.
         }
       + { eapply type_NNRSLetMutNotUsed.
           + eapply IHs1; eauto.
@@ -1000,7 +1000,7 @@ Section TNNRStoNNRSimp.
         match_destr.
         apply notnone; rewrite in_app_iff.
         right.
-        apply remove_in_neq; tauto.
+        apply remove_in_neq; auto.
     - Case "NNRSIf"%string.
       destruct sf as [disjc [disjd [sf1 sf2]]].
       econstructor.
@@ -1017,12 +1017,12 @@ Section TNNRStoNNRSimp.
         match_destr.
         apply notnone; repeat rewrite in_app_iff.
         right; left.
-        apply remove_in_neq; tauto.
+        apply remove_in_neq; auto.
       + eapply IHs2; eauto; intros; simpl.
         match_destr.
         apply notnone; repeat rewrite in_app_iff.
         right; right.
-        apply remove_in_neq; tauto.
+        apply remove_in_neq; auto.
   Qed.
 
   Theorem tnnrs_to_nnrs_imp_correct_b {Γc} {si:nnrs} {τ} :

--- a/compiler/core/Translation/Typing/TNRAtocNNRC.v
+++ b/compiler/core/Translation/Typing/TNRAtocNNRC.v
@@ -23,6 +23,9 @@ Require Import NRASystem.
 Require Import cNNRCSystem.
 Require Import NRAtocNNRC.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section TNRAtocNNRC.
   (** Type preservation for the translation from NRA to NNRC *)
 

--- a/compiler/core/Translation/Typing/TNRAtocNNRC.v
+++ b/compiler/core/Translation/Typing/TNRAtocNNRC.v
@@ -43,7 +43,7 @@ Section TNRAtocNNRC.
     (op ▷ τin >=> τout ⊣ τconstants) ->
     nnrc_core_type τconstants tenv (nra_to_nnrc_core op vid) τout.
   Proof.
-    Hint Constructors nra_type.
+    Hint Constructors nra_type : qcert.
     Opaque fresh_var.
     intros.
     revert vid tenv H.
@@ -153,20 +153,20 @@ Section TNRAtocNNRC.
     nnrc_core_type τconstants tenv (nra_to_nnrc_core op vid) τout ->
     (op ▷ τin >=> τout ⊣ τconstants).
   Proof.
-    Hint Constructors nra_type.
+    Hint Constructors nra_type : qcert.
     intros.
     revert τin τout vid tenv H H0.
     nra_cases (induction op) Case; simpl; intros; inversion H0; subst.
     - Case "NRAGetConstant"%string.
       econstructor. eauto.
     - Case "NRAID"%string.
-      rewrite H in H3; inversion H3; subst. eauto.
+      rewrite H in H3; inversion H3; subst. qeauto.
     - Case "NRAConst"%string.
-      eauto.
+      qeauto.
     - Case "NRABinop"%string.
-      eauto. 
+      qeauto. 
     - Case "NRAUnop"%string.
-      eauto.
+      qeauto.
     - Case "NRAMap"%string.
       econstructor; eauto 2.
       eapply (IHop1 _ _ (fresh_var "tmap$" [vid])
@@ -300,8 +300,8 @@ Section TNRAtocNNRC.
     nnrc_core_type τconstants tenv (nra_to_nnrc_core op vid) τout ->
     (op ▷ τin >=> τout ⊣ τconstants).
   Proof.
-    Hint Resolve tnra_sem_correct tnra_sem_correct_back.
-    intuition; eauto.
+    Hint Resolve tnra_sem_correct tnra_sem_correct_back : qcert.
+    intuition; qeauto.
   Qed.
 
 End TNRAtocNNRC.

--- a/compiler/core/Translation/Typing/TOQLtoNRAEnv.v
+++ b/compiler/core/Translation/Typing/TOQLtoNRAEnv.v
@@ -15,7 +15,7 @@
 Require Import String.
 Require Import List.
 Require Import Arith.
-Require Import Omega.
+Require Import Lia.
 Require Import EquivDec.
 Require Import Morphisms.
 Require Import Utils.

--- a/compiler/core/Translation/Typing/TOQLtoNRAEnv.v
+++ b/compiler/core/Translation/Typing/TOQLtoNRAEnv.v
@@ -32,20 +32,20 @@ Section TOQLtoNRAEnv.
       nraenv_type τconstant (oql_to_nraenv_expr (domain τdefls) e) (Rec Closed τdefls pfd) (Rec Closed τenv pfe) τout.
     Proof.
       unfold nraenv_type; simpl.
-      Hint Constructors nraenv_core_type.
+      Hint Constructors nraenv_core_type : qcert.
       revert τconstant τdefls pfd τenv pfe τout.
-      induction e; simpl; intros τconstant τdefls pfd τenv pfe τout ot; invcs ot; eauto 4.
+      induction e; simpl; intros τconstant τdefls pfd τenv pfe τout ot; invcs ot; eauto 4 with qcert.
       - unfold lookup_table.
           unfold tdot, edot, rec_concat_sort in *.
           rewrite assoc_lookupr_drec_sort in H1.
           rewrite (assoc_lookupr_app τconstant τdefls _ ODT_eqdec) in H1.
         match_destr; simpl; intros.
-        + econstructor; [ | eauto].
+        + econstructor; [ | qeauto].
           apply in_dom_lookupr with (dec:=ODT_eqdec) in i.
           destruct i as [? ?].
           match_case_in H1; [intros ? eqq | intros eqq]; rewrite eqq in H1.
           * invcs H1.
-            eauto.
+            qeauto.
           * congruence.
         + constructor.
           apply assoc_lookupr_nin_none with (dec:=ODT_eqdec) in n.
@@ -57,25 +57,25 @@ Section TOQLtoNRAEnv.
       nraenv_type τconstant (oql_to_nraenv_query_program (domain τdefls) oq) (Rec Closed τdefls pfd) (Rec Closed τenv pfe) τout.
     Proof.
       unfold nraenv_type; simpl.
-      Hint Constructors nraenv_core_type.
+      Hint Constructors nraenv_core_type : qcert.
       revert τdefls pfd τenv pfe τout.
       induction oq; simpl; intros τdefls pfd τenv pfe τout ot; invcs ot.
       - econstructor.
-        + econstructor; eauto.
-          econstructor; eauto.
+        + econstructor; qeauto.
+          econstructor; qeauto.
           apply oql_to_nraenv_expr_type_preserve_f; eauto.
         + specialize (IHoq (rec_concat_sort τdefls ((s, τ₁) :: nil))).
           assert (eqls:equivlist (s :: domain τdefls) (domain (rec_concat_sort τdefls ((s, τ₁) :: nil))))
             by (rewrite rec_concat_sort_domain_app_commutatuve_equiv; simpl; reflexivity).
           rewrite eqls.
           apply IHoq; trivial.
-      - econstructor; eauto.
+      - econstructor; qeauto.
         rewrite <- domain_rremove; trivial.
         auto.
       - apply oql_to_nraenv_expr_type_preserve_f; trivial.
         Grab Existential Variables.
         solve[apply is_sorted_rremove; trivial].
-        solve[eauto].
+        solve[qeauto].
         solve[simpl; trivial].
     Qed.
 

--- a/compiler/core/Translation/Typing/TcNNRCtoCAMP.v
+++ b/compiler/core/Translation/Typing/TcNNRCtoCAMP.v
@@ -40,19 +40,19 @@ Section TcNNRCtoCAMP.
     [τc&Γ] |= p ; τ₁ ~> τ₂ ->
     [τc&Γ] |= pdot (loop_var s) p ; (Rec k (nnrc_to_camp_env Γ₁) pf) ~> τ₂.
   Proof.
-    Hint Constructors camp_type.
+    Hint Constructors camp_type : qcert.
     unfold pdot; intros.
     eapply PTletIt; eauto.
-    eapply PTunop; eauto.
+    eapply PTunop; qeauto.
     constructor.
     rewrite <- env_lookup_edot; eauto.
   Qed.
 
-  Hint Resolve merge_bindings_nil_r.
-  Hint Resolve PTdot.
+  Hint Resolve merge_bindings_nil_r : qcert.
+  Hint Resolve PTdot : qcert.
 
-  Hint Resolve sorted_rec_nil.
-  Hint Constructors camp_type.
+  Hint Resolve sorted_rec_nil : qcert.
+  Hint Constructors camp_type : qcert.
 
   Lemma wf_env_same_domain {env tenv} v :
     bindings_type env tenv -> (In v (domain env) <-> In v (domain tenv)).
@@ -90,7 +90,7 @@ Section TcNNRCtoCAMP.
     NoDup (@domain _ B Γ) <-> 
     NoDup (domain (nnrc_to_camp_env Γ)).
   Proof.
-    Hint Constructors NoDup.
+    Hint Constructors NoDup : qcert.
     unfold nnrc_to_camp_env, domain.
     rewrite map_map; simpl.
     induction Γ; simpl; intuition.
@@ -107,7 +107,7 @@ Section TcNNRCtoCAMP.
        eauto.
   Qed.
 
-  Hint Constructors unary_op_type binary_op_type data_type.
+  Hint Constructors unary_op_type binary_op_type data_type : qcert.
 
   Lemma is_list_sorted_nnrc_to_camp_env_nodup {B} {tenv} :
     is_list_sorted ODT_lt_dec (@domain _ B (nnrc_to_camp_env tenv)) = true ->
@@ -119,7 +119,7 @@ Section TcNNRCtoCAMP.
     eapply StringOrder.lt_strorder.
   Qed.
 
-  Hint Resolve is_list_sorted_nnrc_to_camp_env_nodup.
+  Hint Resolve is_list_sorted_nnrc_to_camp_env_nodup : qcert.
 
   (* TODO: move to Assoc *)
   Lemma lookup_incl_perm_nodup {A B} {dec:EqDec A eq} {l1 l2:list (A*B)} :
@@ -366,13 +366,13 @@ Section TcNNRCtoCAMP.
       [τc&(nnrc_to_camp_env Γ)] |= (nnrcToCamp_ns n) ; τ₀ ~> τout.
   Proof.
     revert Γ τout; induction n; intros;
-      inversion H2; subst; try solve [econstructor; eauto 3].
+      inversion H2; subst; try solve [econstructor; eauto 3 with qcert].
     - simpl in H0, H1. simpt; econstructor; eauto.
     - simpl. 
       simpl in H, H0, H1. simpt. 
-      econstructor; eauto.
+      econstructor; qeauto.
       eapply PTletEnv.
-      + econstructor; eauto. 
+      + econstructor; qeauto. 
       + rewrite merge_bindings_single_nin; eauto.
         rewrite <- loop_var_in_nnrc_to_camp_env; intuition.
       + rewrite rec_concat_sort_concats.
@@ -383,17 +383,17 @@ Section TcNNRCtoCAMP.
         assert (nd:NoDup (domain ((loop_var v, τ₁) :: nnrc_to_camp_env Γ))).
         * simpl. constructor.
           rewrite <- nnrc_to_camp_in; trivial.
-          apply -> (@nnrc_to_camp_nodup rtype); auto.
+          apply -> (@nnrc_to_camp_nodup rtype); qauto.
         * rewrite <- (drec_sort_perm_eq _ _ nd perm).
           replace ((loop_var v, τ₁) :: nnrc_to_camp_env Γ) 
           with (nnrc_to_camp_env ((v, τ₁) :: Γ)) by reflexivity.
           destruct (rec_sort_nnrc_to_camp_env_pullback ((v, τ₁) :: Γ)) 
             as [Γ' [eq' perm']].
-          apply nnrc_to_camp_nodup; auto.
+          apply nnrc_to_camp_nodup; qauto.
           rewrite eq'.
           destruct (in_dec string_eqdec v (nnrc_bound_vars n2)); intuition.
-          eapply IHn2; eauto.
-          rewrite <- eq'. eauto.
+          eapply IHn2; qeauto.
+          rewrite <- eq'. qeauto.
           intros.
           apply nnrc_to_camp_in in H5.
           rewrite <- eq' in H5.
@@ -408,10 +408,10 @@ Section TcNNRCtoCAMP.
             intuition.
     - simpl.
       simpl in H, H0, H1. simpt. 
-      econstructor; eauto.
-      eapply PTmapall; eauto.
+      econstructor; qeauto.
+      eapply PTmapall; qeauto.
       eapply PTletEnv.
-      + econstructor; eauto. 
+      + econstructor; qeauto. 
       + rewrite merge_bindings_single_nin; eauto.
          rewrite <- loop_var_in_nnrc_to_camp_env; intuition.
       + rewrite rec_concat_sort_concats.
@@ -422,7 +422,7 @@ Section TcNNRCtoCAMP.
         assert (nd:NoDup (domain ((loop_var v, τ₁) :: nnrc_to_camp_env Γ))).
         * simpl. constructor.
           rewrite <- nnrc_to_camp_in; trivial.
-          apply -> (@nnrc_to_camp_nodup rtype); auto.
+          apply -> (@nnrc_to_camp_nodup rtype); qauto.
         * rewrite <- (drec_sort_perm_eq _ _ nd perm).
           replace ((loop_var v, τ₁) :: nnrc_to_camp_env Γ) 
           with (nnrc_to_camp_env ((v, τ₁) :: Γ)) by reflexivity.
@@ -433,7 +433,7 @@ Section TcNNRCtoCAMP.
           destruct (in_dec string_eqdec v (nnrc_bound_vars n2)); intuition.
           eapply IHn2; eauto.
           rewrite <- eq'.
-          eauto.
+          qeauto.
           intros.
           apply nnrc_to_camp_in in H5.
           rewrite <- eq' in H5.
@@ -450,23 +450,23 @@ Section TcNNRCtoCAMP.
       eapply PTorElse.
       + eapply PTletEnv.
         * eapply PTassert.
-          eapply PTbinop; eauto.
-          econstructor; simpl; eauto.
+          eapply PTbinop; qeauto.
+          econstructor; simpl; qeauto.
         * rewrite merge_bindings_nil_r. reflexivity.
-        * eapply camp_type_tenv_rec; eauto.
+        * eapply camp_type_tenv_rec; qeauto.
       + eapply PTletEnv.
         * eapply PTassert.
-          eapply PTunop; eauto.
+          eapply PTunop; qeauto.
         * rewrite merge_bindings_nil_r. reflexivity.
-        * eapply camp_type_tenv_rec; eauto.
+        * eapply camp_type_tenv_rec; qeauto.
     - simpl in *.
       apply in_in_cons_cons_app_app_false in H1.
       destruct H1 as [?[?[?[??]]]].
       repeat rewrite andb_true_iff in H0; destruct H0 as [[[[??]?]?]?].
       match_destr_in H0. match_destr_in H7.
-      eapply PTletIt; [eauto | ].
+      eapply PTletIt; [qeauto | ].
       eapply PTorElse.
-      + eapply PTletIt; [eauto | ].
+      + eapply PTletIt; [qeauto | ].
         eapply PTletEnv.
         * repeat econstructor.
         * rewrite merge_bindings_single_nin. reflexivity.
@@ -475,7 +475,7 @@ Section TcNNRCtoCAMP.
         * assert (nd:NoDup (domain ((loop_var v, τl) :: nnrc_to_camp_env Γ))).
           simpl; constructor.
           rewrite <- loop_var_in_nnrc_to_camp_env; trivial.
-          apply -> (@nnrc_to_camp_nodup rtype); auto.
+          apply -> (@nnrc_to_camp_nodup rtype); qauto.
           assert (perm:Permutation 
                          ((loop_var v, τl) :: nnrc_to_camp_env Γ)
                          (nnrc_to_camp_env Γ ++ [(loop_var v, τl)]))
@@ -485,19 +485,19 @@ Section TcNNRCtoCAMP.
           with (nnrc_to_camp_env ((v, τl) :: Γ)) by reflexivity.
           destruct (rec_sort_nnrc_to_camp_env_pullback ((v, τl) :: Γ)) 
             as [Γ' [eq' perm']].
-          apply nnrc_to_camp_nodup. auto.
+          apply nnrc_to_camp_nodup. qauto.
           rewrite eq'.
           apply IHn2; trivial.
-          rewrite <- eq'; eauto; reflexivity.
+          rewrite <- eq'; qeauto; reflexivity.
           intros ? inn.
           symmetry in perm'.
           generalize (Permutation_in _ (dom_perm _ _ perm') inn); simpl; intros [inn'|inn']; subst; eauto.
           apply (nnrc_core_type_context_perm _ _ _ perm'); trivial.
           simpl.
-          constructor; auto.
+          constructor; qauto.
           simpl.
           intros ? [?|?]; subst; eauto.
-      + eapply PTletIt; [eauto | ].
+      + eapply PTletIt; [qeauto | ].
         eapply PTletEnv.
         * repeat econstructor.
         * rewrite merge_bindings_single_nin. reflexivity.
@@ -507,7 +507,7 @@ Section TcNNRCtoCAMP.
           assert (nd:NoDup (domain ((loop_var v0, τr) :: nnrc_to_camp_env Γ))).
           simpl; constructor.
           rewrite <- loop_var_in_nnrc_to_camp_env; trivial.
-          apply -> (@nnrc_to_camp_nodup rtype); auto.
+          apply -> (@nnrc_to_camp_nodup rtype); qauto.
           assert (perm:Permutation 
                          ((loop_var v0, τr) :: nnrc_to_camp_env Γ)
                          (nnrc_to_camp_env Γ ++ [(loop_var v0, τr)]))
@@ -517,15 +517,15 @@ Section TcNNRCtoCAMP.
           with (nnrc_to_camp_env ((v0, τr) :: Γ)) by reflexivity.
           destruct (rec_sort_nnrc_to_camp_env_pullback ((v0, τr) :: Γ)) 
             as [Γ' [eq' perm']].
-          apply nnrc_to_camp_nodup; auto.
+          apply nnrc_to_camp_nodup; qauto.
           rewrite eq'.
           apply IHn3; trivial.
-          rewrite <- eq'; eauto; reflexivity.
+          rewrite <- eq'; qeauto; reflexivity.
           intros ? inn.
           symmetry in perm'.
           generalize (Permutation_in _ (dom_perm _ _ perm') inn); simpl; intros [inn'|inn']; subst; eauto.
           apply (nnrc_core_type_context_perm _ _ _ perm'); trivial.
-          simpl; constructor; auto.
+          simpl; constructor; qauto.
           simpl.
           intros ? [?|?]; subst; eauto.
           Grab Existential Variables.
@@ -575,8 +575,8 @@ Section TcNNRCtoCAMP.
      @domain_app 
   : fresh_bindings.
 
-  Hint Resolve StringOrder.lt_strorder.
-  Hint Resolve is_list_sorted_NoDup.
+  Hint Resolve StringOrder.lt_strorder : qcert.
+  Hint Resolve is_list_sorted_NoDup : qcert.
 
   Hint Rewrite 
        @rec_concat_sort_concats 
@@ -606,8 +606,8 @@ Section TcNNRCtoCAMP.
     ([τc&b] |= (nnrcToCamp_ns n) ; τ₁ ~> τ₂) ->
     [τc&(rec_concat_sort b ((let_var x, xv)::nil))] |= (nnrcToCamp_ns n) ; τ₁ ~> τ₂.
   Proof.
-    Hint Resolve loop_let_var_distinct.
-    Hint Resolve rec_concat_sort_sorted.
+    Hint Resolve loop_let_var_distinct : qcert.
+    Hint Resolve rec_concat_sort_sorted : qcert.
     intro Hiscore.
     revert Hiscore b x xv τ₁ τ₂.
     induction n; intros; trivial; simpl in H1;
@@ -616,11 +616,11 @@ Section TcNNRCtoCAMP.
     - simpl in *. t. econstructor; eauto.
     - simpl in *.
       t.
-      repeat econstructor; eauto.
-      rewrite tdot_rec_concat_sort_neq; [idtac|eauto].
-      rewrite sort_sorted_is_id; eauto.
-    - simpl in *; t; eauto.
-    - simpl in *; simpt;  t; eauto.
+      repeat econstructor; qeauto.
+      rewrite tdot_rec_concat_sort_neq; [idtac|qeauto].
+      rewrite sort_sorted_is_id; qeauto.
+    - simpl in *; t; qeauto.
+    - simpl in *; simpt;  t; qeauto.
     - simpl in *.
       inversion H6; subst.
       econstructor; [idtac|eauto].
@@ -632,7 +632,7 @@ Section TcNNRCtoCAMP.
       econstructor; eauto.
       destruct x0; simpl in *. subst.
       econstructor.
-      + econstructor; eauto.
+      + econstructor; qeauto.
       + rewrite merge_bindings_single_nin; [reflexivity|idtac].
         autorewrite with simpr.
         simpl; subst; intuition.
@@ -645,7 +645,7 @@ Section TcNNRCtoCAMP.
         apply perm_swap.
         erewrite drec_sort_perm_eq; try eapply perm.
         rewrite <- rec_sort_rec_sort_app1.
-        eapply IHn2; eauto 2.
+        eapply IHn2; eauto 2 with qcert.
         * autorewrite with fresh_bindings.
           simpl.
           autorewrite with fresh_bindings.
@@ -673,11 +673,11 @@ Section TcNNRCtoCAMP.
     - elim Hiscore; clear Hiscore; intros Hcore1 Hcore2;
       specialize (IHn1 Hcore1); specialize (IHn2 Hcore2).
       simpl in *. simpt; t.
-      econstructor; eauto.
-      eapply PTmapall; eauto.
+      econstructor; qeauto.
+      eapply PTmapall; qeauto.
       destruct x0; simpl in *. subst.
       econstructor.
-      + econstructor; eauto.
+      + econstructor; qeauto.
       + rewrite merge_bindings_single_nin; [reflexivity|idtac].
         autorewrite with simpr.
         simpl; subst; intuition.
@@ -690,7 +690,7 @@ Section TcNNRCtoCAMP.
         apply perm_swap.
         erewrite drec_sort_perm_eq; try eapply perm.
         rewrite <- rec_sort_rec_sort_app1.
-        eapply IHn2; eauto 2.
+        eapply IHn2; eauto 2 with qcert.
         * autorewrite with fresh_bindings.
           simpl.
           autorewrite with fresh_bindings.
@@ -720,9 +720,9 @@ Section TcNNRCtoCAMP.
       elim Hiscore; clear Hiscore; intros Hcore2 Hcore3;
       specialize (IHn1 Hcore1); specialize (IHn2 Hcore2); specialize (IHn3 Hcore3).
       simpt; t.
-      econstructor; eauto.
+      econstructor; qeauto.
       + inversion H35; subst.
-        econstructor. eauto.
+        econstructor. qeauto.
         rewrite merge_bindings_nil_r.
         rewrite drec_sort_drec_sort_concat.
         reflexivity.
@@ -730,7 +730,7 @@ Section TcNNRCtoCAMP.
         assert (rec_sort b = b) by (eapply rec_sorted_id; eauto).
         unfold rec_sort in *. rewrite <- H6; assumption.
       + inversion H35; subst.
-        econstructor. eauto.
+        econstructor. qeauto.
         rewrite merge_bindings_nil_r.
         rewrite drec_sort_drec_sort_concat.
         reflexivity.
@@ -767,7 +767,7 @@ Section TcNNRCtoCAMP.
       rtype_equalizer. subst.
       econstructor; [eauto | ].
       econstructor.
-      + econstructor; [eauto | ]; simpl.
+      + econstructor; [qeauto | ]; simpl.
         econstructor.
         * simpl. repeat econstructor.
         * rewrite merge_bindings_single_nin; try reflexivity.
@@ -812,7 +812,7 @@ Section TcNNRCtoCAMP.
               simpl.
               constructor; trivial.
           }
-      + econstructor; [eauto | ]; simpl.
+      + econstructor; [qeauto | ]; simpl.
         econstructor.
         * simpl. repeat econstructor.
         * rewrite merge_bindings_single_nin; try reflexivity.
@@ -865,11 +865,11 @@ Section TcNNRCtoCAMP.
      Grab Existential Variables.
      eauto.
      eauto.
+     qeauto.
+     qeauto.
      eauto.
      eauto.
-     eauto.
-     eauto.
-     eauto.
+     qeauto.
   Qed.
 
   Lemma nnrc_to_camp_ns_let_type_equiv n τc Γ τout :
@@ -891,8 +891,8 @@ Section TcNNRCtoCAMP.
     - eauto.
     - eauto.
     - eauto.
-    - rewrite map_app in ninb; apply in_in_app_false in ninb; intuition; eauto.
-    - intuition; eauto.
+    - rewrite map_app in ninb; apply in_in_app_false in ninb; intuition; qeauto.
+    - intuition; qeauto.
     - simpl in Hiscore; elim Hiscore; clear Hiscore; intros Hcore1 Hcore2;
       specialize (IHn1 Hcore1); specialize (IHn2 Hcore2).
       rewrite map_app in ninb; apply in_in_cons_app_false in ninb; intuition.
@@ -902,9 +902,9 @@ Section TcNNRCtoCAMP.
       subst.
       econstructor; eauto.
       econstructor.
-      + econstructor; eauto.
+      + econstructor; qeauto.
       + eassumption.
-      + eapply IHn2; eauto.
+      + eapply IHn2; qeauto.
          * intros ? inn1 inn2.
            repeat defresh.
            assert (inn1': In (let_var x) (domain (Γ ++ [(loop_var v, s0)])))
@@ -931,13 +931,13 @@ Section TcNNRCtoCAMP.
       subst.
       econstructor; eauto.
       econstructor.
-      + econstructor; eauto.
-         econstructor; eauto.
+      + econstructor; qeauto.
+         econstructor; qeauto.
          econstructor.
-         econstructor; eauto.
+         econstructor; qeauto.
          eauto.
          inversion H15; subst.
-         eapply IHn2; eauto 2.
+         eapply IHn2; eauto 2 with qcert.
          * unfold mapall_let in H1. 
             autorewrite with fresh_bindings in H1.
             intuition.
@@ -996,7 +996,7 @@ Section TcNNRCtoCAMP.
       t.
       rewrite sort_sorted_is_id in H24,H28,H33,H37 by eauto.
       econstructor.
-      + eauto.
+      + qeauto.
       + rewrite merge_bindings_single_nin.
         reflexivity.
         intro inn.
@@ -1004,12 +1004,12 @@ Section TcNNRCtoCAMP.
         reflexivity.
       + econstructor.
         * econstructor.
-          econstructor; eauto.
-          econstructor; eauto.
-          econstructor; eauto.
-          econstructor; eauto.
-          econstructor; eauto.
-          econstructor; eauto.
+          econstructor; qeauto.
+          econstructor; qeauto.
+          econstructor; qeauto.
+          econstructor; qeauto.
+          econstructor; qeauto.
+          econstructor; qeauto.
           inversion H32; clear H32; subst.
           inversion H41; clear H41; subst.
           apply tdot_rec_concat_sort_eq.
@@ -1019,7 +1019,7 @@ Section TcNNRCtoCAMP.
           rewrite merge_bindings_nil_r.
           rewrite drec_sort_drec_sort_concat.
           reflexivity.
-          eapply IHn2; eauto.
+          eapply IHn2; qeauto.
           
           rewrite
             rec_concat_sort_concats,
@@ -1048,7 +1048,7 @@ Section TcNNRCtoCAMP.
           rewrite fresh_let_var_as_let in eqq.
           eapply loop_let_var_distinct; eauto.
           
-          eapply nnrcToCamp_ns_type_ignored_let_binding; eauto.
+          eapply nnrcToCamp_ns_type_ignored_let_binding; qeauto.
           apply fresh_bindings_let_to_naive; trivial.
           
           intros inn. apply let_vars_let_to_naive in inn.
@@ -1060,8 +1060,8 @@ Section TcNNRCtoCAMP.
           
           intros inn; eapply H8; eauto.
           reflexivity.
-        * econstructor; [eauto|..].
-          repeat (econstructor; eauto).
+        * econstructor; [qeauto|..].
+          repeat (econstructor; qeauto).
           inversion H41.
           apply tdot_rec_concat_sort_eq.
           intro inn.
@@ -1071,7 +1071,7 @@ Section TcNNRCtoCAMP.
           rewrite merge_bindings_nil_r.
           rewrite drec_sort_drec_sort_concat.
           reflexivity.
-          eapply IHn3; eauto.
+          eapply IHn3; qeauto.
           
           unfold rec_concat_sort.
           rewrite fresh_bindings_domain_drec_sort,
@@ -1099,7 +1099,7 @@ Section TcNNRCtoCAMP.
           rewrite fresh_let_var_as_let in eqq.
           eapply loop_let_var_distinct; eauto.
           
-          eapply nnrcToCamp_ns_type_ignored_let_binding; eauto.
+          eapply nnrcToCamp_ns_type_ignored_let_binding; qeauto.
           apply fresh_bindings_let_to_naive; trivial.
           
           intros inn. apply let_vars_let_to_naive in inn.
@@ -1140,9 +1140,9 @@ Section TcNNRCtoCAMP.
       destruct p.
       inversion H21; clear H21; rtype_equalizer.
       subst.
-      econstructor; [eauto | ].
+      econstructor; [qeauto | ].
       econstructor.
-      + econstructor; [eauto | ].
+      + econstructor; [qeauto | ].
         econstructor.
         * repeat econstructor.
         * rewrite <- H22. reflexivity.
@@ -1150,18 +1150,18 @@ Section TcNNRCtoCAMP.
           match_case_in H22; intros comcamp;
           rewrite comcamp in H22; try discriminate.
           inversion H22; clear H22; subst.
-          { apply IHn2; trivial.
+          { apply IHn2; qtrivial.
             - unfold rec_concat_sort.
               autorewrite with fresh_bindings.
               simpl. autorewrite with fresh_bindings.
-              auto.
+              qauto.
             - unfold rec_concat_sort. intros ? inn.
               rewrite in_dom_rec_sort, domain_app, in_app_iff in inn.
               simpl in inn. destruct inn as [?|[?|?]]; subst; eauto.
               rewrite in_map_iff. intros [? [injj ?]]; apply loop_var_inj in injj.
               subst; eauto.
           } 
-      + econstructor; [eauto | ].
+      + econstructor; [qeauto | ].
         econstructor.
         * repeat econstructor.
         * rewrite <- H24. reflexivity.
@@ -1169,11 +1169,11 @@ Section TcNNRCtoCAMP.
           match_case_in H24; intros comcamp;
           rewrite comcamp in H24; try discriminate.
           inversion H24; clear H24; subst.
-          { apply IHn3; trivial.
+          { apply IHn3; qtrivial.
             - unfold rec_concat_sort.
               autorewrite with fresh_bindings.
               simpl. autorewrite with fresh_bindings.
-              auto.
+              qauto.
             - unfold rec_concat_sort; intros ? inn.
               rewrite in_dom_rec_sort, domain_app, in_app_iff in inn.
               simpl in inn. destruct inn as [?|[?|?]]; subst; eauto.
@@ -1184,13 +1184,13 @@ Section TcNNRCtoCAMP.
       Grab Existential Variables.
       solve[eauto].
       solve[eauto].
-      solve[eauto].
+      solve[qeauto].
       solve[eauto].    
+      solve[qeauto].
       solve[eauto].
       solve[eauto].
-      solve[eauto].
-      solve[eauto].
-      solve[eauto].
+      solve[qeauto].
+      solve[qeauto].
       solve[eauto].
       solve[eauto].
       solve[eauto].
@@ -1270,7 +1270,7 @@ Section TcNNRCtoCAMP.
     - t.
       econstructor.
       unfold tdot in H4.
-      rewrite env_lookup_edot; eauto.
+      rewrite env_lookup_edot; qeauto.
     - econstructor; eauto.
     - simpl in *; simpt. econstructor; eauto.
     - simpl in *; simpt. econstructor; eauto.
@@ -1281,16 +1281,16 @@ Section TcNNRCtoCAMP.
       destruct x0; destruct x; simpl in *; subst.
       eapply type_cNNRCLet; eauto.
       destruct (rec_sort_nnrc_to_camp_env_pullback ((v, s2) :: Γ)) 
-        as [g' [grec gperm]]; simpl; [econstructor; eauto|idtac].
+        as [g' [grec gperm]]; simpl; [econstructor; qeauto|idtac].
       symmetry in gperm.
       assert(nin:forall x : string, In x (domain g') -> In x (nnrc_bound_vars n2) -> False) 
         by (intros ? inn1 inn2; apply dom_perm in gperm;
             apply (Permutation_in _ gperm) in inn1;
             simpl in inn1; destruct inn1; subst; eauto).
-      apply (nnrc_core_type_context_perm _ _ _ gperm); try rewrite gperm; trivial.
-      + simpl; econstructor; eauto.
-      + eapply IHn2; trivial;
-          unfold rtype; rewrite <- grec; eauto.
+      apply (nnrc_core_type_context_perm _ _ _ gperm); try rewrite gperm; qtrivial.
+      + simpl; econstructor; qeauto.
+      + eapply IHn2; qtrivial;
+          unfold rtype; rewrite <- grec; qeauto.
          * repeat defresh. 
             unfold rec_concat_sort in H20.
             simpl nnrc_to_camp_env.
@@ -1298,8 +1298,8 @@ Section TcNNRCtoCAMP.
                             ((loop_var v, s2) :: nnrc_to_camp_env Γ) 
                             (nnrc_to_camp_env Γ ++ [(loop_var v, s2)]))
               by (rewrite Permutation_app_comm; simpl; reflexivity).
-              erewrite drec_sort_perm_eq; try eapply perm; eauto.
-              simpl. econstructor; eauto.
+              erewrite drec_sort_perm_eq; try eapply perm; qeauto.
+              simpl. econstructor; qeauto.
               intros inn1.
               apply nnrc_to_camp_in in inn1.
               intuition.
@@ -1310,15 +1310,15 @@ Section TcNNRCtoCAMP.
       destruct x0; destruct x; simpl in *; subst.
       eapply type_cNNRCFor; eauto.
       destruct (rec_sort_nnrc_to_camp_env_pullback ((v, s2) :: Γ)) 
-        as [g' [grec gperm]]; [simpl; econstructor; eauto|idtac].
+        as [g' [grec gperm]]; [simpl; econstructor; qeauto|idtac].
       symmetry in gperm.
       assert(nin:forall x : string, In x (domain g') -> In x (nnrc_bound_vars n2) -> False) 
         by (intros ? inn1 inn2; apply dom_perm in gperm;
             apply (Permutation_in _ gperm) in inn1;
             simpl in inn1; destruct inn1; subst; eauto).
       apply (nnrc_core_type_context_perm _ _ _ gperm); try rewrite gperm; trivial.
-      + simpl; econstructor; eauto.
-      + eapply IHn2; unfold rtype; trivial; rewrite <- grec; eauto.
+      + simpl; econstructor; qeauto.
+      + eapply IHn2; unfold rtype; trivial; rewrite <- grec; qeauto.
         unfold merge_bindings in H14.
         destruct (Compat.compatible (nnrc_to_camp_env Γ) [(loop_var v, s2)]);
             [idtac|discriminate].
@@ -1329,8 +1329,8 @@ Section TcNNRCtoCAMP.
                             ((loop_var v, s2) :: nnrc_to_camp_env Γ) 
                             (nnrc_to_camp_env Γ ++ [(loop_var v, s2)]))
                    by (rewrite Permutation_app_comm; simpl; reflexivity).
-            erewrite drec_sort_perm_eq; try eapply perm; eauto 2.
-            simpl. econstructor; eauto.
+            erewrite drec_sort_perm_eq; try eapply perm; eauto 2 with qcert.
+            simpl. econstructor; qeauto.
             intros inn1.
             apply nnrc_to_camp_in in inn1.
             intuition.
@@ -1359,42 +1359,42 @@ Section TcNNRCtoCAMP.
       inversion H25; clear H25; subst.
       econstructor; [eauto | .. ].
       + destruct (rec_sort_nnrc_to_camp_env_pullback ((v, s4) :: Γ)) 
-          as [g' [grec gperm]]; [simpl; econstructor; eauto|idtac].
+          as [g' [grec gperm]]; [simpl; econstructor; qeauto|idtac].
         symmetry in gperm.
         assert(nin:forall x : string, In x (domain g') -> In x (nnrc_bound_vars n2) -> False) 
           by (intros ? inn1 inn2; apply dom_perm in gperm;
               apply (Permutation_in _ gperm) in inn1;
               simpl in inn1; destruct inn1; subst; eauto).
         apply (nnrc_core_type_context_perm _ _ _ gperm); try rewrite gperm; trivial.
-        simpl; econstructor; eauto.
-        eapply IHn2; unfold rtype; trivial; rewrite <- grec; eauto.
+        simpl; econstructor; qeauto.
+        eapply IHn2; unfold rtype; trivial; rewrite <- grec; qeauto.
         * unfold rec_concat_sort in H32.
           assert (perm: Permutation 
                           ((loop_var v, s4) :: nnrc_to_camp_env Γ) 
                           (nnrc_to_camp_env Γ ++ [(loop_var v, s4)]))
             by (rewrite Permutation_app_comm; simpl; reflexivity).
             erewrite drec_sort_perm_eq; try eapply perm; eauto.
-            simpl. econstructor; eauto.
+            simpl. econstructor; qeauto.
             intros inn1.
             apply nnrc_to_camp_in in inn1.
             intuition.
       + destruct (rec_sort_nnrc_to_camp_env_pullback ((v0, s6) :: Γ)) 
-          as [g' [grec gperm]]; [simpl; econstructor; eauto|idtac].
+          as [g' [grec gperm]]; [simpl; econstructor; qeauto|idtac].
         symmetry in gperm.
         assert(nin:forall x : string, In x (domain g') -> In x (nnrc_bound_vars n3) -> False) 
           by (intros ? inn1 inn2; apply dom_perm in gperm;
               apply (Permutation_in _ gperm) in inn1;
               simpl in inn1; destruct inn1; subst; eauto).
         apply (nnrc_core_type_context_perm _ _ _ gperm); try rewrite gperm; trivial.
-        simpl; econstructor; eauto.
-        eapply IHn3; unfold rtype; trivial; rewrite <- grec; eauto.
+        simpl; econstructor; qeauto.
+        eapply IHn3; unfold rtype; trivial; rewrite <- grec; qeauto.
         * unfold rec_concat_sort in H29.
           assert (perm: Permutation 
                           ((loop_var v0, s6) :: nnrc_to_camp_env Γ) 
                           (nnrc_to_camp_env Γ ++ [(loop_var v0, s6)]))
             by (rewrite Permutation_app_comm; simpl; reflexivity).
-            erewrite drec_sort_perm_eq; try eapply perm; eauto.
-            simpl. econstructor; eauto.
+            erewrite drec_sort_perm_eq; try eapply perm; qeauto.
+            simpl. econstructor; qeauto.
             intros inn1.
             apply nnrc_to_camp_in in inn1.
             intuition.
@@ -1421,16 +1421,16 @@ Section TcNNRCtoCAMP.
     unfold mapall_let; intros.
     autorewrite with fresh_bindings in H0; intuition. 
     specialize (H0 _ (eq_refl _)).
-    repeat econstructor; eauto.
+    repeat econstructor; qeauto.
     - rewrite merge_bindings_single_nin; [reflexivity|trivial].
-    - rewrite tdot_rec_concat_sort_eq; eauto.
+    - rewrite tdot_rec_concat_sort_eq; qeauto.
     - rewrite drec_sort_drec_sort_concat.
-      rewrite tdot_rec_concat_sort_eq; eauto.
+      rewrite tdot_rec_concat_sort_eq; qeauto.
       Grab Existential Variables.
-      eauto.
-      eauto.
-      eauto.
-      eauto.
+      qeauto.
+      qeauto.
+      qeauto.
+      qeauto.
   Qed.
 
   Lemma PTmapall_let_inv τc {Γ : tbindings} {τ₁ τ₂ : rtype} {p : camp} :
@@ -1473,7 +1473,7 @@ Section TcNNRCtoCAMP.
     t. subst. eauto.
   Qed.
 
-  Hint Resolve merge_bindings_sorted.
+  Hint Resolve merge_bindings_sorted : qcert.
 
   Lemma nnrcToCamp_ns_type_weaken_let_binding τc b x xv τ₁ τ₂ n :
     nnrcIsCore n ->
@@ -1488,9 +1488,9 @@ Section TcNNRCtoCAMP.
                          ((let_var x, xv)::nil))] |= (nnrcToCamp_ns n) ; τ₁ ~> τ₂ ->
                                                                         [τc&b] |= (nnrcToCamp_ns n) ; τ₁ ~> τ₂.
   Proof.
-    Hint Resolve loop_let_var_distinct.
-    Hint Resolve rec_concat_sort_sorted.
-    Hint Resolve drec_concat_sort_sorted.
+    Hint Resolve loop_let_var_distinct : qcert.
+    Hint Resolve rec_concat_sort_sorted : qcert.
+    Hint Resolve drec_concat_sort_sorted : qcert.
 
     intro Hiscore.
     revert Hiscore b x xv τ₁ τ₂.
@@ -1500,12 +1500,12 @@ Section TcNNRCtoCAMP.
     - simpl in *. t. econstructor; eauto.
     - simpl in *.
       t.
-      repeat econstructor; eauto.
-      rewrite tdot_rec_concat_sort_neq in H7; [idtac|eauto].
+      repeat econstructor; qeauto.
+      rewrite tdot_rec_concat_sort_neq in H7; [idtac|qeauto].
       rewrite sort_sorted_is_id in H7; eauto.
-    - simpl in *; t; eauto.
-    - simpl in *; simpt;  t; eauto.
-    - simpl in *; simpt;  t; eauto.
+    - simpl in *; t; qeauto.
+    - simpl in *; simpt;  t; qeauto.
+    - simpl in *; simpt;  t; qeauto.
     - simpl in Hiscore;
       elim Hiscore; clear Hiscore; intros Hcore1 Hcore2;
       specialize (IHn1 Hcore1); specialize (IHn2 Hcore2).
@@ -1513,11 +1513,10 @@ Section TcNNRCtoCAMP.
       econstructor; eauto.
       destruct x0; simpl in *; subst.
       econstructor.
-      + econstructor; eauto.
+      + econstructor; qeauto.
       + rewrite merge_bindings_single_nin; [reflexivity|idtac].
         eauto.
-      + eapply IHn2; eauto 2;  unfold rec_concat_sort.
-        * apply (drec_sort_sorted (odt:=ODT_string)).
+      + eapply IHn2; eauto 2 with qcert;  unfold rec_concat_sort.
         * autorewrite with fresh_bindings.
           simpl.
           autorewrite with fresh_bindings.
@@ -1532,7 +1531,7 @@ Section TcNNRCtoCAMP.
           apply in_map_iff in inn2.
           destruct inn2 as [? [? ?]].
           apply loop_var_inj in H11; subst. eauto.
-        * eauto.
+        * qeauto.
         * intros inn.
           rewrite in_dom_rec_sort, domain_app, in_app_iff in inn.
           simpl in inn. intuition.
@@ -1555,19 +1554,18 @@ Section TcNNRCtoCAMP.
       elim Hiscore; clear Hiscore; intros Hcore1 Hcore2;
       specialize (IHn1 Hcore1); specialize (IHn2 Hcore2).
       simpl in *. simpt; t.
-      eapply PTmapall_inv in H20; eauto 2.
+      eapply PTmapall_inv in H20; eauto 2 with qcert.
       destruct H20 as [?[?[?[??]]]]; subst.
       econstructor; eauto.
-      eapply PTmapall; eauto.
+      eapply PTmapall; qeauto.
       econstructor.
-      + econstructor; eauto.
+      + econstructor; qeauto.
       + rewrite merge_bindings_single_nin; [reflexivity|idtac].
         eauto.
-      + t. 
+      + t.
         destruct x0; simpl in *; subst.
         intuition.
-        eapply IHn2; eauto 2;  unfold rec_concat_sort.
-        * apply (drec_sort_sorted (odt:=ODT_string)).
+        eapply IHn2; eauto 2 with qcert; unfold rec_concat_sort.
         * autorewrite with fresh_bindings.
           simpl.
           autorewrite with fresh_bindings.
@@ -1581,7 +1579,7 @@ Section TcNNRCtoCAMP.
           subst.
           apply in_map_iff in inn2.
           destruct inn2 as [? [? ?]].
-          apply loop_var_inj in H12; subst. eauto.
+          apply loop_var_inj in H12; subst. qeauto.
         * intros inn.
           repeat rewrite in_app_iff in H11; simpl in H11.
           intuition.
@@ -1611,14 +1609,14 @@ Section TcNNRCtoCAMP.
       specialize (IHn1 Hcore1); specialize (IHn2 Hcore2); specialize (IHn3 Hcore3).
       simpl in *. simpt; t.
       unfold rec_concat_sort in *.
-      rewrite sort_sorted_is_id in H27,H31 by auto.
+      rewrite sort_sorted_is_id in H27,H31 by qauto.
       econstructor.
-      + econstructor; [eauto|..].
+      + econstructor; [qeauto|..].
         rewrite merge_bindings_nil_r. reflexivity.
         inversion H35; subst.
         rewrite sort_sorted_is_id by auto.
         eauto.
-      + econstructor; [eauto|..].
+      + econstructor; [qeauto|..].
         rewrite merge_bindings_nil_r. reflexivity.
         inversion H35; subst.
         rewrite sort_sorted_is_id by auto.
@@ -1642,12 +1640,12 @@ Section TcNNRCtoCAMP.
       apply not_or in GG1.
       destruct GG1 as [??].
       econstructor.
-      + econstructor; [eauto|idtac].
+      + econstructor; [qeauto|idtac].
         econstructor.
         * repeat econstructor.
         * rewrite merge_bindings_single_nin; try reflexivity.
           eauto.
-        * { eapply IHn2; trivial.
+        * { eapply IHn2; qtrivial.
             - apply (drec_concat_sort_sorted (odt:=ODT_string)).
             - unfold rec_concat_sort.
               autorewrite with fresh_bindings; simpl.
@@ -1658,7 +1656,7 @@ Section TcNNRCtoCAMP.
               destruct inn as [?|[?|?]]; subst; eauto 2.
               rewrite in_map_iff.
               intros [?[injj ?]]; apply loop_var_inj in injj; subst; eauto.
-            - eauto.
+            - qeauto.
             - eauto.
             - unfold rec_concat_sort. intros inn.
               rewrite in_dom_rec_sort, domain_app, in_app_iff in inn.
@@ -1680,15 +1678,15 @@ Section TcNNRCtoCAMP.
                 - repeat rewrite in_app_iff; simpl.
                   intros [?|[?|?]]; eauto 2.
                 - rewrite Permutation_app_comm; simpl.
-                  auto.
+                  qauto.
               }
           } 
-      + econstructor; [eauto|idtac].
+      + econstructor; [qeauto|idtac].
         econstructor.
         * repeat econstructor.
         * rewrite merge_bindings_single_nin; try reflexivity.
           eauto.
-        * { eapply IHn3; trivial.
+        * { eapply IHn3; qtrivial.
             - apply (drec_concat_sort_sorted (odt:=ODT_string)).
             - unfold rec_concat_sort.
               autorewrite with fresh_bindings; simpl.
@@ -1698,7 +1696,7 @@ Section TcNNRCtoCAMP.
               simpl in inn.
               destruct inn as [?|[?|?]]; subst; eauto 2.
               rewrite in_map_iff. intros [?[injj ?]]; apply loop_var_inj in injj; subst; eauto.
-            - eauto.
+            - qeauto.
             - eauto.
             - unfold rec_concat_sort. intros inn.
               rewrite in_dom_rec_sort, domain_app, in_app_iff in inn.
@@ -1719,16 +1717,16 @@ Section TcNNRCtoCAMP.
                 - repeat rewrite in_app_iff; simpl.
                   intros [?|[?|?]]; eauto 2.
                 - rewrite Permutation_app_comm; simpl.
-                  auto.
+                  qauto.
               }
           }
           Grab Existential Variables.
           eauto.
           eauto.
-          eauto.
-          eauto.
-          eauto.
-          eauto.
+          qeauto.
+          qeauto.
+          qeauto.
+          qeauto.
           eauto.
   Qed.
 
@@ -1759,11 +1757,11 @@ Section TcNNRCtoCAMP.
       specialize (IHn1 Hcore1); specialize (IHn2 Hcore2).
       inversion 1; subst; simpl in freshb, shf, ninb;
       autorewrite with fresh_bindings in freshb;
-      simpt; t; eauto.
+      simpt; t; qeauto.
     - specialize (IHn Hiscore).
       inversion 1; subst; simpl in freshb, shf, ninb;
       autorewrite with fresh_bindings in freshb;
-      simpt; t; eauto.
+      simpt; t; qeauto.
     - simpl in Hiscore;
       elim Hiscore; clear Hiscore; intros Hcore1 Hcore2;
       specialize (IHn1 Hcore1); specialize (IHn2 Hcore2).
@@ -1772,7 +1770,7 @@ Section TcNNRCtoCAMP.
       simpt; t; eauto.
       destruct x; destruct x0; simpl in *; subst.
       repeat econstructor; eauto.
-      eapply IHn2; eauto.
+      eapply IHn2; qeauto.
       * repeat defresh.
         unfold rec_concat_sort.
         autorewrite with fresh_bindings.
@@ -1833,7 +1831,7 @@ Section TcNNRCtoCAMP.
                 apply loop_var_inj in H16; subst.
                 eauto.
           }            
-        * eauto 2.
+        * eauto 2 with qcert.
         * econstructor.
           { econstructor.
             - econstructor.
@@ -1870,10 +1868,10 @@ Section TcNNRCtoCAMP.
       specialize (IHn1 Hcore1); specialize (IHn2 Hcore2); specialize (IHn3 Hcore3).
       inversion 1; subst; simpl in freshb, shf, ninb;
       autorewrite with fresh_bindings in freshb;
-      simpt; t; eauto.
+      simpt; t; qeauto.
       specialize (H9 _ (eq_refl _)).
       destruct x; destruct x0; simpl in *; subst.
-      rewrite sort_sorted_is_id in H26,H30,H39,H43 by eauto.
+      rewrite sort_sorted_is_id in H26,H30,H39,H43 by qeauto.
       inversion H22; subst.
       inversion H33; subst.
       t.
@@ -1884,9 +1882,9 @@ Section TcNNRCtoCAMP.
       rewrite tdot_rec_concat_sort_eq in H2 by eauto.
       t.
       econstructor.
-      + econstructor; [eauto|..].
+      + econstructor; [qeauto|..].
         rewrite merge_bindings_nil_r. rewrite sort_sorted_is_id by eauto. reflexivity.
-        eapply nnrcToCamp_ns_type_weaken_let_binding; eauto.
+        eapply nnrcToCamp_ns_type_weaken_let_binding; qeauto.
         * apply fresh_bindings_let_to_naive; auto.
         * intro inn.
           apply (fresh_let_var_fresh "if$" (let_vars (nnrcToCamp_ns_let n1) ++
@@ -1920,10 +1918,10 @@ Section TcNNRCtoCAMP.
           intuition; subst; eauto.
           apply in_map_iff in inn2.
           destruct inn2 as [? [??]]. eapply loop_let_var_distinct; eauto.
-      + econstructor; [eauto|..].
+      + econstructor; [qeauto|..].
         rewrite merge_bindings_nil_r.
         rewrite sort_sorted_is_id by eauto. reflexivity.
-        eapply nnrcToCamp_ns_type_weaken_let_binding; eauto 3.
+        eapply nnrcToCamp_ns_type_weaken_let_binding; eauto 3 with qcert.
         * apply fresh_bindings_let_to_naive; auto.
         * intro inn.
           apply (fresh_let_var_fresh "if$" (let_vars (nnrcToCamp_ns_let n1) ++
@@ -1965,9 +1963,9 @@ Section TcNNRCtoCAMP.
       autorewrite with fresh_bindings in freshb;
       simpt; t; eauto.
       destruct x; destruct x0; destruct x1; destruct x2; simpl in *; subst.
-      econstructor; [eauto | ].
+      econstructor; [qeauto | ].
       econstructor.
-      + econstructor; [eauto | ].
+      + econstructor; [qeauto | ].
         econstructor.
         * repeat econstructor.
         * eauto.
@@ -1985,7 +1983,7 @@ Section TcNNRCtoCAMP.
               rewrite in_map_iff.
               intros [?[injj ?]]; apply loop_var_inj in injj; subst; eauto.
           }
-      + econstructor; [eauto | ].
+      + econstructor; [qeauto | ].
         econstructor.
         * repeat econstructor.
         * eauto.
@@ -2007,11 +2005,11 @@ Section TcNNRCtoCAMP.
       Grab Existential Variables.
       eauto.
       eauto.
+      qeauto.
       eauto.
+      qeauto.
       eauto.
-      eauto.
-      eauto.
-      eauto.
+      qeauto.
       eauto.
   Qed.
 
@@ -2026,7 +2024,7 @@ Section TcNNRCtoCAMP.
     generalize (unshadow_simpl_preserve_core (domain Γ) n Hiscore); intros.
     unfold cNNRCShadow.unshadow_simpl in *.
     eapply nnrc_core_unshadow_type.
-    eapply (nnrc_to_camp_ns_type_preserve_back); trivial.
+    eapply (nnrc_to_camp_ns_type_preserve_back); qtrivial.
     - apply unshadow_preserve_core; assumption.
     - apply unshadow_shadow_free.
     - apply unshadow_avoid.
@@ -2069,9 +2067,9 @@ Section TcNNRCtoCAMP.
     (nnrc_core_type τc Γ n τout <->
     [τc&(nnrc_to_camp_env Γ)]  |= (nnrcToCamp_let (domain Γ) n) ; τ₀ ~> τout).
    Proof.
-     Hint Resolve nnrc_to_camp_let_type_preserve.
-     Hint Resolve nnrc_to_camp_let_type_preserve_back.
-     intuition; eauto.
+     Hint Resolve nnrc_to_camp_let_type_preserve : qcert.
+     Hint Resolve nnrc_to_camp_let_type_preserve_back : qcert.
+     intuition; qeauto.
    Qed.
 
 End TcNNRCtoCAMP.

--- a/compiler/core/Translation/Typing/TcNNRCtoCAMP.v
+++ b/compiler/core/Translation/Typing/TcNNRCtoCAMP.v
@@ -26,7 +26,10 @@ Require Import DataSystem.
 Require Import cNNRCSystem.
 Require Import CAMPSystem.
 Require Import cNNRCtoCAMP.
-  
+
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section TcNNRCtoCAMP.
 
   (** Auxiliary definitions and lemmas *)

--- a/compiler/core/Translation/Typing/TcNRAEnvtocNNRC.v
+++ b/compiler/core/Translation/Typing/TcNRAEnvtocNNRC.v
@@ -93,35 +93,35 @@ Section TcNRAEnvtocNNRC.
       apply (@type_cNNRCFor m _ τ); [apply (IHnraenv_core_type2 vid venv tenv )|idtac]; trivial.
       apply type_cNNRCIf.
       + apply IHnraenv_core_type1; simpl; trivial; match_destr; elim_fresh e.
-      + econstructor; eauto.
+      + econstructor; qeauto.
         econstructor. simpl.
         match_destr; intuition.
       + econstructor. simpl. repeat econstructor.
     (* cNRAEnvDefault *)
-    - econstructor; eauto.
-      econstructor; eauto.
-      econstructor; eauto.
-      econstructor; eauto.
+    - econstructor; qeauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
       + simpl. match_destr; congruence.
-      + econstructor. econstructor; eauto.
-        econstructor; eauto.
-        econstructor; eauto.
+      + econstructor. econstructor; qeauto.
+        econstructor; qeauto.
+        econstructor; qeauto.
         eapply Forall_nil.
       + apply IHnraenv_core_type2; simpl; trivial; match_destr; elim_fresh e.
-      + econstructor; eauto.
+      + econstructor; qeauto.
         simpl; match_destr; elim_fresh e.
     (* cNRAEnvEither *)
     - econstructor.
-      + econstructor; eauto.
+      + econstructor; qeauto.
       + eapply IHnraenv_core_type1; simpl; trivial; match_destr; try elim_fresh e.
       + eapply IHnraenv_core_type2; simpl; trivial; match_destr; try elim_fresh e.
     (* cNRAEnvEitherConcat *)
-    - econstructor; [eauto | ].
+    - econstructor; [qeauto | ].
       econstructor.
       + eapply IHnraenv_core_type1; simpl; trivial; match_destr; try elim_fresh e.
-      + econstructor; [eauto | ].
-        econstructor; eauto.
-        econstructor; eauto.
+      + econstructor; [qeauto | ].
+        econstructor; qeauto.
+        econstructor; qeauto.
         simpl.
         match_destr; try congruence.
         econstructor. simpl.
@@ -129,7 +129,7 @@ Section TcNRAEnvtocNNRC.
         * symmetry in e; elim_fresh e.
         * match_destr; try congruence.
       + econstructor; [econstructor | ].
-        econstructor. econstructor. eauto.
+        econstructor. econstructor. qeauto.
         * econstructor; simpl.
           match_destr; try congruence.
         * econstructor; simpl.
@@ -138,7 +138,7 @@ Section TcNRAEnvtocNNRC.
             - match_destr; try congruence.
           }
     (* cNRAEnvApp *)
-    - repeat (econstructor; eauto 2).
+    - repeat (econstructor; eauto 2 with qcert).
       apply IHnraenv_core_type2; simpl; trivial.
       + simpl; match_destr; intuition.
       + simpl; match_destr.
@@ -146,10 +146,10 @@ Section TcNRAEnvtocNNRC.
     (* cNRAEnvEnv *)
     - apply type_cNNRCVar; assumption.
     (* cNRAEnvAppEnv *)
-    - repeat (econstructor; eauto 2).
+    - repeat (econstructor; eauto 2 with qcert).
       apply IHnraenv_core_type2; simpl; trivial; match_destr; elim_fresh e.
     (* cNRAEnvMapEnv *)
-    - repeat econstructor; eauto 2.
+    - repeat econstructor; eauto 2 with qcert.
       apply IHnraenv_core_type; simpl; trivial; match_destr; elim_fresh e.
   Qed.
 
@@ -161,7 +161,7 @@ Section TcNRAEnvtocNNRC.
     nnrc_core_type τconstants tenv (nraenv_core_to_nnrc_core op vid venv) τout ->
     (op ▷ τin >=> τout ⊣ τconstants;τenv).
   Proof.
-    Hint Constructors nraenv_core_type.
+    Hint Constructors nraenv_core_type : qcert.
     intros.
     revert τin τenv τout vid venv tenv H H0 H1.
     nraenv_core_cases (induction op) Case; simpl; intros; inversion H1; subst.
@@ -169,13 +169,13 @@ Section TcNRAEnvtocNNRC.
       econstructor.
       eauto.
     - Case "cNRAEnvID"%string.
-      rewrite H in H4; inversion H4; subst. eauto.
+      rewrite H in H4; inversion H4; subst. qeauto.
     - Case "cNRAEnvConst"%string.
-      eauto.
+      qeauto.
     - Case "cNRAEnvBinop"%string.
-      eauto. 
+      qeauto. 
     - Case "cNRAEnvUnop"%string.
-      eauto.
+      qeauto.
     - Case "cNRAEnvMap"%string.
       econstructor; eauto 2.
       eapply (IHop1 _ _ _ (fresh_var "tmap$" [vid; venv])
@@ -305,7 +305,7 @@ Section TcNRAEnvtocNNRC.
       eapply (IHop1 _ _ _ (fresh_var "tapp$" [vid; venv]) venv ((fresh_var "tapp$" [vid; venv], τ₁) :: tenv)); simpl; trivial;
         try (match_destr; try elim_fresh e).
     - Case "cNRAEnvEnv"%string.
-      rewrite H0 in H4; inversion H4; subst; eauto.
+      rewrite H0 in H4; inversion H4; subst; qeauto.
     - Case "cNRAEnvAppEnv"%string.
       inversion H; subst; clear H.
       econstructor; eauto 2.
@@ -331,8 +331,8 @@ Section TcNRAEnvtocNNRC.
     nnrc_core_type τconstants tenv (nraenv_core_to_nnrc_core op vid venv) τout ->
     (op ▷ τin >=> τout ⊣ τconstants;τenv).
   Proof.
-    Hint Resolve tnraenv_sem_correct tnraenv_sem_correct_back.
-    intuition; eauto.
+    Hint Resolve tnraenv_sem_correct tnraenv_sem_correct_back : qcert.
+    intuition; qeauto.
   Qed.
 
 End TcNRAEnvtocNNRC.

--- a/compiler/core/Translation/Typing/TcNRAEnvtocNNRC.v
+++ b/compiler/core/Translation/Typing/TcNRAEnvtocNNRC.v
@@ -23,6 +23,9 @@ Require Import cNRAEnvSystem.
 Require Import cNNRCSystem.
 Require Import cNRAEnvtocNNRC.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section TcNRAEnvtocNNRC.
   (** Type preservation for the translation from NRA to NNRC *)
 

--- a/compiler/core/TypeSystem/RConsistentSubtype.v
+++ b/compiler/core/TypeSystem/RConsistentSubtype.v
@@ -29,7 +29,7 @@ Section RConsistentSubtype.
   Context {ftype:foreign_type}.
   Context {br:brand_relation}.
 
-Hint Constructors subtype.
+Hint Constructors subtype : qcert.
 
 Section rtype_join_meet.
   
@@ -136,35 +136,35 @@ Proof.
       * subst. simpl in H.
         simpl in awf',bwf'. repeat rewrite andb_true_iff in awf',bwf'.
         intuition.
-       destruct (to_Rec k ((s0,r) :: rl1) awf).
-       destruct (to_Rec k2 ((s0,r0):: rl2) bwf).
-       rewrite H8, H12 in H0.
-
-       generalize (Rec_subtype_cons_inv H0); intros [pf' [pf'' subinv]].
-       specialize (IHrl1 rl2 H6 awf'' bwf'').
-       simpl in H3.
-       f_equal.
-       f_equal.
-       apply  (H3 H9 _ H2).
-       apply Rec_subtype_cons_eq in H0.
-       destruct r; destruct r0; simpl.
-       eapply subtype_ext; eauto.
-       etransitivity; [|eapply IHrl1].
-       apply (@map_rtype_join₀_lookup_none2 ftype br).
-       apply lookup_nin_none.
-       intro inn.
-       unfold domain in inn; rewrite map_map in inn.
-       simpl in inn.
-       rewrite (map_eq (g:=fst)) in inn by (rewrite Forall_forall; trivial).
-       generalize x; intros isl;
-       apply is_list_sorted_NoDup in isl; [|eapply StringOrder.lt_strorder].
-       inversion isl; subst. intuition.
-       eapply subtype_ext; eauto.
-       inversion subinv; subst; rtype_equalizer.
-       subst; eauto.       
-       subst; eauto.
-       intuition; subst.
-       eapply (SRec_closed_equiv_domain subinv); trivial.
+        destruct (to_Rec k ((s0,r) :: rl1) awf).
+        destruct (to_Rec k2 ((s0,r0):: rl2) bwf).
+        rewrite H8, H12 in H0.
+        
+        generalize (Rec_subtype_cons_inv H0); intros [pf' [pf'' subinv]].
+        specialize (IHrl1 rl2 H6 awf'' bwf'').
+        simpl in H3.
+        f_equal.
+        -- f_equal.
+           apply  (H3 H9 _ H2).
+           apply Rec_subtype_cons_eq in H0.
+           destruct r; destruct r0; simpl.
+           eapply subtype_ext; eauto.
+        -- etransitivity; [|eapply IHrl1].
+           ++ apply (@map_rtype_join₀_lookup_none2 ftype br).
+              apply lookup_nin_none.
+              intro inn.
+              unfold domain in inn; rewrite map_map in inn.
+              simpl in inn.
+              rewrite (map_eq (g:=fst)) in inn by (rewrite Forall_forall; trivial).
+              generalize x; intros isl;
+                apply is_list_sorted_NoDup in isl; [|eapply StringOrder.lt_strorder].
+              inversion isl; subst. intuition.
+           ++ eapply subtype_ext; eauto.
+           ++ inversion subinv; subst; rtype_equalizer.
+              ** subst; qeauto.
+              ** subst; qeauto.
+           ++ intuition; subst.
+              eapply (SRec_closed_equiv_domain subinv); trivial.
      * generalize (H4 s0 r0); simpl.
        destruct (string_dec s0 s0);  [|intuition].
        destruct (string_dec s0 s);  [congruence|].
@@ -343,8 +343,8 @@ Proof.
               (fun x : string * {τ₀ : rtype₀ | wf_rtype₀ τ₀ = true} =>
                  (fst x, proj1_sig (snd x))) rl2)); intros eqq.
              rewrite eqq.
-             generalize awf; simpl; rewrite andb_true_iff; intuition eauto 2.
-          - generalize awf; simpl; rewrite andb_true_iff; intuition eauto 2. 
+             generalize awf; simpl; rewrite andb_true_iff; intuition eauto 2 with qcert.
+          - generalize awf; simpl; rewrite andb_true_iff; intuition eauto 2 with qcert. 
           - intros s.
             {
               case_eq ( lookup string_dec
@@ -496,10 +496,10 @@ Proof.
        generalize x; intros isl;
        apply is_list_sorted_NoDup in isl; [|eapply StringOrder.lt_strorder].
        inversion isl; subst. intuition.
-       eapply subtype_ext; eauto.
+       eapply subtype_ext; qeauto.
        inversion subinv; subst; rtype_equalizer.
-       subst; eauto.       
-       subst; eauto.
+       subst; qeauto.       
+       subst; qeauto.
        intuition; subst.
        eapply (SRec_closed_equiv_domain subinv); trivial.
      * generalize (H4 s0 r0); simpl.
@@ -676,8 +676,8 @@ Proof.
               (fun x : string * {τ₀ : rtype₀ | wf_rtype₀ τ₀ = true} =>
                  (fst x, proj1_sig (snd x))) rl2)); intros eqq.
              rewrite eqq.
-             generalize bwf; simpl; rewrite andb_true_iff; intuition eauto 2.
-          - generalize bwf; simpl; rewrite andb_true_iff; intuition eauto 2. 
+             generalize bwf; simpl; rewrite andb_true_iff; intuition eauto 2 with qcert.
+          - generalize bwf; simpl; rewrite andb_true_iff; intuition eauto 2 with qcert. 
           - intros s.
             {
               case_eq ( lookup string_dec
@@ -910,7 +910,7 @@ Lemma consistent_rtype_join_meet2:
   forall a b,  (rtype_join a b = b -> subtype a b)
                /\ (rtype_meet a b = a -> subtype a b).
 Proof.
-  Hint Resolve STop₀ SBottom₀ SColl₀.
+  Hint Resolve STop₀ SBottom₀ SColl₀ : qcert.
   destruct a as [a awf]; destruct b as [b bwf].
   unfold rtype_join, rtype_meet; simpl.
 
@@ -932,9 +932,9 @@ Proof.
                      intuition;
                      inversion H;
                      destruct b; try discriminate;
-                     eapply subtype_ext; eauto 3].
+                     eapply subtype_ext; eauto 3 with qcert].
   - intuition; simpl in *; inversion H; destruct b; try discriminate;
-      try solve [eapply subtype_ext; eauto];
+      try solve [eapply subtype_ext; qeauto];
       simpl in *;
         inversion H;
       repeat rewrite Coll_canon;
@@ -942,7 +942,7 @@ Proof.
       destruct (IHa awf b bwf) as [pf1 [pf2 [pf3 pf4]]];
       intuition.
   - repeat split.
-    + destruct b; unfold rtype_join₀; simpl; fold rtype_join₀; inversion 1; eauto 2.
+    + destruct b; unfold rtype_join₀; simpl; fold rtype_join₀; inversion 1; eauto 2 with qcert.
       clear H0.
       apply SRec₀;
         [| intros rc; apply record_kind_rtype_join_closed_inv in rc; intuition; congruence].
@@ -989,7 +989,7 @@ Proof.
     intros.
     rewrite (map_rtype_join₀_commutative Closed Closed (ftype:=ftype) (br:=br)) in eqsrl; auto.
     eauto.
-    + destruct b; unfold rtype_meet₀; simpl; fold rtype_meet₀; inversion 1; eauto 2.
+    + destruct b; unfold rtype_meet₀; simpl; fold rtype_meet₀; inversion 1; eauto 2 with qcert.
       clear H2.
     match_destr_in H0.
     inversion H0; clear H0.
@@ -997,10 +997,10 @@ Proof.
     + { intros s τ pfτ los.
         assert (ndr:NoDup (domain r))
                by (generalize awf bwf; simpl; repeat rewrite andb_true_iff; intros [??] [??];
-                   intuition eauto 2).
+                   intuition eauto 2 with qcert).
         assert (ndsrl:NoDup (domain srl))
                by (generalize awf bwf; simpl; repeat rewrite andb_true_iff; intros [??] [??];
-                   intuition eauto 2).
+                   intuition eauto 2 with qcert).
         case_eq (lookup string_dec r s).
         - intros τ2 lors.
           generalize lors; intros lors'.
@@ -1035,7 +1035,7 @@ Proof.
       destruct k; simpl in *; [ discriminate | ].
       rewrite r0; intuition.
     }
-    + destruct b; unfold rtype_join₀; simpl; fold rtype_join₀; inversion 1; eauto 2.
+    + destruct b; unfold rtype_join₀; simpl; fold rtype_join₀; inversion 1; eauto 2 with qcert.
       clear H0.
       apply SRec₀;
         [| intros rc; apply record_kind_rtype_join_closed_inv in rc; intuition; congruence].
@@ -1075,7 +1075,7 @@ Proof.
         apply eqq1 in inn.
         apply lookup_none_nin in r0'in.
         intuition.
-    + destruct b; unfold rtype_meet₀; simpl; fold rtype_meet₀; inversion 1; eauto 2.
+    + destruct b; unfold rtype_meet₀; simpl; fold rtype_meet₀; inversion 1; eauto 2 with qcert.
       clear H2.
     match_destr_in H0.
     inversion H0; clear H0.
@@ -1083,10 +1083,10 @@ Proof.
     + { intros s τ pfτ los.
         assert (ndr:NoDup (domain r))
                by (generalize awf bwf; simpl; repeat rewrite andb_true_iff; intros [??] [??];
-                   intuition eauto 2).
+                   intuition eauto 2 with qcert).
         assert (ndsrl:NoDup (domain srl))
                by (generalize awf bwf; simpl; repeat rewrite andb_true_iff; intros [??] [??];
-                   intuition eauto 2).
+                   intuition eauto 2 with qcert).
         case_eq (lookup string_dec srl s).
         - intros τ2 lors.
           generalize lors; intros lors'.
@@ -1122,7 +1122,7 @@ Proof.
       rewrite r0; intuition.
     }
   - simpl. intros.
-    destruct b; repeat split; try discriminate; eauto 2.
+    destruct b; repeat split; try discriminate; eauto 2 with qcert.
     + intros.
       destruct (Either₀_wf_inv awf) as [a1wf a2wf].
       destruct (Either₀_wf_inv bwf) as [b1wf b2wf].
@@ -1168,7 +1168,7 @@ Proof.
       * destruct (IHa2 a2wf _ b2wf) as [Hpf1 [Hpf2 [Hpf3 Hpf4]]].
         intuition.
   - simpl. intros.
-    destruct b; unfold rtype_meet₀, rtype_join₀; simpl; fold rtype_meet₀; fold rtype_join₀; repeat split; try discriminate; eauto 2.
+    destruct b; unfold rtype_meet₀, rtype_join₀; simpl; fold rtype_meet₀; fold rtype_join₀; repeat split; try discriminate; eauto 2 with qcert.
     + intros.
       destruct (Arrow₀_wf_inv awf) as [a1wf a2wf].
       destruct (Arrow₀_wf_inv bwf) as [b1wf b2wf].
@@ -1218,7 +1218,7 @@ Proof.
       * destruct (IHa2 a2wf _ b2wf) as [Hpf1 [Hpf2 [Hpf3 Hpf4]]].
         intuition.
   - simpl; intros.
-    destruct b0; unfold rtype_meet₀, rtype_join₀; simpl; fold rtype_meet₀; fold rtype_join₀; repeat split; try discriminate; eauto 2.
+    destruct b0; unfold rtype_meet₀, rtype_join₀; simpl; fold rtype_meet₀; fold rtype_join₀; repeat split; try discriminate; eauto 2 with qcert.
     + inversion 1.
       repeat rewrite brand_ext.
        apply SBrand.
@@ -1240,7 +1240,7 @@ Proof.
        apply brand_meet_consistent_can; trivial.
        apply wf_rtype₀_Brand₀; trivial.
   - simpl; intros.
-    destruct b; unfold rtype_meet₀, rtype_join₀; simpl; fold rtype_meet₀; fold rtype_join₀; repeat split; try discriminate; eauto 2.
+    destruct b; unfold rtype_meet₀, rtype_join₀; simpl; fold rtype_meet₀; fold rtype_join₀; repeat split; try discriminate; eauto 2 with qcert.
     + inversion 1.
       repeat rewrite Foreign_canon.
       apply SForeign.
@@ -1301,7 +1301,7 @@ Qed.
 
 Theorem consistent_rtype_join: forall a b, subtype a b <-> rtype_join a b = b.
 Proof.
-  Hint Resolve consistent_rtype_join1 consistent_rtype_join2.
+  Hint Resolve consistent_rtype_join1 consistent_rtype_join2 : qcert.
   intuition.
 Qed.
 
@@ -1337,7 +1337,7 @@ Qed.
  
   Theorem consistent_rtype_meet : forall a b, subtype a b <-> rtype_meet a b = a.
   Proof.
-    Hint Resolve consistent_rtype_meet1 consistent_rtype_meet2.
+    Hint Resolve consistent_rtype_meet1 consistent_rtype_meet2 : qcert.
     intuition.
   Qed.
   

--- a/compiler/core/TypeSystem/RSubtype.v
+++ b/compiler/core/TypeSystem/RSubtype.v
@@ -96,6 +96,8 @@ Qed.
   (** This follows trivially from the consistency of join and subtype.
       However, this version should have better computational properties.*)
 
+  Hint Constructors subtype : qcert.
+  
   Lemma subtype_both_dec x y :
     (prod ({subtype x y} + {~ subtype x y}) ({subtype y x} + {~ subtype y x})).
   Proof.
@@ -103,22 +105,21 @@ Qed.
             | [H:(@eq bool ?x ?x) |- _ ] => generalize (UIP_refl_dec bool_dec H); intro; subst H
           end.
     destruct x.
-    Hint Constructors subtype.
     revert y; induction x
     ; intros y; destruct y as [y pfy]; destruct y; constructor;
-    try solve[right; inversion 1 | left; simpl in *; repeat simp; eauto ].
+    try solve[right; inversion 1 | left; simpl in *; repeat simp; eauto with qcert ].
     - destruct (IHx e (exist _ y pfy)) as [[?|?]_].
       + left. repeat rewrite (Coll_canon).
-        auto.
+        auto with qcert.
       + right. intro ss; apply n. inversion ss; subst.
-         * erewrite (rtype_ext); eauto.
+         * erewrite (rtype_ext); eauto with qcert.
          * destruct r1; destruct r2; simpl in *.
            erewrite (rtype_ext e); erewrite (rtype_ext pfy); eauto.
     - destruct (IHx e (exist _ y pfy)) as [_[?|?]].
       + left. repeat rewrite (Coll_canon).
-        auto.
+        auto with qcert.
       + right. intro ss; apply n. inversion ss; subst.
-         * erewrite (rtype_ext); eauto.
+         * erewrite (rtype_ext); eauto with qcert.
          * destruct r1; destruct r2; simpl in *.
            erewrite (rtype_ext e); erewrite (rtype_ext pfy); eauto.
     - rename srl into srl0; rename r into srl.
@@ -197,7 +198,7 @@ Qed.
              unfold domain; repeat rewrite map_map.
              simpl.
              auto.
-        * right; inversion 1; apply n; rtype_equalizer; subst; eauto.
+        * right; inversion 1; apply n; rtype_equalizer; subst; eauto with qcert.
           intros.
           rewrite <- (lookup_map_some' _ _ _ pf') in H1.
           destruct (H4 _ _ H1) as [? [??]].
@@ -291,7 +292,7 @@ Qed.
                  simpl.
                  auto.
           } 
-        * right; inversion 1; apply n; rtype_equalizer; subst; eauto.
+        * right; inversion 1; apply n; rtype_equalizer; subst; eauto with qcert.
           intros.
           rewrite <- (lookup_map_some' _ _ _ pf') in H1.
           destruct (H4 _ _ H1) as [? [??]].
@@ -306,26 +307,26 @@ Qed.
         * left.
           rewrite (Either_canon _ _ _ pfl1 pfr1).
           rewrite (Either_canon _ _ _ pfl2 pfr2).
-          eauto.
+          eauto with qcert.
         * right; inversion 1; subst.
-            apply n. rewrite (rtype_ext pfr1 pfr2). eauto.
+            apply n. rewrite (rtype_ext pfr1 pfr2). eauto with qcert.
             rewrite (Either_canon _ _ _ pfl1 pfr1) in H.
             rewrite (Either_canon _ _ _ pfl2 pfr2) in H.
             apply n.
             inversion H; rtype_equalizer; subst.
-              rewrite (rtype_ext pfr1 pfr2). eauto.
+              rewrite (rtype_ext pfr1 pfr2). eauto with qcert.
               subst.
               rewrite (rtype_ext pfr1 (proj2_sig r1)).
               rewrite (rtype_ext pfr2 (proj2_sig r2)).
               destruct r1; destruct r2. simpl in *.
               trivial.
       + right; inversion 1; subst.
-         apply n. rewrite (rtype_ext pfl1 pfl2). eauto.
+         apply n. rewrite (rtype_ext pfl1 pfl2). eauto with qcert.
             rewrite (Either_canon _ _ _ pfl1 pfr1) in H.
             rewrite (Either_canon _ _ _ pfl2 pfr2) in H.
             apply n.
             inversion H. rtype_equalizer.
-              subst. rewrite (rtype_ext pfl1 pfl2). eauto.
+              subst. rewrite (rtype_ext pfl1 pfl2). eauto with qcert.
 
             subst.
             rewrite (rtype_ext pfl1 (proj2_sig l1)).
@@ -339,14 +340,14 @@ Qed.
         * left.
           rewrite (Either_canon _ _ _ pfl1 pfr1).
           rewrite (Either_canon _ _ _ pfl2 pfr2).
-          eauto.
+          eauto with qcert.
         * right; inversion 1; subst.
-            apply n. rewrite (rtype_ext pfr1 pfr2). eauto.
+            apply n. rewrite (rtype_ext pfr1 pfr2). eauto with qcert.
             rewrite (Either_canon _ _ _ pfl1 pfr1) in H.
             rewrite (Either_canon _ _ _ pfl2 pfr2) in H.
             apply n.
             { inversion H; rtype_equalizer; subst.
-              - rewrite (rtype_ext pfr1 pfr2). eauto.
+              - rewrite (rtype_ext pfr1 pfr2). eauto with qcert.
               - subst.
               rewrite (rtype_ext pfr2 (proj2_sig r1)).
               rewrite (rtype_ext pfr1 (proj2_sig r2)).
@@ -354,12 +355,12 @@ Qed.
               trivial.
             } 
       + right; inversion 1; subst.
-         apply n. rewrite (rtype_ext pfl1 pfl2). eauto.
+         apply n. rewrite (rtype_ext pfl1 pfl2). eauto with qcert.
             rewrite (Either_canon _ _ _ pfl1 pfr1) in H.
             rewrite (Either_canon _ _ _ pfl2 pfr2) in H.
             apply n.
             inversion H. rtype_equalizer.
-              subst. rewrite (rtype_ext pfl1 pfl2). eauto.
+              subst. rewrite (rtype_ext pfl1 pfl2). eauto with qcert.
 
             subst.
             rewrite (rtype_ext pfl2 (proj2_sig l1)).
@@ -375,24 +376,24 @@ Qed.
           rewrite (Arrow_canon _ _ _ pfl2 pfr2).
           econstructor; eauto.
         * right; inversion 1; subst.
-            apply n. rewrite (rtype_ext pfr1 pfr2). eauto.
+            apply n. rewrite (rtype_ext pfr1 pfr2). eauto with qcert.
             rewrite (Arrow_canon _ _ _ pfl1 pfr1) in H.
             rewrite (Arrow_canon _ _ _ pfl2 pfr2) in H.
             apply n.
             inversion H; rtype_equalizer; subst.
-              rewrite (rtype_ext pfr1 pfr2). eauto.
+              rewrite (rtype_ext pfr1 pfr2). eauto with qcert.
               subst.
               rewrite (rtype_ext pfr1 (proj2_sig out1)).
               rewrite (rtype_ext pfr2 (proj2_sig out2)).
               destruct out1; destruct out2. simpl in *.
               trivial.
       + right; inversion 1; subst.
-         apply n. rewrite (rtype_ext pfl1 pfl2). eauto.
+         apply n. rewrite (rtype_ext pfl1 pfl2). eauto with qcert.
             rewrite (Arrow_canon _ _ _ pfl1 pfr1) in H.
             rewrite (Arrow_canon _ _ _ pfl2 pfr2) in H.
             apply n.
             inversion H. rtype_equalizer.
-            subst. rewrite (rtype_ext pfl1 pfl2). eauto.
+            subst. rewrite (rtype_ext pfl1 pfl2). eauto with qcert.
             rtype_equalizer.
             subst.
             rewrite (rtype_ext pfl1 (proj2_sig in1)).
@@ -408,24 +409,24 @@ Qed.
           rewrite (Arrow_canon _ _ _ pfl2 pfr2).
           econstructor; eauto.
         * right; inversion 1; subst.
-            apply n. rewrite (rtype_ext pfr1 pfr2). eauto.
+            apply n. rewrite (rtype_ext pfr1 pfr2). eauto with qcert.
             rewrite (Arrow_canon _ _ _ pfl1 pfr1) in H.
             rewrite (Arrow_canon _ _ _ pfl2 pfr2) in H.
             apply n.
             inversion H; rtype_equalizer; subst.
-              rewrite (rtype_ext pfr1 pfr2). eauto.
+              rewrite (rtype_ext pfr1 pfr2). eauto with qcert.
               subst.
               rewrite (rtype_ext pfr1 (proj2_sig out2)).
               rewrite (rtype_ext pfr2 (proj2_sig out1)).
               destruct out1; destruct out2. simpl in *.
               trivial.
       + right; inversion 1; subst.
-         apply n. rewrite (rtype_ext pfl1 pfl2). eauto.
+         apply n. rewrite (rtype_ext pfl1 pfl2). eauto with qcert.
             rewrite (Arrow_canon _ _ _ pfl1 pfr1) in H.
             rewrite (Arrow_canon _ _ _ pfl2 pfr2) in H.
             apply n.
             inversion H. rtype_equalizer.
-            subst. rewrite (rtype_ext pfl1 pfl2). eauto.
+            subst. rewrite (rtype_ext pfl1 pfl2). eauto with qcert.
             rtype_equalizer.
             subst.
             rewrite (rtype_ext pfl1 (proj2_sig in2)).
@@ -433,14 +434,14 @@ Qed.
             destruct in1; destruct in2. simpl in *.
               trivial.
     - destruct (sub_brands_dec brand_relation_brands b b0).
-      + left; repeat rewrite Brand_canon; eauto.
+      + left; repeat rewrite Brand_canon; eauto with qcert.
       + right. inversion 1; subst; eauto 2.
         * intuition.
         * apply n.
           repeat rewrite (canon_brands_equiv).
           trivial.
     - destruct (sub_brands_dec brand_relation_brands b0 b).
-      + left; repeat rewrite Brand_canon; eauto.
+      + left; repeat rewrite Brand_canon; eauto with qcert.
       + right. inversion 1; subst; eauto 2.
         * intuition.
         * apply n.

--- a/compiler/core/TypeSystem/RSubtypeProp.v
+++ b/compiler/core/TypeSystem/RSubtypeProp.v
@@ -42,16 +42,16 @@ Section RSubtypeProp.
            | [H: ⊤ <: ?z |- _] => apply top_subtype in H; subst
            end.
 
+  Hint Constructors subtype : qcert.
   Instance subtype_trans : Transitive subtype.
   Proof.
-    Hint Constructors subtype.
     red.
     intros x y.
     revert x.
-    induction y using rtype_rect; intros x z sub1 sub2; inversion sub1; subst; simpl_type; eauto.
-    - inversion sub2; subst; eauto.
-      rtype_equalizer. subst; eauto.
-    - inversion sub2; subst; eauto.
+    induction y using rtype_rect; intros x z sub1 sub2; inversion sub1; subst; simpl_type; eauto with qcert.
+    - inversion sub2; subst; eauto with qcert.
+      rtype_equalizer. subst; eauto with qcert.
+    - inversion sub2; subst; qeauto.
       rtype_equalizer. subst.
       constructor.
       + intros s' r' lsr'.
@@ -62,25 +62,25 @@ Section RSubtypeProp.
         simpl; intros P; eapply P; eauto.
         apply (lookup_in string_dec); trivial.
       + intuition.
-    - inversion sub2; subst; eauto.
-      rtype_equalizer. subst. eauto.
+    - inversion sub2; subst; qeauto.
+      rtype_equalizer. subst. qeauto.
     - rtype_equalizer. subst.
-      inversion sub2; subst; trivial.
+      inversion sub2; subst; trivial with qcert.
       rtype_equalizer. subst.
-      econstructor; eauto.
-    - inversion sub2; subst; trivial.
+      econstructor; qeauto.
+    - inversion sub2; subst; trivial with qcert.
       apply canon_equiv in H; apply canon_equiv in H0.
       rewrite H in H1.
       rewrite H0 in H2.
       constructor; etransitivity; eassumption.
-    - invcs sub2; trivial.
+    - invcs sub2; qtrivial.
       econstructor.
       transitivity ft; trivial.
   Qed.
 
   Global Instance subtype_pre : PreOrder subtype.
   Proof.
-    constructor; eauto.
+    constructor; qeauto.
     apply subtype_trans.
   Qed.
 
@@ -89,7 +89,7 @@ Section RSubtypeProp.
   Proof.
     apply SRec_open; intros.
     simpl.
-    case_eq (string_dec s0 s); [intros ? ?; subst | eauto].
+    case_eq (string_dec s0 s); [intros ? ?; subst | qeauto].
     assert False; [|intuition].
     rewrite domain_cons in pf.
     apply is_list_sorted_NoDup in pf; [|apply StringOrder.lt_strorder].
@@ -248,10 +248,10 @@ Section RSubtypeProp.
         * erewrite (Rec_pr_irrel _ _ pf'12).
           erewrite (Rec_pr_irrel _ _ (is_list_sorted_cons_inv ODT_lt_dec pf)).
           eauto.
-        * inversion sub'1; rtype_equalizer; subst; eauto.
-        * inversion sub'1; rtype_equalizer; subst; eauto.
-        * inversion sub'2; rtype_equalizer; subst; eauto.
-        * inversion sub'2; rtype_equalizer; subst; eauto.
+        * inversion sub'1; rtype_equalizer; subst; qeauto.
+        * inversion sub'1; rtype_equalizer; subst; qeauto.
+        * inversion sub'2; rtype_equalizer; subst; qeauto.
+        * inversion sub'2; rtype_equalizer; subst; qeauto.
     - inversion sub2; subst; trivial;
         rtype_equalizer; subst; trivial.
       subst. f_equal; eauto.

--- a/compiler/core/TypeSystem/RType.v
+++ b/compiler/core/TypeSystem/RType.v
@@ -333,6 +333,8 @@ Section RType.
        explicit pattern matching (it can still be written as a call to
        this induction principle) *)
 
+    Hint Constructors Forallt : qcert.
+
     Theorem rtype_rect (P : rtype -> Type)
             (ftop : P ⊤)
             (fbottom : P ⊥)
@@ -352,7 +354,6 @@ Section RType.
       :
       forall (τ:rtype), P τ.
     Proof.
-      Hint Constructors Forallt.
       destruct τ as [τ₀ wfτ].
       revert wfτ. (* ftop fbottom funit fnat fbool fstring fcol frec. *)
       unfold Top, Bottom, Unit, Nat, Float, Bool, String, Coll, Rec, Either, Arrow in *.
@@ -392,9 +393,9 @@ Section RType.
                      rewrite dreq; rewrite andb_true_iff in wfτ; intuition.
                      assert (pff:Forallt (fun ab : string * rtype => P (snd ab)) srl).
                      revert X. rewrite <- srleq. clear.
-                     induction srl; simpl; eauto.
+                     induction srl; simpl; eauto with qcert.
                      destruct a; destruct r; simpl.
-                     inversion 1; subst; eauto.
+                     inversion 1; subst; eauto with qcert.
                      specialize (frec k srl pfs pff).
                      destruct srleq.
                      erewrite (rtype_ext); eapply frec.
@@ -435,7 +436,6 @@ Section RType.
             (fforeign : forall ft, P (Foreign ft)) :
       forall (τ:rtype), P τ.
     Proof.
-      Hint Constructors Forallt.
       destruct τ as [τ₀ wfτ].
       revert wfτ. (* ftop fbottom funit fnat fbool fstring fcol frec. *)
       unfold Top, Bottom, Unit, Nat, Float, Bool, String, Coll, Rec in *.

--- a/compiler/core/TypeSystem/RTypeMeetJoin.v
+++ b/compiler/core/TypeSystem/RTypeMeetJoin.v
@@ -593,11 +593,11 @@ Proof.
             by (eapply is_list_sorted_cons_inv; eauto).
       { destruct k; simpl in IHr, compat.
         - specialize (IHr Open srl); simpl in IHr.
-          destruct IHr as [rs rwf]; trivial.
+          destruct IHr as [rs rwf]; qtrivial.
           unfold rec_concat_sort in rwf.
           apply forallb_rec_sort_inv in rwf.
           + rewrite forallb_app in rwf; intuition.
-          + apply NoDup_map_rtype_meet₀_lookup_diff; eauto.
+          + apply NoDup_map_rtype_meet₀_lookup_diff; eauto with qcert.
         - destruct k0; simpl in IHr, compat. 
           + inversion compat; subst.
             * destruct srl; simpl in H0; inversion H0.
@@ -617,13 +617,13 @@ Proof.
                     [ | eapply StringOrder.lt_strorder ].
                   simpl in sr_sort. inversion sr_sort; subst.
                   trivial.
-                - apply NoDup_map_rtype_meet₀_lookup_diff; eauto.
+                - apply NoDup_map_rtype_meet₀_lookup_diff; eauto with qcert.
               }
             * destruct (IHr Open srl); trivial.
               { unfold rec_concat_sort in H1.
                 apply forallb_rec_sort_inv in H1.
                 - rewrite forallb_app in H1; intuition.
-                - apply NoDup_map_rtype_meet₀_lookup_diff; eauto.
+                - apply NoDup_map_rtype_meet₀_lookup_diff; eauto with qcert.
               }
           + destruct srl; simpl in compat; inversion compat.
             destruct p; subst. simpl in H.
@@ -642,7 +642,7 @@ Proof.
                     [ | eapply StringOrder.lt_strorder ].
                   simpl in sr_sort. inversion sr_sort; subst.
                   trivial.
-                - apply NoDup_map_rtype_meet₀_lookup_diff; eauto.
+                - apply NoDup_map_rtype_meet₀_lookup_diff; eauto with qcert.
               }
       }
     + simpl; rewrite wfr0; simpl.
@@ -654,7 +654,7 @@ Proof.
           unfold rec_concat_sort in rwf.
           apply forallb_rec_sort_inv in rwf.
           + rewrite forallb_app in rwf; intuition.
-          + apply NoDup_map_rtype_meet₀_lookup_diff; eauto.
+          + apply NoDup_map_rtype_meet₀_lookup_diff; eauto with qcert.
         - destruct k0; simpl in IHr, compat. 
           + inversion compat; subst.
             * destruct srl; simpl in H0; inversion H0.
@@ -664,7 +664,7 @@ Proof.
               { unfold rec_concat_sort in H1.
                 apply forallb_rec_sort_inv in H1.
                 - rewrite forallb_app in H1; intuition.
-                - apply NoDup_map_rtype_meet₀_lookup_diff; eauto.
+                - apply NoDup_map_rtype_meet₀_lookup_diff; eauto with qcert.
               }
           + assert (ins:In s (s::domain r)) by (simpl; intuition).
              rewrite <- compat in ins.
@@ -964,7 +964,10 @@ Proof.
   apply rtype_meet₀_idempotent; trivial.
 Qed.
 
-Lemma map_rtype_join₀_idempotent k {rl1} :
+Hint Resolve rtype_join₀_idempotent : qcert.
+Hint Constructors Forallt : qcert.
+
+  Lemma map_rtype_join₀_idempotent k {rl1} :
   forall (wf1 : wf_rtype₀ (Rec₀ k rl1) = true),
        (fix map_rtype_join₀ (l1 l2 : list (string * rtype₀)) {struct l1} :
            list (string * rtype₀) :=
@@ -978,11 +981,9 @@ Lemma map_rtype_join₀_idempotent k {rl1} :
            end) rl1 rl1
        = rl1.
 Proof.
-  Hint Resolve rtype_join₀_idempotent.
-  Hint Constructors Forallt.
   intros; apply (map_rtype_join₀_idempotent' k); auto.
   clear wf1.
-  induction rl1; simpl; auto.
+  induction rl1; simpl; qauto.
 Qed.
   
  Lemma map_rtype_join₀_commutative' k₁ k₂ {rl1 rl2} :
@@ -1198,15 +1199,15 @@ Proof.
       unfold rec_concat_sort.
       simpl in *; rewrite andb_true_iff in *.
       apply drec_sort_perm_eq.
-      { apply NoDup_map_rtype_meet₀_lookup_diff; intuition; eauto 2. }
+      { apply NoDup_map_rtype_meet₀_lookup_diff; intuition; eauto 2 with qcert. }
       apply NoDup_Permutation.
-      { apply NoDup_domain_NoDup; apply NoDup_map_rtype_meet₀_lookup_diff; intuition; eauto 2. }
-      { apply NoDup_domain_NoDup; apply NoDup_map_rtype_meet₀_lookup_diff; intuition; eauto 2. }
+      { apply NoDup_domain_NoDup; apply NoDup_map_rtype_meet₀_lookup_diff; intuition; eauto 2 with qcert. }
+      { apply NoDup_domain_NoDup; apply NoDup_map_rtype_meet₀_lookup_diff; intuition; eauto 2 with qcert. }
       clear r0.
       destruct x.
       {
       split; (intros inn; apply (in_lookup_nodup string_dec) in inn;
-       [ | apply NoDup_map_rtype_meet₀_lookup_diff; intuition; eauto 2]);
+       [ | apply NoDup_map_rtype_meet₀_lookup_diff; intuition; eauto 2 with qcert]);
       rewrite lookup_app in inn;
       (match_case_in inn; [intros ? eqq | intros eqq]);
       rewrite eqq in inn.
@@ -1370,11 +1371,11 @@ Qed.
                end
            end) rl2 rl1.
 Proof.
-  Hint Resolve rtype_join₀_commutative.
-  Hint Constructors Forallt.
-  intros; apply (@map_rtype_join₀_commutative' Closed Closed); auto.
+  Hint Resolve rtype_join₀_commutative : qcert.
+  Hint Constructors Forallt : qcert.
+  intros; apply (@map_rtype_join₀_commutative' Closed Closed); qauto.
   clear wf1 wf2.
-  induction rl1; simpl; auto.
+  induction rl1; simpl; qauto.
 Qed.
 
 
@@ -1479,7 +1480,7 @@ Lemma map_rtype_join₀_domain_sublist a b :
                 end
             end) a b)) (domain a).
 Proof.
-  induction a; simpl; auto 1.
+  induction a; simpl; auto 1 with qcert.
   destruct a. destruct (lookup string_dec b s); simpl.
   - apply sublist_cons; auto.
   - apply sublist_skip; auto.
@@ -1789,7 +1790,7 @@ Proof.
               apply (is_list_sorted_NoDup ODT_lt_dec).
               eapply is_list_sorted_Sorted_iff.
               eapply insertion_sort_Sorted.
-            - eauto 2.
+            - eauto 2 with qcert.
           }
           apply (NoDup_domain_lookups_Permutation string_dec).
           {
@@ -1799,11 +1800,11 @@ Proof.
               apply (is_list_sorted_NoDup ODT_lt_dec).
               eapply is_list_sorted_Sorted_iff.
               eapply insertion_sort_Sorted.
-            - eauto 2.
+            - eauto 2 with qcert.
           }
           {
             apply NoDup_map_rtype_meet₀_lookup_diff.
-            - eauto 2.
+            - eauto 2 with qcert.
             - rewrite domain_map_rtype_meet₀_diff.
               unfold rec_concat_sort; rewrite domain_rec_sort.
               apply (is_list_sorted_NoDup ODT_lt_dec).
@@ -1816,19 +1817,19 @@ Proof.
             simpl in *. 
             repeat rewrite lookup_app.
             Ltac lsimp :=
-              try (rewrite map_rtype_meet₀_domain_rec_concat_sort by eauto 2);
+              try (rewrite map_rtype_meet₀_domain_rec_concat_sort by eauto 2 with qcert);
               try rewrite lookup_app.
             Ltac lsn t1
-              := rewrite (map_rtype_meet₀_some_none (τ₁:=t1)); trivial;
+              := rewrite (map_rtype_meet₀_some_none (τ₁:=t1)); qtrivial;
                  lsimp.
             Ltac ln 
               := rewrite (map_rtype_meet₀_none); trivial;
                  lsimp.
             Ltac lmm t1 t2
-              := rewrite (map_rtype_meet₀_rtype_meets (τ₁:=t1) (τ₂:=t2)); trivial;
+              := rewrite (map_rtype_meet₀_rtype_meets (τ₁:=t1) (τ₂:=t2)); qtrivial;
                  lsimp.
-            Ltac ldn1 := rewrite lookup_diff_none1; trivial; lsimp.
-            Ltac ldn2 := rewrite lookup_diff_none2; trivial; lsimp.
+            Ltac ldn1 := rewrite lookup_diff_none1; qtrivial; lsimp.
+            Ltac ldn2 := rewrite lookup_diff_none2; qtrivial; lsimp.
 
             case_eq (lookup string_dec r s); [intros τr inr| intros ninr];
             (case_eq (lookup string_dec srl s); [intros τs ins| intros nins];
@@ -2333,22 +2334,22 @@ Fixpoint map_rtype_join l1 l2 :=
 
 Lemma map_rtype_join_sublist_l l₁ l₂ : sublist (domain (map_rtype_join l₁ l₂)) (domain l₁).
 Proof.
-  Hint Constructors sublist.
-  induction l₁; simpl; auto 1.
+  Hint Constructors sublist : qcert.
+  induction l₁; simpl; auto 1 with qcert.
   destruct a.
-  destruct (lookup string_dec l₂ s); simpl; auto.
+  destruct (lookup string_dec l₂ s); simpl; auto with qcert.
 Qed.
 
 Lemma map_rtype_join_is_sorted l₁ l₂ :
   is_list_sorted ODT_lt_dec (domain l₁) = true
   -> is_list_sorted ODT_lt_dec (domain (map_rtype_join l₁ l₂)) = true.
 Proof.
-  Hint Constructors StronglySorted.
+  Hint Constructors StronglySorted : qcert.
   repeat rewrite sorted_StronglySorted by apply StringOrder.lt_strorder.
   induction l₁; simpl; trivial.
   destruct a; simpl.
   case_eq l₁; intros; subst. 
-  -  simpl in *; destruct (lookup string_dec l₂ s); simpl; auto 1.
+  -  simpl in *; destruct (lookup string_dec l₂ s); simpl; auto 1 with qcert.
   - inversion H0; subst.
     specialize (IHl₁ H2).
     destruct p. unfold fst in *.
@@ -2646,10 +2647,10 @@ Qed.
 
   Lemma map_rtype_meet_sublist_l l₁ l₂ : sublist (domain (map_rtype_meet l₁ l₂)) (domain l₁).
 Proof.
-  Hint Constructors sublist.
-  induction l₁; simpl; auto 1.
+  Hint Constructors sublist : qcert.
+  induction l₁; simpl; auto 1 with qcert.
   destruct a.
-  destruct (lookup string_dec l₂ s); simpl; auto.
+  destruct (lookup string_dec l₂ s); simpl; qauto.
 Qed.
 
 Lemma map_rtype_meet_eq

--- a/compiler/core/Updates/UPropag.v
+++ b/compiler/core/Updates/UPropag.v
@@ -63,8 +63,8 @@ Section UPropag.
     intros.
     generalize (compare_either n n1); intro.
     elim H; intro; clear H.
-    - rewrite min_l; omega.
-    - rewrite min_r. omega.
+    - rewrite min_l; lia.
+    - rewrite min_r. lia.
       assumption.
   Qed.
 
@@ -151,8 +151,8 @@ Section UPropag.
     intros.
     generalize (compare_either n n0); intro.
     elim H; intro; clear H.
-    rewrite min_l; omega.
-    rewrite min_r; omega.
+    rewrite min_l; lia.
+    rewrite min_r; lia.
   Qed.
 
   (* P9. (S+dS)-T =b (S-T)+(dS-(T-S)) *)
@@ -169,7 +169,7 @@ Section UPropag.
     generalize (mult t a).
     generalize (mult ds a).
     intros.
-    omega.
+    lia.
   Qed.
 
   (* P10. S-(T+dT) =b (S-T)-dT *)
@@ -199,15 +199,15 @@ Section UPropag.
     generalize (mult ds a).
     intros.
     assert ((n1 <= n0) \/ (n0 <= n1)).
-    omega.
+    lia.
     elim H; intro; clear H.
-    rewrite min_l;[rewrite min_l;[omega|assumption]|omega].
+    rewrite min_l;[rewrite min_l;[lia|assumption]|lia].
     generalize (compare_either (n1 - n) n0); intro.
     elim H; intro; clear H.
     rewrite min_l.
-    rewrite min_r;[omega|assumption].
+    rewrite min_r;[lia|assumption].
     assumption.
-    rewrite min_r;[rewrite min_r;[omega|assumption]|assumption].
+    rewrite min_r;[rewrite min_r;[lia|assumption]|assumption].
   Qed.
 
   (* P11'. S min (T-dT) =b (S min T)-(dT-(T-S)) *)
@@ -237,16 +237,16 @@ Section UPropag.
     generalize (mult ds a) as ndS.
     intros.
     generalize (compare_either nT nS); intro; elim H; intro; clear H.
-    rewrite min_r; try omega.
-    rewrite min_r; try omega.
-    rewrite min_r; omega.
+    rewrite min_r; try lia.
+    rewrite min_r; try lia.
+    rewrite min_r; lia.
     generalize (compare_either (ndS+nS) nT); intro; elim H; intro; clear H.
     - rewrite min_l; try assumption.
-      rewrite min_l; try omega.
-      rewrite min_l; omega.
+      rewrite min_l; try lia.
+      rewrite min_l; lia.
     - rewrite min_r; try assumption.
-      rewrite min_r; try omega.
-      rewrite min_l; omega.
+      rewrite min_r; try lia.
+      rewrite min_l; lia.
   Qed.
 
   (* P12'. S min (T+dT) =b (S min T)+(dT min (S-T)) *)
@@ -279,16 +279,16 @@ Section UPropag.
     generalize (mult ds a) as ndS.
     intros.
     generalize (compare_either nS nT); intro; elim H; intro; clear H.
-    rewrite max_r; try omega.
+    rewrite max_r; try lia.
     rewrite max_r; try assumption.
-    rewrite min_r; omega.
+    rewrite min_r; lia.
     generalize (compare_either nS (nT+ndS)); intro; elim H; intro; clear H.
-    - rewrite max_r; try omega.
+    - rewrite max_r; try lia.
       rewrite max_l; try assumption.
-      rewrite min_r; try omega.
-    - rewrite max_l; try omega.
+      rewrite min_r; try lia.
+    - rewrite max_l; try lia.
       rewrite max_l; try assumption.
-      rewrite min_l; omega.
+      rewrite min_l; lia.
   Qed.
 
   (* P13'. S max (T-dT) =b (S max T)-(dT min (T-S)) *)
@@ -318,13 +318,13 @@ Section UPropag.
     generalize (mult ds a) as ndS.
     intros.
     generalize (compare_either nT nS); intro; elim H; intro; clear H.
-    rewrite max_l; try omega.
-    rewrite max_l; omega.
+    rewrite max_l; try lia.
+    rewrite max_l; lia.
     generalize (compare_either (ndS+nS) nT); intro; elim H; intro; clear H.
     - rewrite max_r; try assumption.
-      rewrite max_r; omega.
+      rewrite max_r; lia.
     - rewrite max_l; try assumption.
-      rewrite max_r; omega.
+      rewrite max_r; lia.
   Qed.
 
   (* P14. (S+dS) max T =b (S max T)+(dS-(T-S)) *)
@@ -352,19 +352,19 @@ Section UPropag.
     generalize (mult s a) as nS; intro.
     generalize (mult ds a) as ndS; intro.
     generalize (compare_either nS ndS); intro; elim H; intro; clear H.
-    - assert (nS - ndS = 0); try omega.
+    - assert (nS - ndS = 0); try lia.
       assert (min ndS nS = nS); try (apply min_r;assumption).
       rewrite H; rewrite H1; simpl.
-      assert ((nS <= 1) \/ (1 <= nS)); try omega.
+      assert ((nS <= 1) \/ (1 <= nS)); try lia.
     - assert (min ndS nS = ndS); try (apply min_l;assumption); rewrite H.
-      assert (((nS - ndS) <= 1) \/ (1 <= (nS - ndS))); try omega.
-      assert ((nS <= 1) \/ (1 <= nS)); try omega.
-      assert ((ndS <= 1) \/ (1 <= ndS)); try omega.
+      assert (((nS - ndS) <= 1) \/ (1 <= (nS - ndS))); try lia.
+      assert ((nS <= 1) \/ (1 <= nS)); try lia.
+      assert ((ndS <= 1) \/ (1 <= ndS)); try lia.
 
       Ltac tme := 
         (rewrite min_l by assumption; tme) ||
         (rewrite min_r by assumption; tme) ||
-        omega.
+        lia.
 
       elim H1; elim H2; elim H3; intros; clear H1 H2 H3; tme.
       
@@ -393,12 +393,12 @@ Section UPropag.
     - auto.
     - assert (mult s a >= 1).
       apply bdistinct_exactly_one_back_diff.
-      omega.
+      lia.
       revert H.
       generalize (mult s a) as ns.
       intros.
       rewrite Max.max_idempotent.
-      omega.
+      lia.
   Qed.
 
   (* P18. (S - dS) x T =b (S x T) - (ds x T)*)

--- a/compiler/core/Utils/Assoc.v
+++ b/compiler/core/Utils/Assoc.v
@@ -140,10 +140,11 @@ Section Assoc.
       destruct (dec x a); subst; intuition.
     Qed.
 
+    Hint Constructors NoDup : qcert.
+    
     Lemma NoDup_domain_NoDup {l} : NoDup (domain l) -> NoDup l.
     Proof.
-      Hint Constructors NoDup.
-      induction l; simpl; intros; trivial.
+      induction l; simpl; intros; trivial with qcert.
       inversion H; subst.
       constructor; auto.
       intro ina; apply H2.
@@ -246,16 +247,17 @@ Section Assoc.
     Qed.
 
     (* TODO: this should just replace in_lookup *)      
+    Hint Resolve in_dom_lookup_strong in_dom : qcert.
     Lemma in_lookup_strong :  forall {l} {a:A} {b0:B}, In (a,b0) l -> {v | lookup l a = Some v}.
     Proof.
-      Hint Resolve in_dom_lookup_strong in_dom.
-      intros. eauto.
+      intros. eauto with qcert.
     Qed.
+
+    Hint Resolve in_dom_lookup in_dom : qcert.
 
     Lemma in_lookup :  forall {l} {a:A} {b0:B}, In (a,b0) l -> exists v, lookup l a = Some v.
     Proof.
-      Hint Resolve in_dom_lookup in_dom.
-      intros. eauto.
+      intros. eauto with qcert.
     Qed.
 
     Lemma in_lookup_nodup : forall {l} {a:A} {b:B}, NoDup (domain l) -> In (a,b) l -> lookup l a = Some b.
@@ -1024,12 +1026,12 @@ Section Assoc.
       inversion H; subst; auto.
   Qed.
 
-  Hint Resolve NoDup_app_inv.
+  Hint Resolve NoDup_app_inv : qcert.
 
   Lemma NoDup_app_inv2 {A:Type} {a b:list A} : NoDup (a++b) -> NoDup b.
   Proof.
     rewrite Permutation_app_comm.
-    eauto.
+    eauto with qcert.
   Qed.
 
   Lemma domain_length  {A B:Type} (l:list (A*B)) :
@@ -1081,12 +1083,13 @@ Section Assoc.
           dl' else x::dl'
       end.
 
+    Hint Constructors NoDup : qcert.
+
     Lemma bdistinct_domain_NoDup {A B} {dec:EqDec A eq} (l:list (A*B)) :
       NoDup (domain (bdistinct_domain l)).
     Proof.
-      Hint Constructors NoDup.
       induction l; simpl.
-      - eauto.
+      - eauto with qcert.
       - case_eq (existsb (fun z : A * B => fst a ==b fst z) (bdistinct_domain l)).
         + trivial.
         + intros; constructor; trivial.

--- a/compiler/core/Utils/Bag.v
+++ b/compiler/core/Utils/Bag.v
@@ -18,7 +18,7 @@ Require Import Arith.
 Require Import Min.
 Require Import Max.
 Require Import ZArith.
-Require Import Omega.
+Require Import Lia.
 Require Import Permutation.
 Require Import Equivalence.
 Require Import Morphisms.
@@ -799,7 +799,7 @@ Section Bag.
     intros.
     assert ((mult l x) <> 0). 
     apply bdistinct_exactly_one_back; assumption.
-    omega.
+    lia.
   Qed.
 
   Lemma exist_or_zero:
@@ -859,7 +859,7 @@ Section Bag.
   Proof.
     split.
     - (* Case "->" *)
-      induction l; simpl; try omega.
+      induction l; simpl; try lia.
       case (equiv_dec x a).
       + intros Hx.
         rewrite Hx in *; clear Hx.
@@ -913,7 +913,7 @@ Section Bag.
     match_case; intros.
     constructor; trivial.
     rewrite <- mult_pos_equiv_in.
-    omega.
+    lia.
   Qed.
 
   Lemma NoDup_bdistinct {l:list A} :
@@ -924,7 +924,7 @@ Section Bag.
     rewrite IHl by trivial.
     rewrite <- mult_pos_equiv_in in H2.
     match_case.
-    intros; omega.
+    intros; lia.
   Qed.
 
   Lemma bdistinct_idem {l:list A} :
@@ -955,7 +955,7 @@ Section Bag.
     induction l; simpl; trivial.
     match_case; simpl; rewrite IHl; trivial; intros.
     assert (inn:In a (bdistinct l))
-      by (apply mult_pos_equiv_in; omega).
+      by (apply mult_pos_equiv_in; lia).
     destruct (in_split _ _ inn) as [t1 [t2 teq]].
     rewrite teq.
     assert (perm:Permutation (t1 ++ a :: t2) (a::t1++ t2))
@@ -1107,11 +1107,11 @@ Section Bag.
     elim (H n n0); intro; clear H.
     rewrite a in *; clear a.
     assert (n0 <= (S n0)); auto.
-    rewrite (min_l n0 (S n0) H); omega.
+    rewrite (min_l n0 (S n0) H); lia.
     generalize (compare_either n0 (S n)); intro.
     elim H; intro; clear H.
-    - rewrite min_l; try assumption; omega.
-    - rewrite min_r; try assumption; omega.
+    - rewrite min_l; try assumption; lia.
+    - rewrite min_r; try assumption; lia.
   Qed.    
 
   Lemma minus_max:
@@ -1123,11 +1123,11 @@ Section Bag.
     elim (H n n0); intro; clear H.
     rewrite a in *; clear a.
     assert (n0 <= (S n0)); auto.
-    rewrite (max_r n0 (S n0) H); omega.
+    rewrite (max_r n0 (S n0) H); lia.
     generalize (compare_either n0 (S n)); intro.
     elim H; intro; clear H.
-    - rewrite max_r; try assumption; omega.
-    - rewrite max_l; try assumption; omega.
+    - rewrite max_r; try assumption; lia.
+    - rewrite max_l; try assumption; lia.
   Qed.
 
   Lemma bmin_mult:
@@ -1286,7 +1286,7 @@ Section Bag.
       apply min_one_yields_one; assumption.
       generalize (compare_either (n+n0) 1); intro; elim H; intros; clear H.
       rewrite min_r; try reflexivity.
-      omega.
+      lia.
       rewrite <- plus_n_Sm.
       simpl.
       rewrite min_r.
@@ -1423,8 +1423,8 @@ Section Bag.
     generalize (mult dQp a) as ndQp; intro.
     generalize (compare_either nQ ndQm); intro.
     elim H; intro; clear H.
-    - rewrite min_l; try assumption; omega.
-    - rewrite min_r; try assumption; omega.
+    - rewrite min_l; try assumption; lia.
+    - rewrite min_r; try assumption; lia.
   Qed.
 
   Lemma theorem2_b:
@@ -1441,8 +1441,8 @@ Section Bag.
     generalize (mult dQp a) as ndQp; intro.
     generalize (compare_either nQ ndQm); intro.
     elim H; intro; clear H.
-    - rewrite min_l; try assumption; omega.
-    - rewrite min_r; try assumption; omega.
+    - rewrite min_l; try assumption; lia.
+    - rewrite min_r; try assumption; lia.
   Qed.
 
   Lemma theorem2_c:
@@ -1465,15 +1465,15 @@ Section Bag.
       rewrite H.
       generalize (compare_either nQ ndQp); intro.
       elim H1; intros; clear H1.
-      + rewrite min_l; omega.
-      + rewrite min_r; omega.
+      + rewrite min_l; lia.
+      + rewrite min_r; lia.
     - assert (min nQ ndQm = ndQm).
       rewrite min_r; [reflexivity|assumption].
       rewrite H.
       generalize (compare_either ndQm ndQp); intro.
       elim H1; intros; clear H1.
-      + rewrite min_l; omega.
-      + rewrite min_r; omega.
+      + rewrite min_l; lia.
+      + rewrite min_r; lia.
   Qed.
 
   Lemma remove_one_bminus r s a:

--- a/compiler/core/Utils/Bag.v
+++ b/compiler/core/Utils/Bag.v
@@ -39,6 +39,7 @@ Section Bag.
 
   Definition bunion := (@app A).
 
+  Declare Scope rbag_scope.
   Delimit Scope rbag_scope with rbag.
   Bind Scope rbag_scope with rbag.
   Open Scope rbag_scope.
@@ -93,7 +94,7 @@ Section Bag.
       | y::tl => if (x == y) then tl else y::(remove_one x tl)
     end.
 
-  Hint Unfold ldeqA.
+  Hint Unfold ldeqA : qcert.
 
   Ltac tac
     := repeat progress (intros; simpl in *; try autorewrite with bag in *; try match goal with
@@ -122,7 +123,7 @@ Section Bag.
            destruct (@equiv_dec A eqA eqvA eqdecA x y)
        end;
                         unfold complement, Equivalence.equiv in *;
-                          try subst; try reflexivity; eauto).
+                          try subst; try reflexivity; eauto with qcert).
 
   Global Instance remove_one_proper : Proper (eq ==> ldeqA ==> ldeqA) remove_one.
   Proof.
@@ -192,7 +193,7 @@ Section Bag.
     unfold Proper, respectful.
     intros x y H.
     elim H; tac.
-    - rewrite remove_one_comm; eauto.
+    - rewrite remove_one_comm; eauto with qcert.
     - rewrite H1; eauto.
       symmetry; eauto.
   Qed. 
@@ -298,7 +299,7 @@ Section Bag.
   Proof.
     intros; induction l; tac.
     left; exists (a0::x).
-    rewrite perm_swap, l0; eauto.
+    rewrite perm_swap, l0; eauto with qcert.
   Qed.
 
   (* It seems some properties are easier to check on a different representation with
@@ -326,7 +327,7 @@ Section Bag.
     
     Notation "X ≅# Y" := (mult_equiv X Y) (at level 70) : rbag_scope.                              (* ≅ = \cong *)
 
-    Hint Unfold mult_equiv.
+    Hint Unfold mult_equiv : qcert.
 
     Global Instance mult_proper : Proper (ldeqA ==> eq ==> eq) mult.
     Proof.
@@ -367,8 +368,8 @@ Section Bag.
 
     Lemma groupby_noDup l : NoDup (domain (groupby l)).
     Proof.
-      Hint Constructors NoDup.
-      induction l; simpl; trivial.
+      Hint Constructors NoDup : qcert.
+      induction l; simpl; trivial with qcert.
       case_eq (lookup equiv_dec (groupby l) a); [intros ? ?| intros neq].
       - rewrite domain_update_first; trivial.
       - simpl; constructor; auto. apply lookup_none_nin in neq; trivial.
@@ -401,13 +402,14 @@ Section Bag.
       trivial.
     Qed.
     
+    Hint Resolve groupby_noDup : qcert.
+
     Lemma smush_groupby l : Permutation (smush (groupby l)) l.
     Proof.
-      Hint Resolve groupby_noDup.
       induction l; simpl; trivial.
       case_eq (lookup equiv_dec (groupby l) a); [intros n eqn | intros neq].
       - destruct (lookup_to_front equiv_dec eqn).
-        assert (perm1:Permutation (update_first equiv_dec (groupby l) a (S n)) (update_first equiv_dec ((a, n) :: x) a (S n))) by (apply update_first_NoDup_perm_proper; auto). 
+        assert (perm1:Permutation (update_first equiv_dec (groupby l) a (S n)) (update_first equiv_dec ((a, n) :: x) a (S n))) by (apply update_first_NoDup_perm_proper; auto with qcert). 
         rewrite perm1.
         simpl. destruct (equiv_dec a a); try congruence.
         rewrite smush1.
@@ -1572,6 +1574,6 @@ Hint Rewrite
      bunion_bminus 
      remove_one_consed : bag.
 
-Hint Unfold ldeqA.
-Hint Unfold mult_equiv.
+Hint Unfold ldeqA : qcert.
+Hint Unfold mult_equiv : qcert.
 

--- a/compiler/core/Utils/Bindings.v
+++ b/compiler/core/Utils/Bindings.v
@@ -743,7 +743,6 @@ Section Bindings.
     Forall2 P l1 l2 ->
     Forall2 P (@rec_sort A l1) (@rec_sort B l2).
   Proof.
-    Hint Constructors Forall2.
     revert l2; induction l1; simpl; inversion 2; subst; eauto.
     simpl in *; inversion H.
     apply rec_cons_sort_Forall2; auto.
@@ -788,7 +787,7 @@ Section Bindings.
     rewrite <- IHl. apply insertion_sort_insert_equiv_domain.
   Qed.
 
-  Hint Resolve ODT_lt_strorder.
+  Hint Resolve ODT_lt_strorder : qcert.
   
   Lemma insertion_sort_insert_swap_neq {A} a1 (b1:A) a2 b2 l :
     ~(eq a1 a2) ->
@@ -1751,9 +1750,9 @@ Section Edot.
     
 End Edot.
 
-Hint Unfold rec_sort rec_concat_sort.
-Hint Resolve drec_sort_sorted drec_concat_sort_sorted.
-Hint Resolve is_list_sorted_NoDup_strlt.
+Hint Unfold rec_sort rec_concat_sort : qcert.
+Hint Resolve drec_sort_sorted drec_concat_sort_sorted : qcert.
+Hint Resolve is_list_sorted_NoDup_strlt : qcert.
 
 Section MergeBindings.
   (* Merge record stuff *)
@@ -1799,7 +1798,7 @@ Section MergeBindings.
     destruct (compatible g1 g2); try discriminate.
     inversion H0; subst.
     unfold rec_concat_sort, rec_concat_sort in *.
-    eauto.
+    eauto with qcert.
   Qed.
 
   Lemma edot_merge_bindings {A} `{EqDec A eq} (l1 l2:list (string*A)) (s:string) (x:A) :
@@ -2298,4 +2297,4 @@ Section RecRemove.
 
 End RecRemove.
 
-Hint Resolve @merge_bindings_sorted.
+Hint Resolve @merge_bindings_sorted : qcert.

--- a/compiler/core/Utils/Bindings.v
+++ b/compiler/core/Utils/Bindings.v
@@ -2297,4 +2297,4 @@ Section RecRemove.
 
 End RecRemove.
 
-Hint Resolve @merge_bindings_sorted : qcert.
+Hint Resolve merge_bindings_sorted : qcert.

--- a/compiler/core/Utils/BindingsNat.v
+++ b/compiler/core/Utils/BindingsNat.v
@@ -30,7 +30,7 @@ Section BindingsNat.
 
 End BindingsNat.
 
-Hint Unfold rec_sort rec_concat_sort.
-Hint Resolve drec_sort_sorted drec_concat_sort_sorted.
-Hint Resolve is_list_sorted_NoDup_strlt.
+Hint Unfold rec_sort rec_concat_sort : qcert.
+Hint Resolve drec_sort_sorted drec_concat_sort_sorted : qcert.
+Hint Resolve is_list_sorted_NoDup_strlt : qcert.
 

--- a/compiler/core/Utils/CoqLibAdd.v
+++ b/compiler/core/Utils/CoqLibAdd.v
@@ -33,6 +33,12 @@ Require Import Znat.
 Require Import Recdef.
 Require Import Compare_dec.
 
+Create HintDb qcert.
+
+Ltac qauto := auto with qcert.
+Ltac qeauto := eauto with qcert.
+Ltac qtrivial := trivial with qcert.
+
 Section CoqLibAdd.
 
   (** * Properties of Booleans *)
@@ -312,7 +318,9 @@ Section CoqLibAdd.
       Forallt_nil : Forallt P nil
     | Forallt_cons : forall (x : A) (l : list A),
         P x -> Forallt P l -> Forallt P (x :: l).
-    
+
+    Hint Constructors Forallt : qcert.
+
     Lemma list_Forallt_eq_dec {A:Type}:
       forall (c l: list A),
         Forallt (fun x : A => forall y : A, {x = y} + {x <> y}) c -> {c = l} + {c <> l}.
@@ -333,19 +341,19 @@ Section CoqLibAdd.
     Lemma forallt_impl {A} {P1 P2:A->Type} {l:list A} :
       Forallt P1 l -> Forallt (fun x => P1 x -> P2 x) l -> Forallt P2 l.
     Proof.
-      Hint Constructors Forallt.
-      induction l; trivial.
+      induction l; trivial with qcert.
       inversion 1; inversion 1; subst.
-      auto.
+      auto with qcert.
     Defined.
 
     Lemma forallt_weaken {A} P : (forall x:A, P x) -> forall l, Forallt P l.
     Proof.
-      Hint Constructors Forallt.
       intros.
-      induction l. apply Forallt_nil.
-      apply Forallt_cons. apply (X a).
-      trivial.
+      induction l.
+      - apply Forallt_nil.
+      - apply Forallt_cons.
+        + apply (X a).
+        + trivial.
     Defined.
 
     Lemma Forallt_inv: forall A P (a:A) l, Forallt P (a :: l) -> P a.

--- a/compiler/core/Utils/CoqLibAdd.v
+++ b/compiler/core/Utils/CoqLibAdd.v
@@ -19,7 +19,7 @@ Require Import Bool.
 Require Import List.
 Require Import String.
 Require Import Sumbool.
-Require Import Omega.
+Require Import Lia.
 Require Import Permutation.
 Require Import Morphisms.
 Require Import Setoid.
@@ -590,7 +590,7 @@ Section CoqLibAdd.
     Lemma compare_either (n1 n2:nat):
       (n1 <= n2) \/ (n2 <= n1).
     Proof.
-      omega.
+      lia.
     Qed.
     
     Lemma min_one_yields_one:
@@ -610,19 +610,19 @@ Section CoqLibAdd.
       simpl in *.
       rewrite (IHl (f a + 0)); simpl.
       rewrite (IHl (f a + x0)); simpl.
-      omega.
+      lia.
     Qed.
     
     Lemma fold_left_arith_dist2 {A} (x0 n0:nat) (l:list A) (f:A -> nat):
       fold_left (fun (x:nat) (y:A) => n0 * (f y) + x) l x0 =
       n0 * (fold_left (fun (x:nat) (y:A) => (f y) + x) l 0) + x0.
     Proof.
-      revert x0; induction l; simpl; intros; try omega.
+      revert x0; induction l; simpl; intros; try lia.
       rewrite (IHl (n0 * f a + x0)); simpl.
       rewrite (fold_left_arith_dist1 (f a + 0)).
       rewrite mult_plus_distr_l.
       rewrite mult_plus_distr_l.
-      omega.
+      lia.
     Qed.
 
     Lemma fold_left_arith_dist3 {A} (x0 n0:nat) (l:list A) (f:A -> nat):
@@ -630,7 +630,7 @@ Section CoqLibAdd.
       n0 * (fold_left (fun (x:nat) (y:A) => x + (f y)) l 0) + x0.
     Proof.
       generalize 0.
-      revert x0; induction l; simpl; intros; try omega.
+      revert x0; induction l; simpl; intros; try lia.
       assert (f a + n = n + f a) by apply plus_comm.
       rewrite H; clear H.
       rewrite (IHl x0 (n + f a)); reflexivity.

--- a/compiler/core/Utils/Digits.v
+++ b/compiler/core/Utils/Digits.v
@@ -123,7 +123,7 @@ Section Digits.
          | _ => l
          end.
 
-    Program Fixpoint nat_to_digits_backwards (n:nat) {measure n lt_wf} :
+    Program Fixpoint nat_to_digits_backwards (n:nat) {measure n lt} :
       {l:list digit | digits_to_nat (rev l) = n /\ (forall a, hd_error (rev l) = Some a -> proj1_sig a <> 0)}
       := if n == 0
          then nil

--- a/compiler/core/Utils/Digits.v
+++ b/compiler/core/Utils/Digits.v
@@ -23,7 +23,7 @@ Require Import List.
 Require Import Equivalence.
 Require Import EquivDec.
 Require Import Compare_dec.
-Require Import Omega.
+Require Import Lia.
 Require Import Nat.
 Require Import ZArith.
 Require Import Eqdep_dec.
@@ -138,11 +138,11 @@ Section Digits.
       generalize (Nat.divmod_spec n base 0 base).
       destruct (Nat.divmod n base 0 base); intros; simpl.
       apply Nat.mod_upper_bound.
-      omega.
+      lia.
     Defined.
     Next Obligation.
       apply Nat.div_lt; trivial.
-      omega.
+      lia.
     Defined.
     Next Obligation.
       unfold digits_to_nat.
@@ -157,17 +157,17 @@ Section Digits.
         rewrite e1.
         rewrite mult_comm.
         rewrite <- Nat.div_mod; trivial.
-        omega.
+        lia.
       - intros. destruct (rev x); simpl in * .
         + inversion H0; clear H0; subst.
           simpl.
           unfold digits_to_nat in e1.
           simpl in *.
-          rewrite <- Nat.div_exact by omega.
+          rewrite <- Nat.div_exact by lia.
           rewrite <- e1.
           rewrite mult_comm.
           simpl.
-          omega.
+          lia.
         + auto.
     Defined.
 
@@ -206,9 +206,9 @@ Section Digits.
         + apply digits_to_nat_aux_acc_le_preserve.
           transitivity (acc*base).
           * transitivity (acc * 1).
-            { omega. }
+            { lia. }
             apply mult_le_compat_l.
-            omega.
+            lia.
           * apply le_plus_l.
     Qed.
 
@@ -218,11 +218,11 @@ Section Digits.
       revert c.
       induction l; simpl.
       - split.
-        + omega.
+        + lia.
         + destruct (mult_O_le c (base*1)).
-          * omega.
+          * lia.
           * rewrite mult_comm.
-            omega.
+            lia.
       - intros.
         destruct (IHl (c * base + proj1_sig a)) as [le1 le2].
         clear IHl.
@@ -271,10 +271,10 @@ Section Digits.
         apply mult_le_compat_r.
         rewrite plus_assoc_reverse.
         apply plus_le_compat_l.
-        omega.
+        lia.
       }
       eapply lt_le_trans in le13; try eapply lt1.
-      rewrite (le_plus_minus n1 n2) in le13 by omega.
+      rewrite (le_plus_minus n1 n2) in le13 by lia.
       rewrite Nat.pow_add_r in le13.
       rewrite mult_assoc in le13.
       assert (le14:c*base+base <= c*base*base).
@@ -283,14 +283,14 @@ Section Digits.
         - apply mult_le_compat_r.
           rewrite mult_comm.
           destruct base.
-          + omega.
+          + lia.
           + simpl.
             apply plus_le_compat_l.
-            destruct n. omega.
-            destruct c. omega.
+            destruct n. lia.
+            destruct c. lia.
             apply lt_le_S.
             replace 0 with (S n *0) by auto.
-            apply mult_lt_compat_l; omega.
+            apply mult_lt_compat_l; lia.
         - rewrite mult_plus_distr_r.
           rewrite mult_1_l.
           trivial.
@@ -310,7 +310,7 @@ Section Digits.
         - simpl; intros _ .
           replace base with (base*base^0) at 1.
           + apply mult_le_compat_l.
-            apply Nat.pow_le_mono_r; omega.
+            apply Nat.pow_le_mono_r; lia.
           + simpl.
             rewrite mult_1_r.
             trivial.
@@ -337,30 +337,30 @@ Section Digits.
       ; [ | eapply (digits_to_nat_aux_acc_inj_helper1 a b c n1 n2); eauto].
       red in e; subst.
       simpl in *.
-      rewrite (le_plus_minus n1 n2) in lt1 by omega.
+      rewrite (le_plus_minus n1 n2) in lt1 by lia.
       rewrite Nat.pow_add_r in lt1.
       rewrite (mult_comm (base ^ n1)) in lt1.
       rewrite mult_assoc in lt1.
       assert (le2:base*base^n1 <= a*base^(n2 - n1) * base ^ n1).
       {
         apply mult_le_compat_r.
-        replace base with (1*base) at 1 by omega.
+        replace base with (1*base) at 1 by lia.
         apply mult_le_compat.
-        - replace 1 with (1*1) by omega.
-          simpl. omega.
+        - replace 1 with (1*1) by lia.
+          simpl. lia.
         - simpl.
           replace base with (base^1) at 1.
-          + apply Nat.pow_le_mono_r; omega.
+          + apply Nat.pow_le_mono_r; lia.
           + apply Nat.pow_1_r.
       } 
       eapply le_lt_trans in lt1; try eapply le2; clear le2.
       assert (le3:(b + 1) * base ^ n1 <= base * base^n1).
       {
         apply mult_le_compat_r.
-        omega.
+        lia.
       }
       eapply le_lt_trans in lt1; try eapply le3; clear le3.
-      omega.
+      lia.
     Qed.
 
     Lemma digits_to_nat_aux_acc_inj_helper2 a b c n :
@@ -373,7 +373,7 @@ Section Digits.
       apply mult_le_compat_r.
       rewrite plus_assoc_reverse.
       apply plus_le_compat_l.
-      omega.
+      lia.
     Qed.
 
     Lemma digits_to_nat_aux_acc_inj_helper01 a b n1 n2 :
@@ -386,20 +386,20 @@ Section Digits.
       intros ? ? ? lt1 l2.
       apply lt_not_le in lt1.
       apply lt1.
-      rewrite (le_plus_minus n2 n1) by omega.
+      rewrite (le_plus_minus n2 n1) by lia.
       rewrite Nat.pow_add_r.
       rewrite (mult_comm a).
       rewrite (mult_comm (b+1)).
       rewrite <- mult_assoc.
       apply mult_le_compat_l.
-      transitivity base; try omega.
+      transitivity base; try lia.
       transitivity (base^1*a).
       - rewrite Nat.pow_1_r.
-        transitivity (base * 1); try omega.
+        transitivity (base * 1); try lia.
         apply mult_le_compat_l.
-        omega.
+        lia.
       - apply mult_le_compat_r.
-        apply Nat.pow_le_mono_r; omega.
+        apply Nat.pow_le_mono_r; lia.
     Qed.
     
     Lemma digits_to_nat_aux_acc_inj l1 l2 c (a b:digit):
@@ -424,7 +424,7 @@ Section Digits.
         generalize (digits_to_nat_aux_acc_inj_helper1 a b c n1 n2 cne0 alt blt lt1).
         generalize (digits_to_nat_aux_acc_inj_helper1 b a c n2 n1 cne0 blt alt lt2).
         intros.
-        omega.
+        lia.
       }
       subst.
       split; trivial.
@@ -432,7 +432,7 @@ Section Digits.
       simpl.
       generalize (digits_to_nat_aux_acc_inj_helper2 a b c n2 lt1).
       generalize (digits_to_nat_aux_acc_inj_helper2 b a c n2 lt2).
-      omega.
+      lia.
     Qed.
     
     Lemma digits_to_nat_aux_acc_inj2 l1 l2 c (a b:digit):
@@ -458,7 +458,7 @@ Section Digits.
         generalize (digits_to_nat_aux_acc_inj_helper12 a b c n1 n2 ane0 alt blt lt1).
         generalize (digits_to_nat_aux_acc_inj_helper12 b a c n2 n1 bne0 blt alt lt2).
         intros.
-        omega.
+        lia.
       }
       subst.
       split; trivial.
@@ -466,7 +466,7 @@ Section Digits.
       simpl.
       generalize (digits_to_nat_aux_acc_inj_helper2 a b c n2 lt1).
       generalize (digits_to_nat_aux_acc_inj_helper2 b a c n2 lt2).
-      omega.
+      lia.
     Qed.
   
     Lemma digits_to_nat_aux_digits_inj l1 l2 n :
@@ -480,23 +480,23 @@ Section Digits.
       - trivial. 
       - generalize (digits_to_nat_aux_le l2 (n * base + proj1_sig d)); intros eqq.
         rewrite <- H0 in eqq.
-        assert (le1:n * base <= n*1) by omega.
-        assert (le2:n * base <= n*1) by omega.
+        assert (le1:n * base <= n*1) by lia.
+        assert (le2:n * base <= n*1) by lia.
         destruct n; [congruence|].
         apply mult_S_le_reg_l in le2.
-        omega.
+        lia.
       - generalize (digits_to_nat_aux_le l1 (n * base + proj1_sig a)); intros eqq.
         rewrite H0 in eqq.
-        assert (le1:n * base <= n*1) by omega.
-        assert (le2:n * base <= n*1) by omega.
+        assert (le1:n * base <= n*1) by lia.
+        assert (le2:n * base <= n*1) by lia.
         destruct n; [congruence|].
         apply mult_S_le_reg_l in le2.
-        omega.
+        lia.
       - assert (lt0:0<n * base).
-        { assert (equ1:0<n) by omega.
+        { assert (equ1:0<n) by lia.
           assert (eqq1:n*0<n * base).
-          { apply Nat.mul_lt_mono_pos_l; trivial. omega. }
-          omega.
+          { apply Nat.mul_lt_mono_pos_l; trivial. lia. }
+          lia.
         } 
         assert (eql:a = d).
         + generalize (digits_to_nat_aux_acc_inj
@@ -505,11 +505,11 @@ Section Digits.
                         n
                         a d); intros eqq1.
           apply eqq1.
-          * omega.
+          * lia.
           * trivial.
         + subst. f_equal.
           revert H0. eapply IHl1.
-          omega.
+          lia.
     Qed.
 
     Lemma trim_digits_nz {y d l}: trim_digits y = d :: l -> proj1_sig d <> 0.
@@ -520,7 +520,7 @@ Section Digits.
       destruct d; simpl in *.
       intros.
       inversion H; subst.
-      omega.
+      lia.
     Qed.
 
     Lemma digits_to_nat_nzero l x :
@@ -530,10 +530,10 @@ Section Digits.
       revert x.
       induction l; simpl; trivial; intros.
       apply IHl.
-      cut (0 < x*base + proj1_sig a); try omega.
-      cut (0 < x * base); try omega.
-      cut (0*base < x*base); try omega.
-      apply mult_lt_compat_r; try omega.
+      cut (0 < x*base + proj1_sig a); [lia | ].
+      cut (0 < x * base); [lia | ].
+      cut (0*base < x*base); [lia | ].
+      apply mult_lt_compat_r; lia.
     Qed.
 
     Lemma trim_nat_to_digits x :
@@ -748,7 +748,7 @@ Section Digits.
                 ;  [apply digit_ext; simpl; trivial
                    | congruence]
               end | ]).
-      omega.
+      lia.
     Qed.
 
     Fixpoint string_to_digits (s:string) : option (list digit*string)
@@ -851,7 +851,7 @@ Section Digits.
 
     Lemma digit0pf : 0 < base.
     Proof.
-      omega.
+      lia.
     Qed.
 
     Definition digit0 : digit := exist _ 0 digit0pf.
@@ -870,7 +870,7 @@ Section Digits.
       - f_equal.
         apply digit_ext.
         simpl; trivial.
-      - omega.
+      - lia.
     Qed.
 
     Lemma char_to_digit0_inv a pf :
@@ -932,7 +932,7 @@ Section Digits.
       destruct (ascii_dec a "0"%char).
       - subst.
         unfold char_to_digit in eqq; simpl in eqq.
-        destruct (lt_dec 0 base); [ | omega].
+        destruct (lt_dec 0 base); [ | lia].
         inversion eqq; clear eqq; subst.
         case_eq (string_to_digits s)
         ; [intros ? eqq2 | intros eqq2]
@@ -1248,7 +1248,7 @@ Section Digits.
         rewrite Pos2Nat.id.
         case_eq (Pos.to_nat p); trivial.
         generalize (Pos2Nat.is_pos p).
-        omega.
+        lia.
     Qed.
 
     Theorem Z_to_string_inj_full

--- a/compiler/core/Utils/Float.v
+++ b/compiler/core/Utils/Float.v
@@ -15,68 +15,46 @@
 Require Import String.
 Require Import List.
 Require Import BinPos Zpower ZArith.
-Require Flocq.Appli.Fappli_IEEE.
-Require Flocq.Appli.Fappli_IEEE_bits.
-Require Import JsAst.JsNumber.
+Require Floats PrimFloat.
+Require JsAst.JsNumber.
 
 (** Floating point numbers use Flocq binary 64 representation (double precision IEEE 754) *)
 
-Definition float : Set := Fappli_IEEE_bits.binary64.
-
+Definition float : Set := PrimFloat.float.
 
 (** The following definitions already exist in JsAst.JsNumber *)
 
-Definition float_nan : float := nan.
-Definition float_zero : float := zero.
-Definition float_neg_zero : float := neg_zero.
-Definition float_one : float := one.
-Definition float_neg_one : float := neg_one.
-Definition float_infinity : float := infinity.
-Definition float_neg_infinity : float := neg_infinity.
+Definition float_nan : float := PrimFloat.nan.
+Definition float_zero : float := PrimFloat.zero.
+Definition float_neg_zero : float := PrimFloat.neg_zero.
+Definition float_one : float := PrimFloat.one.
+Definition float_neg_one : float := Eval compute in (PrimFloat.opp PrimFloat.one).
+Definition float_infinity : float := PrimFloat.infinity.
+Definition float_neg_infinity : float := PrimFloat.neg_infinity.
 
-Definition float_max_value : float := max_value.
-Definition float_min_value : float := min_value.
+Parameter float_min_value : float.
+Parameter float_max_value : float.
 
-(** Initial idea for converting external sign+mantisse+exponent into Flocq binary64. Possibly this could be tied to a parser from strings. *)
-Definition float_triple : Set := (bool * positive * Z).
-Definition float_triple_to_b64 (ft:float_triple) : float :=
-  let '(sign, m, e) := ft in
-  match e with
-  | Z0 => Fappli_IEEE.B754_zero _ _ false
-  | Zneg e =>
-    let my :=
-        match Zpower_pos 10 e with
-        | Zpos p => p
-        | _ => xH
-        end
-    in
-    Fappli_IEEE.FF2B
-      53 1024 _
-      (proj1
-         (Fappli_IEEE.Bdiv_correct_aux
-            53 1024
-            (eq_refl Lt) (eq_refl Lt)
-            Fappli_IEEE.mode_NE
-            sign m 0
-            false my 0))
-  | Zpos e =>
-    Fappli_IEEE.B754_zero _ _ false
-  end.
+(* from JsAst *)
+Definition float_from_string : string -> float := JsNumber.from_string.
+Definition float_to_string : float -> string := JsNumber.to_string.
 
-Definition float_from_string : string -> float := from_string.
-Definition float_to_string : float -> string := to_string.
+Definition float_neg : float -> float := PrimFloat.opp.
+Definition float_floor : float -> float := JsNumber.floor.
+Definition float_absolute : float -> float := PrimFloat.abs.
 
-Definition float_neg : float -> float := neg.
-Definition float_floor : float -> float := floor. (* Note: this is an axiom in JsAst.JsNumber *)
-Definition float_absolute : float -> float := absolute.
-Definition float_sign : float -> float := sign.
+Definition float_sign : float -> float := (* Note: This sign function is consistent with Math.sign in JavaScript *)
+  fun x => match PrimFloat.classify x with
+        | FloatClass.PNormal => float_one
+        | FloatClass.NNormal => float_neg_one
+        | _ => x
+        end.
 
-Definition float_add : float -> float -> float := add.
-Definition float_sub : float -> float -> float := sub.
-Definition float_mod : float -> float -> float := fmod. (* Note: this is an axiom in JsAst.JsNumber *)
 
-Definition float_mult : float -> float -> float := mult.
-Definition float_div : float -> float -> float := div.
+Definition float_add : float -> float -> float := PrimFloat.add.
+Definition float_sub : float -> float -> float := PrimFloat.sub.
+Definition float_mult : float -> float -> float := PrimFloat.mul.
+Definition float_div : float -> float -> float := PrimFloat.div.
 
 (** The following are additional floating point operations used in Q*cert *)
 
@@ -87,7 +65,8 @@ Parameter float_exp : float -> float.
 Parameter float_log : float -> float.
 Parameter float_log10 : float -> float.
 Parameter float_ceil : float -> float.
-Parameter float_eq : float -> float -> bool. (* TODO by pattern matching on B754 *)
+
+Definition float_eq : float -> float -> bool := PrimFloat.eqb.
 
 Conjecture float_eq_correct :
   forall f1 f2, (float_eq f1 f2 = true <-> f1 = f2).
@@ -112,27 +91,27 @@ Parameter float_pow : float -> float -> float.
 Parameter float_min : float -> float -> float. (** TODO: Check in JavaScript spec what happens for min/max *)
 Parameter float_max : float -> float -> float.
 Parameter float_ne : float -> float -> bool.
-Definition float_lt (n1 n2 : float) := lt_bool n1 n2.
-Parameter float_le : float -> float -> bool.
-Parameter float_gt : float -> float -> bool.
-Parameter float_ge : float -> float -> bool.
+Definition float_lt (n1 n2 : float) := PrimFloat.ltb n1 n2.
+Definition float_le : float -> float -> bool := PrimFloat.leb.
+Definition float_gt (n1 n2: float) : bool := float_lt n2 n1.
+Definition float_ge (n1 n2: float) : bool := float_le n2 n1.
 
 Parameter float_of_int : Z -> float. (** Binary normalize *)
 Parameter float_truncate : float -> Z. (** Do like parsing ... *)
 
 Definition float_list_min (l:list float) : float :=
-  fold_right (fun x y => float_min x y) infinity l.
+  fold_right (fun x y => float_min x y) float_infinity l.
 
 Definition float_list_max (l:list float) : float :=
-  fold_right (fun x y => float_max x y) neg_infinity l.
+  fold_right (fun x y => float_max x y) float_neg_infinity l.
 
 Definition float_list_sum (l:list float) : float :=
-  fold_right (fun x y => float_add x y) zero l.
+  fold_right (fun x y => float_add x y) float_zero l.
 
 Definition float_list_arithmean (l:list float) : float :=
   let ll := List.length l in
   match ll with
-  | O => zero
+  | O => float_zero
   | _ => float_div (float_list_sum l) (float_of_int (Z_of_nat ll))
   end.
 

--- a/compiler/core/Utils/Fresh.v
+++ b/compiler/core/Utils/Fresh.v
@@ -21,7 +21,7 @@ Require Import Permutation.
 Require Import Arith Min.
 Require Import EquivDec.
 Require Import Morphisms.
-Require Import Omega.
+Require Import Lia.
 Require Import CoqLibAdd.
 Require Import ListAdd.
 Require Import StringAdd.
@@ -66,9 +66,9 @@ Section Fresh.
     induction bound; simpl; intros.
     - discriminate.
     - match_destr_in H.
-      + inversion H; subst; omega.
+      + inversion H; subst; lia.
       + specialize (IHbound (S init) _ H).
-        omega.
+        lia.
   Qed.
 
   Lemma find_bounded_S_seq f bound init :

--- a/compiler/core/Utils/GroupByDomain.v
+++ b/compiler/core/Utils/GroupByDomain.v
@@ -27,7 +27,7 @@ Require Import Setoid.
 Require Import EquivDec.
 Require Import Equivalence.
 Require Import RelationClasses.
-Require Import Omega.
+Require Import Lia.
 Require Import CoqLibAdd.
 Require Import Lift.
 Require Import ListAdd.

--- a/compiler/core/Utils/Interleaved.v
+++ b/compiler/core/Utils/Interleaved.v
@@ -724,7 +724,7 @@ Section close_enough.
     - apply is_interleaved_disjoint_update_first; trivial.
   Qed.
 
-  Hint Resolve disjoint_nil_l disjoint_nil_r.
+  Hint Resolve disjoint_nil_l disjoint_nil_r : qcert.
   
   Lemma close_enough_lists_cons {A B} {dec:EqDec A eq} (a:(A*B)) l1 l2 : 
     close_enough_lists l1 l2 ->
@@ -757,7 +757,7 @@ Section close_enough.
       + constructor; trivial.
         rewrite Forall_map.
         revert nin; apply Forall_impl; intros.
-        apply disjoint_cons1; trivial.
+        apply disjoint_cons1; trivial with qcert.
       + econstructor; eauto.
         apply is_interleaved_cons_nil in isl1; trivial.
       + econstructor; eauto.

--- a/compiler/core/Utils/Interleaved.v
+++ b/compiler/core/Utils/Interleaved.v
@@ -23,7 +23,7 @@ Require Import Setoid.
 Require Import EquivDec.
 Require Import Equivalence.
 Require Import RelationClasses.
-Require Import Omega.
+Require Import Lia.
 Require Import CoqLibAdd.
 Require Import Lift.
 Require Import ListAdd.

--- a/compiler/core/Utils/LiftIterators.v
+++ b/compiler/core/Utils/LiftIterators.v
@@ -17,7 +17,7 @@
 Require Import Arith.
 Require Import Min.
 Require Import Max.
-Require Import Omega.
+Require Import Lia.
 Require Import Permutation.
 Require Import Equivalence.
 Require Import Morphisms.

--- a/compiler/core/Utils/LiftIterators.v
+++ b/compiler/core/Utils/LiftIterators.v
@@ -334,7 +334,7 @@ Section LiftIterators.
                  /\ sublist l' l.
     Proof.
       induction l; simpl; intros F.
-      - eauto.
+      - eauto with qcert.
       - invcs F.
         destruct H1 as [? eqq1].
         destruct (IHl H2) as [? [eqq2 Feq]].
@@ -350,7 +350,7 @@ Section LiftIterators.
       { l' : list A | lift_filter f l = Some l' & sublist l' l}.
     Proof.
       induction l; simpl; intros F.
-      - eauto.
+      - eauto with qcert.
       - invcs F.
         destruct H0 as [? eqq1].
         destruct (IHl X) as [? eqq2 Feq].

--- a/compiler/core/Utils/ListAdd.v
+++ b/compiler/core/Utils/ListAdd.v
@@ -354,7 +354,7 @@ Section ListAdd.
         + right. now inversion_clear 1.
     Defined.
 
-    Global Instance Forall_perm {A P} : Proper ((@Permutation A) ==> iff) (@Forall A P).
+    Global Instance Forall_perm {P} : Proper ((@Permutation A) ==> iff) (@Forall A P).
     Proof.
       intros ? ? perm.
       repeat rewrite Forall_forall.

--- a/compiler/core/Utils/ListAdd.v
+++ b/compiler/core/Utils/ListAdd.v
@@ -618,7 +618,6 @@ Section ListAdd.
           <->
           forallb2 f l1 l2 = true.
       Proof.
-        Hint Unfold iff.
         induction l1; destruct l2; simpl; intuition;
           repeat rewrite andb_true_iff in *; firstorder.
       Qed.
@@ -626,7 +625,6 @@ Section ListAdd.
       Lemma forallb2_Forallb {A B:Type} (f:A->B->bool) :
         forall l1 l2, forallb2 f l1 l2 = true <-> Forall2 (fun x y => f x y = true) l1 l2.
       Proof.
-        Hint Constructors Forall2.
         Ltac inv := try match goal with 
                         | [H:Forall2 _ _ (_::_) |- _ ] => inversion H; clear H
                         | [H:Forall2 _ (_::_) _ |- _ ] => inversion H; clear H
@@ -660,7 +658,6 @@ Section ListAdd.
         (forall x y, In x l1 -> In y l2 -> f1 x y-> f2 x y) ->
         Forall2 f1 l1 l2 -> Forall2 f2 l1 l2.
       Proof.
-        Hint Constructors Forall2.
         intros.
         induction H0; firstorder.
       Qed.
@@ -740,7 +737,6 @@ Section ListAdd.
       Lemma Forall2_conj {A B} {f1 f2:A->B->Prop} {l1 l2} : 
         Forall2 f1 l1 l2 -> Forall2 f2 l1 l2 -> Forall2 (fun x y => f1 x y /\ f2 x y) l1 l2.
       Proof.
-        Hint Constructors Forall2.
         intros.
         induction H0; trivial.
         invcs H; firstorder.
@@ -1676,7 +1672,7 @@ Section ListAdd.
       unfold asymmetric_over; simpl; intuition.
     Qed.
 
-    Hint Resolve asymmetric_over_cons_inv.
+    Hint Resolve asymmetric_over_cons_inv : qcert.
 
     Lemma asymmetric_over_swap {A} R {a b:A} {l1} :
       asymmetric_over R (a::b::l1) ->
@@ -1693,8 +1689,8 @@ Section ListAdd.
     
     Global Instance perm_in {A} : Proper (eq ==> (@Permutation A) ==> iff) (@In A).
     Proof.
-      Hint Resolve Permutation_in Permutation_sym.
-      unfold Proper, respectful; intros; subst; intuition; eauto.
+      Hint Resolve Permutation_in Permutation_sym : qcert.
+      unfold Proper, respectful; intros; subst; intuition; eauto with qcert.
     Qed.
     
     Lemma NoDup_perm' {A:Type} {a b:list A} : NoDup a -> Permutation a b -> NoDup b.
@@ -1703,7 +1699,7 @@ Section ListAdd.
       revert nd.
       revert a b p.
       apply (Permutation_ind_bis (fun l l' => NoDup l -> NoDup l')); intuition.
-      - inversion H1; subst. constructor; eauto.
+      - inversion H1; subst. constructor; eauto with qcert.
       - inversion H1; subst. inversion H5; subst.
         rewrite H in H4,H6.
         constructor; [|constructor]; simpl in *; intuition; subst; eauto.
@@ -1712,8 +1708,8 @@ Section ListAdd.
     Global Instance NoDup_perm {A:Type} :
       Proper (@Permutation A ==> iff) (@NoDup A).
     Proof.
-      Hint Resolve NoDup_perm' Permutation_sym.
-      unfold Proper, respectful; intros; subst; intuition; eauto.
+      Hint Resolve NoDup_perm' Permutation_sym : qcert.
+      unfold Proper, respectful; intros; subst; intuition; eauto with qcert.
     Qed.
 
     Lemma NoDup_Permutation' {A : Type} (l l' : list A) :
@@ -1738,12 +1734,12 @@ Section ListAdd.
         inversion H; subst; auto.
     Qed.
     
-    Hint Resolve NoDup_app_inv.
+    Hint Resolve NoDup_app_inv : qcert.
 
     Lemma NoDup_app_inv2 {A:Type} {a b:list A} : NoDup (a++b) -> NoDup b.
     Proof.
       rewrite Permutation_app_comm.
-      eauto.
+      eauto with qcert.
     Qed.
 
     Lemma NoDup_dec {A:Type} {dec:EqDec A eq} (l:list A): {NoDup l} + {~NoDup l}.
@@ -1903,7 +1899,7 @@ Section ListAdd.
       red; inversion 2.
     Qed.
 
-    Hint Immediate disjoint_nil_l disjoint_nil_r.
+    Hint Immediate disjoint_nil_l disjoint_nil_r : qcert.
 
     Lemma disjoint_incl {A:Type} (l1 l2 l3:list A) :
       incl l3 l2 ->
@@ -2282,6 +2278,7 @@ Section ListAdd.
 
 End ListAdd.
 
-Hint Resolve disjoint_nil_l disjoint_nil_r.
+Hint Resolve disjoint_nil_l disjoint_nil_r : qcert.
+Hint Immediate NoDup_nil : qcert.
 
 Global Arguments remove_nin_inv {A eqdec v1 v2 l}.

--- a/compiler/core/Utils/ListAdd.v
+++ b/compiler/core/Utils/ListAdd.v
@@ -17,6 +17,7 @@ lists. *)
 
 Require Import List.
 Require Import ListSet.
+Require Import Arith.Compare_dec.
 Require Import Bool.
 Require Import Permutation.
 Require Import Morphisms.
@@ -24,7 +25,7 @@ Require Import Setoid.
 Require Import EquivDec.
 Require Import Equivalence.
 Require Import RelationClasses.
-Require Import Omega.
+Require Import Lia.
 Require Import CoqLibAdd.
 Require Import Lift.
 Require Import Program.Basics.
@@ -64,7 +65,7 @@ Section ListAdd.
       assert (pm:Datatypes.length l1 + Datatypes.length l2' - Datatypes.length l2' =
                  Datatypes.length l1' + Datatypes.length l2' - Datatypes.length l2').
       { rewrite eqq1; trivial. }
-      repeat rewrite Nat.add_sub in pm; trivial.
+      lia.
     Qed.
 
     Lemma length_app_other_head {l1 l2 l1' l2' : list A} :
@@ -75,7 +76,7 @@ Section ListAdd.
       intros eqqs.
       apply length_app_other_tail.
       repeat rewrite app_length in *.
-      rewrite plus_comm, eqqs, plus_comm; trivial.
+      lia.
     Qed.
 
     Lemma app_inv_head_length {l1 l2 l1' l2' : list A} :
@@ -400,7 +401,7 @@ Section ListAdd.
       apply filter_length.
       auto with arith.
       assert ((length (x :: l)) <> (length (filter p l))).
-      omega.
+      lia.
       unfold not in *; intro.
       apply H0.
       apply eq_means_same_length.
@@ -2065,7 +2066,7 @@ Section ListAdd.
       revert init.
       induction bound; simpl; intuition.
       specialize (IHbound (S init) x H0).
-      omega.
+      lia.
     Qed.
     
     Lemma seq_NoDup init bound :
@@ -2077,7 +2078,7 @@ Section ListAdd.
       - econstructor; eauto.
         intro inn.
         apply seq_ge in inn.
-        omega.
+        lia.
     Qed.
 
     Lemma seq_plus a b c : seq a (b+c) = seq a b ++ seq (a+b) c.
@@ -2097,8 +2098,7 @@ Section ListAdd.
       x = y.
     Proof.
       intros nlt eq1 eq2.
-      assert (n2eq:n2 = n1 + (n2 - n1))
-        by (rewrite le_plus_minus_r; auto with arith).
+      assert (n2eq:n2 = n1 + (n2 - n1)) by lia.
       rewrite n2eq in eq2.
       rewrite seq_plus, find_app, eq1 in eq2.
       congruence.

--- a/compiler/core/Utils/NativeString.v
+++ b/compiler/core/Utils/NativeString.v
@@ -47,6 +47,8 @@ Section NativeString.
 
 End NativeString.
 
+Declare Scope nstring_scope.
+
 Notation "^ e" := (nstring_quote e) (left associativity, at level 40) : nstring_scope.
 Notation "& e" := (nstring_unquote e) (left associativity, at level 40) : nstring_scope.
 Notation "e1 +++ e2" := (nstring_append e1 e2) (right associativity, at level 70): nstring_scope.

--- a/compiler/core/Utils/Result.v
+++ b/compiler/core/Utils/Result.v
@@ -73,7 +73,7 @@ Section Result.
              end)
         end.
     
-    Fixpoint lift_failure_map {A B E:Type} (f: A -> Result B E) (al:list A) : Result (list B) E :=
+    Definition lift_failure_map {A B E:Type} (f: A -> Result B E) (al:list A) : Result (list B) E :=
       let init_bl := Success _ _ nil in
       let proc_one (a:A) (acc:Result (list B) E) : Result (list B) E :=
           lift_failure_in_two

--- a/compiler/core/Utils/SortingAdd.v
+++ b/compiler/core/Utils/SortingAdd.v
@@ -50,21 +50,23 @@ Section SortingAdd.
          | a::xs => insertion_sort_insert a (insertion_sort xs)
          end.
 
+    Hint Constructors LocallySorted : qcert.
+
     Lemma insertion_sort_insert_Sorted a (l:list A) :
       Sorted R l -> Sorted R (insertion_sort_insert a l).
     Proof.
-      Hint Constructors LocallySorted.
       repeat rewrite Sorted_LocallySorted_iff.
       induction l; inversion 1; subst; simpl in *;
         repeat match goal with
                | [|- context [R_dec ?x ?y]] => destruct (R_dec x y)
-               end; eauto.
+               end; eauto with qcert.
     Qed.
+
+    Hint Resolve insertion_sort_insert_Sorted : qcert.
 
     Lemma insertion_sort_Sorted (l:list A) : Sorted R (insertion_sort l).
     Proof.
-      Hint Resolve insertion_sort_insert_Sorted.
-      induction l; simpl; eauto.
+      induction l; simpl; eauto with qcert.
     Qed.
 
     Fixpoint is_list_sorted (l:list A) :=
@@ -293,7 +295,8 @@ Section SortingAdd.
       intuition.
     Qed.
 
-    Hint Resolve asymmetric_over_cons_inv.
+    Hint Resolve asymmetric_over_cons_inv : qcert.
+    
     Lemma insertion_sort_insert_in_strong {A R R_dec} {x l a} 
           (contr:asymmetric_over R (a::l)) :
       a = x \/ In x l -> In x (@insertion_sort_insert A R R_dec a l).
@@ -304,9 +307,9 @@ Section SortingAdd.
       revert H0.
       case_eq (R_dec a a0); simpl; intros; intuition; subst; intuition.
       - right; apply (IHl x x); intuition.
-        apply asymmetric_over_swap in contr. eauto. 
+        apply asymmetric_over_swap in contr. eauto with qcert. 
       - right. apply (IHl x a0); intuition.
-        apply asymmetric_over_swap in contr. eauto.
+        apply asymmetric_over_swap in contr. eauto with qcert.
     Qed.
 
     Lemma insertion_sort_insert_in {A R R_dec} {x l a}
@@ -330,7 +333,7 @@ Section SortingAdd.
       - intuition.
     Qed.
 
-    Hint Resolve asymmetric_asymmetric_over.
+    Hint Resolve asymmetric_asymmetric_over : qcert.
 
     Lemma insertion_sort_in {A R R_dec} {x l}
           (contr:forall x y,  ~R x y -> ~R y x -> x = y) :

--- a/compiler/core/Utils/SortingDesc.v
+++ b/compiler/core/Utils/SortingDesc.v
@@ -16,7 +16,7 @@ Require Import Orders.
 Require Import Equivalence.
 Require Import EquivDec.
 Require Import Compare_dec.
-Require Import Omega.
+Require Import Lia.
 Require Import String.
 Require Import List.
 Require Import ZArith.

--- a/compiler/core/Utils/StringAdd.v
+++ b/compiler/core/Utils/StringAdd.v
@@ -24,7 +24,7 @@ Require Import Min.
 Require Import Equivalence.
 Require Import EquivDec.
 Require Import Compare_dec.
-Require Import Omega.
+Require Import Lia.
 Require Import CoqLibAdd.
 
 (** * Total order on characters *)
@@ -47,7 +47,7 @@ Module AsciiOrder <: OrderedTypeFull with Definition t:=ascii.
       repeat match goal with 
              | [H:Nat.compare _ _ = Lt |- _ ] => apply nat_compare_lt in H
              | [|- Nat.compare _ _ = Lt ] => apply nat_compare_lt
-             end; omega.
+             end; lia.
   Qed.
 
   Lemma lt_compat : Proper (eq ==> eq ==> iff) lt.
@@ -362,7 +362,7 @@ Section Prefix.
       f_equal.
       f_equal.
       f_equal.
-      omega.
+      lia.
     - rewrite IHl.
       match_case.
   Qed.
@@ -373,7 +373,7 @@ Section Prefix.
   Proof.
     revert s n m.
     induction l; destruct s; destruct n; destruct m; simpl; trivial;
-      try omega; intuition.
+      try lia; intuition.
     match_destr; intuition.
   Qed.
 
@@ -383,7 +383,7 @@ Section Prefix.
     rewrite substring_bounded.
     rewrite <- (substring_all l) at 3.
     apply substring_le_prefix.
-    replace (String.length l - 0) with (String.length l) by omega.
+    replace (String.length l - 0) with (String.length l) by lia.
     apply le_min_r.
   Qed.
 
@@ -398,7 +398,7 @@ Section Prefix.
     - exists (append pre y).
       rewrite string_length_append.
       replace ((String.length pre + String.length y - String.length pre))
-        with (String.length y) by omega.
+        with (String.length y) by lia.
       rewrite substring_append_cancel.
       split; trivial.
       apply filter_In.
@@ -411,7 +411,7 @@ Section Prefix.
       subst.
       rewrite string_length_append.
       replace ((String.length pre + String.length x0 - String.length pre))
-        with (String.length x0) by omega.
+        with (String.length x0) by lia.
       rewrite substring_append_cancel.
       trivial.
   Qed.

--- a/compiler/core/Utils/Sublist.v
+++ b/compiler/core/Utils/Sublist.v
@@ -23,7 +23,7 @@ Require Import Morphisms.
 Require Import Setoid.
 Require Import EquivDec.
 Require Import RelationClasses.
-Require Import Omega.
+Require Import Lia.
 Require Import CoqLibAdd.
 Require Import ListAdd.
 Require Import SortingAdd.
@@ -104,7 +104,7 @@ Section Sublist.
       - intros; apply sublist_nil_r in H; subst; auto.
       - inversion 1; subst; simpl; intros.
         + f_equal; auto with arith.
-        + apply sublist_length in H2. omega.
+        + apply sublist_length in H2. lia.
     Qed.
 
     Global Instance sublist_antisymm : Antisymmetric (list A) eq sublist.
@@ -113,7 +113,7 @@ Section Sublist.
       apply (sublist_length_eq sub1).
       apply sublist_length in sub1.
       apply sublist_length in sub2.
-      omega.
+      lia.
     Qed.
 
     Global Instance sublist_part : PartialOrder eq sublist.

--- a/compiler/core/Utils/Sublist.v
+++ b/compiler/core/Utils/Sublist.v
@@ -43,7 +43,7 @@ Section Sublist.
         forall x l1 l2, sublist l1 l2 -> sublist l1 (x::l2)
     .
     
-    Hint Constructors sublist.
+    Hint Constructors sublist : qcert.
     
     Lemma sublist_In {l1 l2:list A} :
       sublist l1 l2 -> forall x, In x l1 -> In x l2.
@@ -68,7 +68,7 @@ Section Sublist.
     Qed.
 
     
-    Hint Immediate sublist_nil_l.
+    Hint Immediate sublist_nil_l : qcert.
     
     Global Instance sublist_pre : PreOrder sublist.
     Proof.
@@ -77,10 +77,10 @@ Section Sublist.
       - intros.
         apply sublist_nil_r in H0; subst.
         apply sublist_nil_r in H; subst.
-        auto.
+        auto with qcert.
       - intros.
-        inversion H0; subst; eauto 3.
-        inversion H; subst; eauto 3.
+        inversion H0; subst; eauto 3 with qcert.
+        inversion H; subst; eauto 3 with qcert.
     Qed.
 
     Lemma sublist_trans l1 l2 l3:
@@ -136,14 +136,15 @@ Section Sublist.
         eapply sublist_In; eauto.
     Qed.
 
+    Hint Constructors sublist : qcert.
+    
     Lemma sublist_app {a1 b1 a2 b2:list A}:
       sublist a1 b1 ->
       sublist a2 b2 ->
       sublist (a1 ++ a2) (b1 ++ b2).
     Proof.
-      Hint Constructors sublist.
       revert a1 a2 b2.
-      induction b1; inversion 1; subst; simpl; eauto.
+      induction b1; inversion 1; subst; simpl; eauto with qcert.
     Qed.
 
     Lemma sublist_app_l (l1 l2:list A) : sublist l1 (l1 ++ l2).
@@ -171,8 +172,6 @@ Section Sublist.
     
   End sublist.
 
-  Hint Constructors sublist.
-
   Lemma cut_down_to_sublist
         {A B} {dec:EqDec A eq}
         (l:list (A*B)) (l2:list A) :
@@ -182,12 +181,14 @@ Section Sublist.
     apply filter_sublist.
   Qed.
 
+  Hint Constructors sublist : qcert.
+
   Lemma sublist_map {A B} {l1 l2} (f:A->B) :
     sublist l1 l2 -> sublist (map f l1) (map f l2).
   Proof.
     revert l1; induction l2; intros.
-    - apply sublist_nil_r in H; subst; simpl; auto.
-    - inversion H; subst; simpl; auto.
+    - apply sublist_nil_r in H; subst; simpl; auto with qcert.
+    - inversion H; subst; simpl; auto with qcert.
   Qed.
 
   Lemma sublist_domain {A B} {l1 l2:list(A*B)} :
@@ -202,11 +203,11 @@ Section Sublist.
   Proof.
     revert l1 l2.
     induction l3; intros.
-    - apply sublist_nil_r in H; subst; simpl; trivial.
+    - apply sublist_nil_r in H; subst; simpl; trivial with qcert.
     - inversion H; subst.
       + simpl.
-        match_destr; eauto.
-      + eauto.
+        match_destr; eauto with qcert.
+      + eauto with qcert.
   Qed.
   
   Global Instance Forall_sublist {A} {P:A->Prop} :
@@ -276,7 +277,7 @@ Section Sublist.
     trivial.
   Qed.
 
-  Hint Immediate sublist_nil_l.
+  Hint Immediate sublist_nil_l : qcert.
 
   Lemma StronglySorted_incl_sublist {A R l1 l2} `{EqDec A eq} `{StrictOrder A R} : 
     StronglySorted R l1 ->
@@ -289,10 +290,10 @@ Section Sublist.
     generalize (StronglySorted_NoDup _ H2).
     revert l1 H1 H2 H3.
     induction l2; simpl.
-    - destruct l1; simpl; auto 1.
+    - destruct l1; simpl; auto 1 with qcert.
       intros. specialize (H3 a); intuition.
     - intros. inversion H2; subst.
-      destruct l1; auto 1.
+      destruct l1; auto 1 with qcert.
       simpl in *.
       inversion H1; subst.
       inversion H4; inversion H5; subst.
@@ -379,7 +380,7 @@ Section Sublist.
     sublist l1 l2 -> sublist (filter f l1) (filter f l2).
   Proof.
     revert l1. induction l2; simpl; intros.
-    - apply sublist_nil_r in H; subst; simpl; auto 1.
+    - apply sublist_nil_r in H; subst; simpl; auto 1 with qcert.
     - inversion H; subst.
       + specialize (IHl2 _ H2); simpl.
         destruct (f a); [apply sublist_cons | ]; congruence.
@@ -444,12 +445,12 @@ Section Sublist.
   Proof.
     revert l1.
     induction l2; intros l1; destruct l1.
-    - left; trivial.
+    - left; trivial with qcert.
     - right; inversion 1.
     - left; apply sublist_nil_l.
     - destruct (a0 == a).
       + destruct (IHl2 l1).
-        * left. rewrite e. eauto.
+        * left. rewrite e. eauto with qcert.
         * right. rewrite e. intro subl.
           apply sublist_cons_eq_inv in subl.
           intuition.
@@ -463,7 +464,7 @@ Section Sublist.
     sublist (remove dec x l1) (remove dec x l2).
   Proof.
     revert l1. induction l2; simpl; intros.
-    - apply sublist_nil_r in H; subst; simpl; auto 1.
+    - apply sublist_nil_r in H; subst; simpl; auto 1 with qcert.
     - inversion H; subst.
       + specialize (IHl2 _ H2); simpl.
         match_destr. apply sublist_cons; auto.
@@ -597,7 +598,7 @@ Section Sublist.
     unfold incl.
     revert l1.
     induction l2; simpl.
-    - destruct l1; simpl; eauto 3.
+    - destruct l1; simpl; eauto 3 with qcert.
       intros ? inn.
       specialize (inn a); intuition.
     - intros.
@@ -835,4 +836,5 @@ Section Sublist.
   Qed.
 
 End Sublist.
-Hint Immediate sublist_nil_l.
+
+Hint Immediate sublist_nil_l : qcert.

--- a/compiler/core/cNNRC/Lang/cNNRC.v
+++ b/compiler/core/cNNRC/Lang/cNNRC.v
@@ -44,6 +44,7 @@ Require Import Morphisms.
 Require Import Utils.
 Require Import DataRuntime.
 
+Declare Scope nnrc_scope.
 Section cNNRC.
   Context {fruntime:foreign_runtime}.
   

--- a/compiler/core/cNNRC/Lang/cNNRCEq.v
+++ b/compiler/core/cNNRC/Lang/cNNRCEq.v
@@ -84,7 +84,7 @@ Section cNNRCEq.
     intros; simpl; rewrite H0 by trivial; rewrite H1 by trivial; clear H0 H1.
     case_eq (nnrc_core_eval h cenv env y0);
       case_eq (nnrc_core_eval h cenv env y1); intros; simpl; trivial.
-    rewrite (H h); eauto.
+    rewrite (H h); qeauto.
   Qed.
 
   (* NNRCUnop *)
@@ -94,7 +94,7 @@ Section cNNRCEq.
     unfold Proper, respectful, nnrc_core_eq.
     intros; simpl; rewrite H0 by trivial; clear H0.
     case_eq (nnrc_core_eval h cenv env y0); simpl; trivial; intros.
-    rewrite (H h); eauto.
+    rewrite (H h); qeauto.
   Qed.
     
   (* NNRCLet *)
@@ -106,12 +106,12 @@ Section cNNRCEq.
     case_eq (nnrc_core_eval h cenv env y0); simpl; trivial; intros.
     rewrite H; clear H.
     rewrite H1; eauto.
-    constructor; eauto.
+    constructor; qeauto.
   Qed.
 
   (* NNRCFor *)
 
-    Hint Resolve data_normalized_dcoll_in.
+    Hint Resolve data_normalized_dcoll_in : qcert.
 
   Global Instance proper_cNNRCFor : Proper (eq ==> nnrc_core_eq ==> nnrc_core_eq ==> nnrc_core_eq) NNRCFor.
   Proof.
@@ -121,7 +121,7 @@ Section cNNRCEq.
     destruct d; try reflexivity; simpl.
     f_equal.
     apply lift_map_ext; intros.
-    apply H1; simpl; eauto.
+    apply H1; simpl; qeauto.
   Qed.
 
   (* NNRCIf *)
@@ -132,7 +132,7 @@ Section cNNRCEq.
     intros; simpl. rewrite H by trivial; clear H.
     case_eq (nnrc_core_eval h cenv env y); simpl; trivial; intros.
     destruct d; try reflexivity; simpl.
-    destruct b; eauto.
+    destruct b; qeauto.
   Qed.
 
   (* NNRCEither *)
@@ -142,12 +142,12 @@ Section cNNRCEq.
     intros; simpl. subst.
     rewrite H by trivial.
     match_case; intros ? eqq1. match_destr.
-    - assert (dn:data_normalized h (dleft d)) by eauto.
+    - assert (dn:data_normalized h (dleft d)) by qeauto.
       inversion dn; subst.
       apply H1; simpl; eauto.
-    - assert (dn:data_normalized h (dright d)) by eauto.
+    - assert (dn:data_normalized h (dright d)) by qeauto.
       inversion dn; subst.
-      apply H3; simpl; eauto.
+      apply H3; simpl; qeauto.
   Qed.
 
   (* NNRCGroupBy *)

--- a/compiler/core/cNNRC/Lang/cNNRCNorm.v
+++ b/compiler/core/cNNRC/Lang/cNNRCNorm.v
@@ -105,5 +105,5 @@ Section cNNRCNorm.
 
 End cNNRCNorm.
 
-Hint Resolve nnrc_core_eval_normalized.
+Hint Resolve nnrc_core_eval_normalized : qcert.
 

--- a/compiler/core/cNNRC/Lang/cNNRCVars.v
+++ b/compiler/core/cNNRC/Lang/cNNRCVars.v
@@ -652,7 +652,7 @@ Section cNNRCVars.
   End core.
   
   Section FreeVars.
-    Fixpoint nnrc_free_variables (q:nnrc) : list var := nnrc_free_vars q.
+    Definition nnrc_free_variables (q:nnrc) : list var := nnrc_free_vars q.
   End FreeVars.
 
 End cNNRCVars.

--- a/compiler/core/cNNRC/Typing/TcNNRC.v
+++ b/compiler/core/cNNRC/Typing/TcNNRC.v
@@ -22,6 +22,9 @@ Require Import Utils.
 Require Import DataSystem.
 Require Import cNNRC.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section TcNNRC.
   (** Typing rules for cNNRC *)
   Context {m:basic_model}.

--- a/compiler/core/cNNRC/Typing/TcNNRC.v
+++ b/compiler/core/cNNRC/Typing/TcNNRC.v
@@ -192,7 +192,7 @@ Section TcNNRC.
   Qed.
 
   (* we are only sensitive to the environment up to lookup *)
-  Global Instance nnrc_core_type_lookup_equiv_prop {m:basic_model} :
+  Global Instance nnrc_core_type_lookup_equiv_prop :
     Proper (eq ==> lookup_equiv ==> eq ==> eq ==> iff) nnrc_core_type.
   Proof.
     cut (Proper (eq ==> lookup_equiv ==> eq ==> eq ==> impl) nnrc_core_type);

--- a/compiler/core/cNNRC/Typing/TcNNRCEq.v
+++ b/compiler/core/cNNRC/Typing/TcNNRCEq.v
@@ -56,7 +56,7 @@ Section TcNNRCEq.
     apply bindings_type_Forall_normalized.
   Qed.
 
-  Hint Resolve data_normalized_bindings_type_map.
+  Hint Resolve data_normalized_bindings_type_map : qcert.
   
   Lemma nnrc_base_rewrites_typed_with_untyped (e1 e2:nnrc) :
     e1 ≡ᶜᶜ e2 ->
@@ -69,16 +69,16 @@ Section TcNNRCEq.
     intros.
     unfold tnncr_core_rewrites_to; simpl; intros.
     split; auto 2; intros.
-    apply H; eauto.
+    apply H; qeauto.
   Qed.
 
   (****************
    * Proper stuff *
    ****************)
 
-  Hint Constructors nnrc_core_type.
-  Hint Constructors unary_op_type.
-  Hint Constructors binary_op_type.
+  Hint Constructors nnrc_core_type : qcert.
+  Hint Constructors unary_op_type : qcert.
+  Hint Constructors binary_op_type : qcert.
 
   Global Instance  tnncr_core_rewrites_to_pre : PreOrder tnncr_core_rewrites_to.
   Proof.
@@ -165,7 +165,7 @@ Section TcNNRCEq.
     inversion H2; clear H2; subst.
     specialize (H0 τenv τ₁ H8); elim H0; clear H0 H8; intros.
     specialize (H1 ((y, τ₁) :: τenv) τout H9); elim H1; clear H1 H9; intros.
-    econstructor; eauto.
+    econstructor; qeauto.
     intros; simpl.
     rewrite (H0 cenv env H3 H4).
     case_eq (nnrc_core_eval brand_relation_brands cenv env y0); intros; try reflexivity.
@@ -210,7 +210,7 @@ Section TcNNRCEq.
     inversion H2; clear H2; subst.
     specialize (H0 τenv (Coll τ₁) H8); elim H0; clear H0 H8; intros.
     specialize (H1 ((y, τ₁) :: τenv) τ₂ H9); elim H1; clear H1 H9; intros.
-    econstructor; eauto.
+    econstructor; qeauto.
     intros; simpl.
     rewrite (H0 cenv env H3 H4).
     case_eq (nnrc_core_eval brand_relation_brands cenv env y0); intros; try reflexivity.
@@ -244,7 +244,7 @@ Section TcNNRCEq.
     specialize (H τenv Bool H7); elim H; clear H H7; intros.
     specialize (H0 τenv τout H9); elim H0; clear H0 H9; intros.
     specialize (H1 τenv τout H10); elim H1; clear H1 H10; intros.
-    econstructor; eauto.
+    econstructor; qeauto.
     intros; simpl.
     rewrite (H2 cenv env H5 H6). rewrite (H3 cenv env H5 H6). rewrite (H4 cenv env H5 H6).
     reflexivity.
@@ -263,7 +263,7 @@ Section TcNNRCEq.
     destruct (H3 _ _ H12).
     clear H H1 H3.
     simpl.
-    split; [eauto | ]; intros.
+    split; [qeauto | ]; intros.
     rewrite H2; trivial.
     destruct (@typed_nnrc_core_yields_typed_data _ _ _ _ _ _ _ H H1 H0) as [?[??]].
     rewrite H3.
@@ -275,5 +275,5 @@ Section TcNNRCEq.
 
 End TcNNRCEq.
 
-Notation "e1 ⇒ᶜᶜ e2" := (tnncr_core_rewrites_to e1 e2) (at level 80).
+Notation "e1 ⇒ᶜᶜ e2" := (tnncr_core_rewrites_to e1 e2) (at level 80) : nnrc_scope.
 

--- a/compiler/core/cNNRC/Typing/TcNNRCShadow.v
+++ b/compiler/core/cNNRC/Typing/TcNNRCShadow.v
@@ -25,7 +25,7 @@ Require Import cNNRCShadow.
 Require Import TcNNRC.
   
 Section TcNNRCShadow.
-  Hint Constructors nnrc_core_type.
+  Hint Constructors nnrc_core_type : qcert.
 
   Context {m:basic_model}.
 
@@ -42,9 +42,9 @@ Section TcNNRCShadow.
     (nnrc_core_type τcenv (l ++ (v,x)::l') e τ <-> nnrc_core_type τcenv (l ++ l') e τ).
   Proof.
     split; revert l v x l' τ H;
-      induction e; simpl; inversion 2; subst; intuition; eauto 3.
+      induction e; simpl; inversion 2; subst; intuition; eauto 3 with qcert.
     - constructor. erewrite <- lookup_remove_nin; eauto.
-    - apply nin_app_or in H. intuition. eauto.
+    - apply nin_app_or in H. intuition. qeauto.
     - apply nin_app_or in H. intuition.
       econstructor; eauto.
       destruct (equiv_dec v v0); unfold Equivalence.equiv in *; subst.
@@ -58,7 +58,7 @@ Section TcNNRCShadow.
       + eapply (IHe2 ((v, τ₁) :: l)); eauto. 
         intro; elim H2; apply remove_in_neq; eauto.
     - apply nin_app_or in H; destruct H as [? HH]; apply nin_app_or in HH.
-      intuition. eauto.
+      intuition. qeauto.
     - apply nin_app_or in H. destruct H as [neq1 neq2].
       apply nin_app_or in neq2. destruct neq2 as [neq2 neq3].
       econstructor; eauto.
@@ -71,7 +71,7 @@ Section TcNNRCShadow.
         * eapply (IHe3 ((v0, τr) :: l)); eauto.
           rewrite <- remove_in_neq in neq3; intuition.
     - constructor. erewrite lookup_remove_nin; eauto.
-    - apply nin_app_or in H. intuition. eauto.
+    - apply nin_app_or in H. intuition. qeauto.
     - apply nin_app_or in H. intuition.
       econstructor; eauto.
       destruct (equiv_dec v v0); unfold Equivalence.equiv in *; subst.
@@ -170,11 +170,11 @@ Section TcNNRCShadow.
     - intuition.
       constructor.
       destruct (string_dec v v₀); simpl; subst; intuition; inversion H; subst; simpl in *; repeat dest_eqdec; intuition.
-    - inversion 1; subst. eauto.
+    - inversion 1; subst. qeauto.
     - inversion 1; subst.
       rewrite nin_app_or in nfree, nbound.
-      intuition; eauto.
-    - inversion 1; subst. eauto.
+      intuition; qeauto.
+    - inversion 1; subst. qeauto.
     - inversion 1; subst.
       rewrite nin_app_or in nfree. intuition.
       apply nin_app_or in H3. intuition.
@@ -208,7 +208,7 @@ Section TcNNRCShadow.
     - inversion 1; subst.
       apply nin_app_or in nfree; destruct nfree as [? HH]; apply nin_app_or in HH.
       apply nin_app_or in nbound; destruct nbound as [? HHH]; apply nin_app_or in HHH.
-      intuition; eauto.
+      intuition; qeauto.
     - intro HH; inversion HH; subst; clear HH.
       apply not_or in nbound; destruct nbound as [nb1 nb2].
       apply not_or in nb2; destruct nb2 as [nb2 nb3].
@@ -248,11 +248,11 @@ Section TcNNRCShadow.
         inversion H; subst; simpl in *; repeat dest_eqdec; intuition;
           inversion H4; subst; constructor; simpl;
             repeat dest_eqdec; intuition.
-    - inversion 1; subst. eauto.
+    - inversion 1; subst. qeauto.
     - inversion 1; subst.
       rewrite nin_app_or in nfree, nbound.
-      intuition; eauto.
-    - inversion 1; subst. eauto.
+      intuition; qeauto.
+    - inversion 1; subst. qeauto.
     - inversion 1; subst.
       rewrite nin_app_or in nfree. intuition.
       apply nin_app_or in H3. intuition.
@@ -329,11 +329,11 @@ Section TcNNRCShadow.
         intros typ; inversion typ; clear typ; subst;
           unfold equiv_dec in *; simpl in * .
     - Case "NNRCGetConstant"%string.
-      eauto.
+      qeauto.
     - Case "NNRCVar"%string.
       match_destr.
       + congruence.
-      + auto.
+      + qauto.
     - Case "NNRCConst"%string.
       econstructor; trivial.
     - Case "NNRCBinop"%string.
@@ -432,8 +432,8 @@ Section TcNNRCShadow.
   Theorem nnrc_core_unshadow_type {τcenv} sep renamer avoid Γ n τ :
     nnrc_core_type τcenv Γ n τ <-> nnrc_core_type τcenv Γ (unshadow sep renamer avoid n) τ.
   Proof.
-    Hint Resolve really_fresh_from_free  really_fresh_from_bound.
-    split; revert Γ τ; induction n; simpl in *; inversion 1; subst; eauto; simpl.
+    Hint Resolve really_fresh_from_free  really_fresh_from_bound : qcert.
+    split; revert Γ τ; induction n; simpl in *; inversion 1; subst; qeauto; simpl.
     - econstructor; [eauto|..].
       apply nnrc_core_type_rename_pick_subst.
       eauto.

--- a/compiler/core/cNRAEnv/Context/cNRAEnvContext.v
+++ b/compiler/core/cNRAEnv/Context/cNRAEnvContext.v
@@ -33,6 +33,8 @@ Require Import DataRuntime.
 Require Import cNRAEnv.
 Require Import cNRAEnvEq.
 
+Declare Scope nraenv_core_ctxt_scope.
+
 Section cNRAEnvContext.
   Local Open Scope nraenv_core_scope.
 
@@ -803,9 +805,9 @@ Section cNRAEnvContext.
        apply Nat.lt_strorder.
      - specialize (H (rec_sort ps)).
        cut_to H.
-       + Hint Resolve rec_sort_perm.
-         rewrite aec_substs_perm with (c:=c1) (ps2:=(rec_sort ps)); auto.
-         rewrite aec_substs_perm with (c:=c2) (ps2:=(rec_sort ps)); auto.
+       + Hint Resolve rec_sort_perm : qcert.
+         rewrite aec_substs_perm with (c:=c1) (ps2:=(rec_sort ps)); qauto.
+         rewrite aec_substs_perm with (c:=c2) (ps2:=(rec_sort ps)); qauto.
        + apply (@rec_sort_pf nat ODT_nat).
        + rewrite drec_sort_equiv_domain. trivial.
    Qed.

--- a/compiler/core/cNRAEnv/Context/cNRAEnvContextLift.v
+++ b/compiler/core/cNRAEnv/Context/cNRAEnvContextLift.v
@@ -193,8 +193,8 @@ Section cNRAEnvContext.
               | [H: data_normalized _ (dright _) |- _ ] => inversion H; clear H; try subst
               end.
 
-  Hint Resolve nraenv_core_eval_normalized.
-  Hint Resolve data_normalized_dcoll_in.
+  Hint Resolve nraenv_core_eval_normalized : qcert.
+  Hint Resolve data_normalized_dcoll_in : qcert.
 
   Instance aeu_Binop_proper h c env :
     Proper
@@ -226,7 +226,7 @@ Section cNRAEnvContext.
   Proof.
     unfold Proper, respectful, nraenv_core_eq_under; simpl; intros.
     rewrite H0 by trivial.
-    goal_eq_simpler; eauto.
+    goal_eq_simpler; qeauto.
   Qed.
 
   Instance aeu_MapProduct_proper h c env (dn_c:Forall (fun x => data_normalized h (snd x)) c) (dn_env:data_normalized h env) :
@@ -237,7 +237,7 @@ Section cNRAEnvContext.
   Proof.
     unfold Proper, respectful, nraenv_core_eq_under; simpl; intros.
     rewrite H0 by trivial.
-    goal_eq_simpler; eauto.
+    goal_eq_simpler; qeauto.
   Qed.
 
   Instance aeu_Product_proper h c env (dn_c:Forall (fun x => data_normalized h (snd x)) c) (dn_env:data_normalized h env) :
@@ -248,7 +248,7 @@ Section cNRAEnvContext.
   Proof.
     unfold Proper, respectful, nraenv_core_eq_under; simpl; intros.
     rewrite H, H0 by trivial.
-    goal_eq_simpler; eauto.
+    goal_eq_simpler; qeauto.
   Qed.
 
   Instance aeu_Select_proper h c env (dn_c:Forall (fun x => data_normalized h (snd x)) c) (dn_env:data_normalized h env):
@@ -259,8 +259,8 @@ Section cNRAEnvContext.
   Proof.
     unfold Proper, respectful, nraenv_core_eq_under; simpl; intros.
     rewrite H0 by trivial.
-    goal_eq_simpler; eauto.
-    rewrite H; eauto.
+    goal_eq_simpler; qeauto.
+    rewrite H; qeauto.
   Qed.
 
   Instance aeu_Default_proper h c env :
@@ -281,7 +281,7 @@ Section cNRAEnvContext.
                        nraenv_core_eq_under h c env) cNRAEnvEither.
   Proof.
     unfold Proper, respectful, nraenv_core_eq_under; simpl; intros.
-    match_destr; dn_inverter; eauto.
+    match_destr; dn_inverter; qeauto.
   Qed.
 
   Instance aeu_EitherConcat_proper h c env :
@@ -292,8 +292,8 @@ Section cNRAEnvContext.
   Proof.
     unfold Proper, respectful, nraenv_core_eq_under; simpl; intros.
     rewrite H0 by trivial.
-    goal_eq_simpler; eauto.
-    rewrite H; eauto.
+    goal_eq_simpler; qeauto.
+    rewrite H; qeauto.
   Qed.
 
   Instance aeu_App_proper h c env (dn_c:Forall (fun x => data_normalized h (snd x)) c) (dn_env:data_normalized h env) :
@@ -304,7 +304,7 @@ Section cNRAEnvContext.
   Proof.
     unfold Proper, respectful, nraenv_core_eq_under; simpl; intros.
     rewrite H0 by trivial.
-    goal_eq_simpler; eauto.
+    goal_eq_simpler; qeauto.
   Qed.
   
   Instance aec_under_refl h c env : Reflexive (nraenv_core_ctxt_equiv_under h c env).

--- a/compiler/core/cNRAEnv/Lang/cNRAEnv.v
+++ b/compiler/core/cNRAEnv/Lang/cNRAEnv.v
@@ -42,6 +42,8 @@ Require Import Utils.
 Require Import DataRuntime.
 Require Import NRARuntime.
 
+Declare Scope nraenv_core_scope.
+
 Section cNRAEnv.
   Context {fruntime:foreign_runtime}.
 
@@ -1416,7 +1418,6 @@ Section cNRAEnv.
   
 End cNRAEnv.
 
-(* Delimit Scope nraenv_core_scope with nraenv_core. *)
 Delimit Scope nraenv_core_scope with nraenv_core.
 
 Notation "h ⊢ₑ op @ₑ x ⊣ c ; env " := (nraenv_core_eval h c op env x) (at level 10) : nraenv_core_scope.
@@ -1475,9 +1476,9 @@ Section RcNRAEnv2.
     data_normalized h d ->
     data_normalized h o.
   Proof.
-    Hint Resolve dnrec_sort_content.
+    Hint Resolve dnrec_sort_content : qcert.
     rewrite unfold_env_nra_sort; intros.
-    eauto.
+    qeauto.
   Qed.
 
   Section Top.
@@ -1571,7 +1572,7 @@ Notation "r1 ◯ r2" := (cNRAEnvApp r1 r2) (right associativity, at level 60): n
 Notation "r1 ◯ₑ r2" := (cNRAEnvAppEnv r1 r2) (right associativity, at level 60): nraenv_core_scope.           (* ◯ = \bigcirc *)
 Notation "χᵉ⟨ p ⟩" := (cNRAEnvMapEnv p) (at level 70) : nraenv_core_scope.                              (* χ = \chi *)
 
-Hint Resolve nraenv_core_eval_normalized.
+Hint Resolve nraenv_core_eval_normalized : qcert.
 
 Tactic Notation "nraenv_core_cases" tactic(first) ident(c) :=
   first;

--- a/compiler/core/cNRAEnv/Lang/cNRAEnvEq.v
+++ b/compiler/core/cNRAEnv/Lang/cNRAEnvEq.v
@@ -34,7 +34,7 @@ Section cNRAEnvEq.
 
   (* Equivalence for environment-enabled algebra *)
   
-  Hint Resolve dnrec_sort_content.
+  Hint Resolve dnrec_sort_content : qcert.
 
   Definition nraenv_core_eq (op1 op2:nraenv_core) : Prop :=
     forall
@@ -58,7 +58,7 @@ Section cNRAEnvEq.
       intros. rewrite (H h c dn_c env dn_env x0) by trivial; rewrite (H0 h c dn_c env dn_env x0) by trivial; reflexivity.
   Qed.
 
-  Hint Resolve dnrec_sort.
+  Hint Resolve dnrec_sort : qcert.
     
   (* all the extended nraebraic constructors are proper wrt. equivalence *)
 
@@ -104,8 +104,8 @@ Section cNRAEnvEq.
     specialize (H2 H4).
     simpl in H2.
     apply (H2 h (rec_sort c)).
-    eauto.
-    eauto.
+    qeauto.
+    qeauto.
   Qed.
 
   (* cNRAEnvUnop *)
@@ -126,11 +126,11 @@ Section cNRAEnvEq.
     intros; reflexivity.
     specialize (H1 H2).
     apply (H1 h).
-    eauto.
-    eauto.
+    qeauto.
+    qeauto.
   Qed.
 
-  Hint Resolve data_normalized_dcoll_in.
+  Hint Resolve data_normalized_dcoll_in : qcert.
 
   (* cNRAEnvMap *)
   Global Instance proper_cNRAEnvMap : Proper (nraenv_core_eq ==> nraenv_core_eq ==> nraenv_core_eq) cNRAEnvMap.
@@ -141,7 +141,7 @@ Section cNRAEnvEq.
     case_eq (nra_eval h (rec_sort c) (nra_of_nraenv_core y0) (nra_context_data env x1)); simpl; trivial.
     destruct d; try reflexivity; simpl; intros.
     f_equal. apply lift_map_ext; intros.
-    apply H; eauto.
+    apply H; qeauto.
   Qed.
 
   (* cNRAEnvMapProduct *)
@@ -153,7 +153,7 @@ Section cNRAEnvEq.
     destruct d; try reflexivity; simpl; intros.
     f_equal.
     apply omap_product_ext; intros.
-    apply H; eauto.
+    apply H; qeauto.
   Qed.
 
   (* cNRAEnvProduct *)
@@ -179,7 +179,7 @@ Section cNRAEnvEq.
                h0 ⊢ nra_of_nraenv_core y0 @ₐ x3 ⊣ c = h0 ⊢ nra_of_nraenv_core y0 @ₐ x3 ⊣ c))
       by (intros; reflexivity).
     specialize (H1 H2 (nra_of_nraenv_core y0) (nra_of_nraenv_core y0) H3).
-    apply (H1 h); eauto.      
+    apply (H1 h); qeauto.      
   Qed.
 
   (* cNRAEnvSelect *)
@@ -191,7 +191,7 @@ Section cNRAEnvEq.
     destruct d; try reflexivity; simpl.
     f_equal.
     apply lift_filter_ext; intros.
-    rewrite H; eauto.
+    rewrite H; qeauto.
   Qed.
 
   (* cNRAEnvDefault *)
@@ -219,7 +219,7 @@ Section cNRAEnvEq.
                h0 ⊢ nra_of_nraenv_core y0 @ₐ x3 ⊣ c = h0 ⊢ nra_of_nraenv_core y0 @ₐ x3 ⊣ c)).
     intros; reflexivity.
     specialize (H1 H3).
-    apply (H1 h); eauto.
+    apply (H1 h); qeauto.
   Qed.
 
   (* cNRAEnvEither *)
@@ -242,7 +242,7 @@ Section cNRAEnvEq.
     unfold Proper, respectful, nraenv_core_eq; intros; simpl.
     rewrite H0 by trivial.
     case_eq (h ⊢ₑ y0 @ₑ x1 ⊣ c;env); intros; trivial; simpl.
-    eauto.
+    qeauto.
   Qed.
 
   (* cNRAEnvGetConstant *)
@@ -265,7 +265,7 @@ Section cNRAEnvEq.
     unfold Proper, respectful, nraenv_core_eq; intros; simpl.
     rewrite H0 by trivial.
     case_eq (h ⊢ₑ y0 @ₑ x1 ⊣ c;env); intros; simpl; trivial.
-    apply H; eauto.
+    apply H; qeauto.
   Qed.
 
   (* cNRAEnvMapEnv *)
@@ -275,7 +275,7 @@ Section cNRAEnvEq.
     destruct env; try reflexivity; simpl.
     f_equal.
     apply lift_map_ext; intros.
-    eauto.
+    qeauto.
   Qed.
 
   Lemma nraenv_core_of_nra_proper : Proper (nra_eq ==> nraenv_core_eq) nraenv_core_of_nra.
@@ -334,7 +334,7 @@ Section cNRAEnvEq.
     intros.
     specialize (H h c dn_c (nra_context_data env x0)).
     repeat rewrite <- unfold_env_nra in H by trivial.
-    auto.
+    qauto.
   Qed.
 
   Definition nraenv_core_always_ensures (P:data->Prop) (q:nraenv_core) :=

--- a/compiler/core/cNRAEnv/Lang/cNRAEnvSize.v
+++ b/compiler/core/cNRAEnv/Lang/cNRAEnvSize.v
@@ -12,7 +12,7 @@
  * limitations under the License.
  *)
 
-Require Import Omega.
+Require Import Lia.
 Require Import DataRuntime.
 Require Import cNRAEnv.
 
@@ -42,7 +42,7 @@ Section cNRAEnvSize.
 
   Lemma nraenv_core_size_nzero (a:nraenv_core) : nraenv_core_size a <> 0.
   Proof.
-    induction a; simpl; omega.
+    induction a; simpl; lia.
   Qed.
   
   Fixpoint nraenv_core_depth (a:nraenv_core) : nat :=

--- a/compiler/core/cNRAEnv/Typing/TcNRAEnv.v
+++ b/compiler/core/cNRAEnv/Typing/TcNRAEnv.v
@@ -24,6 +24,9 @@ Require Import cNRAEnv.
 Require Import cNRAEnvEq.
 Require Import NRASystem.
 
+Import ListNotations.
+Local Open Scope list_scope.
+
 Section TcNRAEnv.
   Local Open Scope nraenv_core_scope.
   

--- a/compiler/core/cNRAEnv/Typing/TcNRAEnv.v
+++ b/compiler/core/cNRAEnv/Typing/TcNRAEnv.v
@@ -568,8 +568,8 @@ Section TcNRAEnv.
 
   (* Evaluation into single value for typed core NRAe *)
 
-  Hint Constructors nra_type unary_op_type binary_op_type.
-  Hint Resolve ATdot ATnra_data.
+  Hint Constructors nra_type unary_op_type binary_op_type : qcert.
+  Hint Resolve ATdot ATnra_data : qcert.
   (** Corrolaries of the main type soudness theorem *)
 
   Definition typed_nraenv_core_total {τc} {τenv τin τout} (op:nraenv_core) (HOpT: op ▷ τin >=> τout ⊣ τc;τenv) c (env:data) (d:data)
@@ -609,35 +609,35 @@ Section TcNRAEnv.
     - unfold nra_bind, nra_context_type.
       econstructor; eauto.
     (* cNRAEnvID *)
-    - eauto.
+    - qeauto.
     (* cNRAEnvConst *)
-    - eauto.
+    - qeauto.
     (* cNRAEnvBinop *)
-    - eauto.
+    - qeauto.
     (* cNRAEnvUnop *)
-    - eauto.
+    - qeauto.
     (* cNRAEnvMap *)
     - apply (@type_NRAMap m τc (nra_context_type τenv τin) (nra_context_type τenv τ₁) τ₂); try assumption.
       eapply ATunnest_two.
-      eapply (type_NRAUnop). eauto.
+      eapply (type_NRAUnop). qeauto.
       unfold nra_wrap_a1, nra_double.
-      eapply type_NRABinop. eauto.
-      eapply (type_NRAUnop). eauto.
-      eapply type_NRAUnop; eauto.
-      eapply type_OpDot. unfold tdot, edot; simpl. auto.
-      eapply (type_NRAUnop). eauto.
+      eapply type_NRABinop. qeauto.
+      eapply (type_NRAUnop). qeauto.
+      eapply type_NRAUnop; qeauto.
+      eapply type_OpDot. unfold tdot, edot; simpl. qauto.
+      eapply (type_NRAUnop). qeauto.
       eauto.
       unfold tdot, edot; auto.
       reflexivity.
       reflexivity.
     (* cNRAEnvMapProduct *)
     - apply (@type_NRAMap m τc (nra_context_type τenv τin) (Rec Closed (("PBIND"%string, τenv) :: ("PDATA"%string, (Rec Closed τ₁ pf1)) :: ("PDATA2"%string, (Rec Closed τ₂ pf2)) :: nil) (eq_refl _))).
-      econstructor; eauto.
-      econstructor; eauto.
-      econstructor; eauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
       reflexivity.
-      econstructor; eauto.
-      econstructor; eauto.
+      econstructor; qeauto.
+      econstructor; qeauto.
       reflexivity.
       apply (@type_NRAMapProduct m τc (nra_context_type τenv τin)
                           [("PBIND"%string, τenv); ("PDATA"%string, Rec Closed τ₁ pf1)]
@@ -647,90 +647,90 @@ Section TcNRAEnv.
                           (unnest_two "a1" "PDATA" (NRAUnop OpBag (nra_wrap_a1 (nra_of_nraenv_core op2))))
                           eq_refl eq_refl
             ); try reflexivity.
-      eauto.
+      qeauto.
       unfold nra_wrap_a1.
       apply (ATunnest_two "a1" "PDATA" (NRAUnop OpBag (nra_double "PBIND" "a1" nra_bind (nra_of_nraenv_core op2))) τc (nra_context_type τenv τin) [("PBIND"%string, τenv); ("a1"%string, Coll (Rec Closed τ₁ pf1))] eq_refl (Rec Closed τ₁ pf1)); try reflexivity.
       apply (@type_NRAUnop m τc (nra_context_type τenv τin) (Rec Closed [("PBIND"%string, τenv); ("a1"%string, Coll (Rec Closed τ₁ pf1))] eq_refl)).
       econstructor; eauto.
       unfold nra_double, nra_bind.
       apply (@type_NRABinop m τc (nra_context_type  τenv τin) (Rec Closed [("PBIND"%string, τenv)] eq_refl) (Rec Closed [("a1"%string, Coll (Rec Closed τ₁ pf1))] eq_refl)); try eauto.
-        econstructor; eauto.
+        econstructor; qeauto.
 
-        econstructor; eauto.
-        econstructor; eauto.
+        econstructor; qeauto.
+        econstructor; qeauto.
     (* cNRAEnvProduct *)
-    - eauto.
+    - qeauto.
     (* cNRAEnvSelect *)
     - econstructor; eauto.
       2: { econstructor; eauto.
            eapply ATunnest_two.
-           + econstructor; eauto.
+           + econstructor; qeauto.
              unfold nra_wrap_a1, nra_double.
              eapply type_NRABinop.
              * econstructor; reflexivity.
-             * econstructor; eauto.
-               econstructor; eauto.
+             * econstructor; qeauto.
+               econstructor; qeauto.
                eapply type_OpDot; unfold tdot, edot; simpl; eauto.
-             * econstructor; eauto.
+             * econstructor; qeauto.
            + unfold tdot, edot; simpl; eauto.
            + econstructor; eauto. }
-        * econstructor; eauto.
+        * econstructor; qeauto.
           eapply type_OpDot; unfold tdot, edot; simpl; eauto.
     (* cNRAEnvDefault *)
-    - eauto.
+    - qeauto.
     (* type_cNRAEnvEither *)
     - econstructor.
       + econstructor; try reflexivity.
         * { econstructor.
-            - econstructor; eauto.
-              econstructor; eauto.
+            - econstructor; qeauto.
+              econstructor; qeauto.
               reflexivity.
-            - econstructor; eauto.
+            - econstructor; qeauto.
           }
-        * { econstructor; eauto.
-            - econstructor; eauto.
-              econstructor; eauto.
-              econstructor; eauto.
+        * { econstructor; qeauto.
+            - econstructor; qeauto.
+              econstructor; qeauto.
+              econstructor; qeauto.
             
           } 
-      + econstructor; eauto.
+      + econstructor; qeauto.
     (* cNRAEnvEitherConcat *)
-    - eauto.
+    - qeauto.
     (* cNRAEnvApp *)
     - apply (@type_NRAApp m τc (nra_context_type τenv τin) (nra_context_type τenv τ1) τ2).
       + unfold nra_context, nra_bind, nra_context_type, nra_double; simpl.
         unfold nra_wrap.
         apply (@type_NRABinop m τc (Rec Closed [("PBIND"%string, τenv); ("PDATA"%string, τin)] eq_refl) (Rec Closed (("PBIND"%string, τenv)::nil) (eq_refl _)) (Rec Closed (("PDATA"%string, τ1)::nil) (eq_refl _))).
-        econstructor; eauto.
-        econstructor; eauto.
-        econstructor; eauto.
-        econstructor; eauto.
-        econstructor; eauto.
+        econstructor; qeauto.
+        econstructor; qeauto.
+        econstructor; qeauto.
+        econstructor; qeauto.
+        econstructor; qeauto.
       + trivial.
     (* cNRAEnvEnv *)
-    - unfold nra_bind, nra_context_type. eauto.
+    - unfold nra_bind, nra_context_type. qeauto.
     (* cNRAEnvAppEnv *)
     - apply (@type_NRAApp m τc (nra_context_type τenv τin) (nra_context_type τenv' τin) τ2).
       + unfold nra_context, nra_bind, nra_context_type, nra_double; simpl.
         apply (@type_NRABinop m τc (Rec Closed [("PBIND"%string, τenv); ("PDATA"%string, τin)] eq_refl) (Rec Closed (("PBIND"%string, τenv')::nil) (eq_refl _)) (Rec Closed (("PDATA"%string, τin)::nil) (eq_refl _))).
-        econstructor; eauto.
-        do 3 (econstructor; eauto).
-        do 3 (econstructor; eauto).
+        econstructor; qeauto.
+        do 3 (econstructor; qeauto).
+        do 3 (econstructor; qeauto).
       + trivial.
     (* cNRAEnvMapEnv *)
-    - econstructor; eauto.
+    - econstructor; qeauto.
       eapply ATunnest_two.
-      + econstructor; eauto.
+      + econstructor; qeauto.
         unfold nra_wrap_bind_a1, nra_double.
-        eapply type_NRABinop; eauto.
-        * do 3 (econstructor; eauto).
+        eapply type_NRABinop; qeauto.
+        * do 3 (econstructor; qeauto).
           reflexivity.
       + reflexivity.
       + simpl; trivial.
       Grab Existential Variables.
-      eauto. eauto. eauto. eauto. eauto. 
-      eauto. eauto. eauto. eauto. eauto.
-      eauto. eauto.
+      qeauto. qeauto. qeauto. qeauto. qeauto. 
+      qeauto. qeauto. qeauto. qeauto. qeauto.
+      qeauto. qeauto.
   Qed.
 
   Lemma fold_nra_context_type (env d: {τ₀ : rtype₀ | wf_rtype₀ τ₀ = true}) pf :
@@ -810,26 +810,26 @@ Section TcNRAEnv.
     nra_type τc (nra_of_nraenv_core op) (Rec k [("PBIND"%string, τenv); ("PDATA"%string, τin)] pf) τout ->
     nraenv_core_type τc op τenv τin τout.
   Proof.
-    Hint Constructors nraenv_core_type.
+    Hint Constructors nraenv_core_type : qcert.
     revert k τenv τin τout pf.
     induction op; simpl; intros.
     - inversion H; clear H; subst.
       econstructor; trivial.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
-    - nra_inverter2; try tdot_inverter; eauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
+    - nra_inverter2; try tdot_inverter; qeauto.
   Qed.
   
   Theorem typed_nraenv_core_to_typed_nra_inv {τc} {τenv τin τout} (op:nraenv_core):
@@ -845,7 +845,7 @@ Section TcNRAEnv.
     nraenv_core_type τc op τenv τin τout.
   Proof.
     revert τc op τenv τin τout.
-    induction op; simpl; inversion 1; rtype_equalizer; subst; eauto.
+    induction op; simpl; inversion 1; rtype_equalizer; subst; qeauto.
     unfold tdot, edot in *.
     rewrite (assoc_lookupr_drec_sort (odt:=ODT_string)) in H1.
     econstructor. apply H1.
@@ -856,7 +856,7 @@ Section TcNRAEnv.
       nraenv_core_type (rec_sort τc) op τenv τin τout.
   Proof.
     revert τc op τenv τin τout.
-    induction op; simpl; inversion 1; rtype_equalizer; subst; eauto.
+    induction op; simpl; inversion 1; rtype_equalizer; subst; qeauto.
     econstructor.
     unfold tdot, edot.
     rewrite (assoc_lookupr_drec_sort (odt:=ODT_string)).
@@ -881,9 +881,9 @@ Notation "Op @▷ d ⊣ C ; e" := (tnraenv_core_eval C Op e d) (at level 70).
 
 (* Used to prove type portion of typed directed rewrites *)
   
-Hint Constructors nraenv_core_type.
-Hint Constructors unary_op_type.
-Hint Constructors binary_op_type.
+Hint Constructors nraenv_core_type : qcert.
+Hint Constructors unary_op_type : qcert.
+Hint Constructors binary_op_type : qcert.
 
 Ltac nraenv_core_inverter := 
   match goal with
@@ -943,7 +943,7 @@ Ltac nraenv_core_inverter :=
   end; try rtype_equalizer; try assumption; try subst; simpl in *; try nraenv_core_inverter.
 
 (* inverts, then tries and solve *)
-Ltac nraenv_core_inferer := try nraenv_core_inverter; subst; try eauto.
+Ltac nraenv_core_inferer := try nraenv_core_inverter; subst; try qeauto.
 
 (* simplifies when a goal evaluates an expression over well-typed data *)
 

--- a/compiler/core/cNRAEnv/Typing/TcNRAEnvEq.v
+++ b/compiler/core/cNRAEnv/Typing/TcNRAEnvEq.v
@@ -56,14 +56,14 @@ Section TcNRAEnvEq.
   Notation "t1 ⇝ₑ t2 ⊣ τc ; tenv" := (typed_nraenv_core τc tenv t1 t2) (at level 80).
   Notation "X ≡τₑ Y" := (tnraenv_core_eq X Y) (at level 80).               (* ≡ = \equiv *)
 
-  Hint Resolve data_type_normalized.
-  Hint Resolve bindings_type_Forall_normalized.
+  Hint Resolve data_type_normalized : qcert.
+  Hint Resolve bindings_type_Forall_normalized : qcert.
 
   Lemma nraenv_core_eq_impl_tnraenv_core_eq {m:basic_model} {τc τenv τin τout} (op1 op2: τin ⇝ₑ τout ⊣ τc;τenv) :
     `op1 ≡ₑ `op2 -> op1 ≡τₑ op2.
   Proof.
     unfold tnraenv_core_eq, nraenv_core_eq; intros.
-    eapply H; eauto.
+    eapply H; qeauto.
   Qed.
 
   Lemma nraenv_core_eq_pf_irrel {m:basic_model} {op} {τin τout τc τenv} (pf1 pf2: op ▷ τin >=> τout ⊣ τc;τenv) :
@@ -97,7 +97,7 @@ Section TcNRAEnvEq.
   Proof.
     intros.
     unfold tnraenv_core_rewrites_to; simpl; intros.
-    split; eauto.
+    split; qeauto.
   Qed.
 
   (* Rewrite implies type-based equivalence! *)
@@ -164,7 +164,7 @@ Section TcNRAEnvEq.
     nraenv_core_inferer.
     specialize (H0 τc τenv τin τ₁ H9); elim H0; clear H0 H9; intros.
     specialize (H1 τc τenv τin τ₂ H10); elim H1; clear H1 H10; intros.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     rewrite (H0 x2 c env dt_x dt_c dt_env); rewrite (H2 x2 c env dt_x dt_c dt_env); reflexivity.
   Qed.
   
@@ -176,7 +176,7 @@ Section TcNRAEnvEq.
     unfold Proper, respectful, tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
     specialize (H0 τc τenv τin τ H8); elim H0; clear H0 H8; intros.
-    econstructor; eauto.
+    econstructor; qeauto.
     intros.
     rewrite (H0 x c env dt_x dt_c dt_env); reflexivity.
   Qed.
@@ -190,7 +190,7 @@ Section TcNRAEnvEq.
     nraenv_core_inferer.
     specialize (H0 τc τenv τin (Coll τ₁) H8); elim H0; clear H0 H8; intros.
     specialize (H τc τenv τ₁ τ₂ H4); elim H; clear H H4; intros.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     rewrite (H1 x1 c env dt_x dt_c dt_env).
     input_well_typed.
     dtype_inverter.
@@ -215,7 +215,7 @@ Section TcNRAEnvEq.
     nraenv_core_inferer.
     specialize (H0 τc τenv τin (Coll (Rec Closed τ₁ pf1)) H5); elim H0; clear H0 H5; intros.
     specialize (H τc τenv (Rec Closed τ₁ pf1) (Coll (Rec Closed τ₂ pf2)) H4); elim H; clear H H4; intros.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     rewrite (H1 x1 c env dt_x dt_c dt_env).
     input_well_typed.
     dtype_inverter.
@@ -259,7 +259,7 @@ Section TcNRAEnvEq.
     nraenv_core_inferer.
     specialize (H0 τc τenv τin (Coll (Rec Closed τ₂ pf2)) H5); elim H0; clear H0 H5; intros.
     specialize (H τc τenv τin (Coll (Rec Closed τ₁ pf1)) H4); elim H; clear H H4; intros.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     rewrite (H1 x1 c env dt_x dt_c dt_env).
     rewrite (H2 x1 c env dt_x dt_c dt_env).
     reflexivity.
@@ -274,7 +274,7 @@ Section TcNRAEnvEq.
     nraenv_core_inferer.
     specialize (H0 τc τenv τin (Coll τ) H8); elim H0; clear H0 H8; intros.
     specialize (H τc τenv τ Bool H4); elim H; clear H H4; intros.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     rewrite (H1 x1 c env dt_x dt_c dt_env).
     input_well_typed.
     dtype_inverter.
@@ -294,7 +294,7 @@ Section TcNRAEnvEq.
     nraenv_core_inferer.
     specialize (H0 τc τenv τin (Coll τ) H8); elim H0; clear H0 H8; intros.
     specialize (H τc τenv τin (Coll τ) H4); elim H; clear H H4; intros.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     rewrite (H2 x1 c env dt_x dt_c dt_env).
     rewrite (H1 x1 c env dt_x dt_c dt_env).
     reflexivity.
@@ -308,7 +308,7 @@ Section TcNRAEnvEq.
     inversion H1; subst.
     specialize (H0  _ _ _ _ H8); elim H0; clear H0 H8; intros.
     specialize (H _ _ _ _ H4); elim H; intros.
-    econstructor; eauto; intros. simpl.
+    econstructor; qeauto; intros. simpl.
     inversion dt_x; rtype_equalizer.
     - subst; eauto.
     - subst; eauto.
@@ -322,7 +322,7 @@ Section TcNRAEnvEq.
     inversion H1; clear H1; subst.
     specialize (H0 _ _ _ _ H5); elim H0; clear H0 H5; intros.
     specialize (H _ _ _ _ H4); elim H; clear H H4; intros.
-    econstructor; eauto; intros. simpl.
+    econstructor; qeauto; intros. simpl.
     rewrite H1, H2; trivial.
   Qed.
   
@@ -335,7 +335,7 @@ Section TcNRAEnvEq.
     nraenv_core_inferer.
     specialize (H0 τc τenv τin τ1 H4); elim H0; clear H0 H4; intros.
     specialize (H τc τenv τ1 τout H8); elim H; clear H H8; intros.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     rewrite (H1 x1 c env dt_x dt_c dt_env).
     input_well_typed.
     rewrite (H2 dout c env τout0 dt_c dt_env).
@@ -360,7 +360,7 @@ Section TcNRAEnvEq.
     nraenv_core_inferer.
     specialize (H0 τc τenv τin τenv' H4); elim H0; clear H0 H4; intros.
     specialize (H τc τenv' τin τout H8); elim H; clear H H8; intros.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     rewrite (H1 x1 c env dt_x dt_c dt_env).
     input_well_typed.                           
     rewrite (H2 x1 c dout dt_x dt_c τout0).
@@ -375,7 +375,7 @@ Section TcNRAEnvEq.
     unfold Proper, respectful, tnraenv_core_rewrites_to; intros.
     nraenv_core_inferer.
     specialize (H τc τenv0 τin τ₂ H2); elim H; clear H H2; intros.
-    econstructor; eauto; intros.
+    econstructor; qeauto; intros.
     dtype_inverter.
     f_equal.
     apply lift_map_ext; intros.

--- a/compiler/core/tDNNRC/Typing/tDNNRCInfer.v
+++ b/compiler/core/tDNNRC/Typing/tDNNRCInfer.v
@@ -14,6 +14,7 @@
 
 Require Import String.
 Require Import List.
+Require Import BinInt.
 Require Import Arith.
 Require Import Bool.
 Require Import Program.
@@ -412,12 +413,13 @@ Section tDNNRCInfer.
   (* Small utility function which gets the final type annotation,
      removes the proof and evaluates it to get the final type result *)
   Definition unwrap_pf_compute {A} n :=
-    Eval vm_compute in
+    (* TODO: this currently causes an Anomaly "Uncaught exception Not_found." *)
+    (* Eval vm_compute in *)
     match @di_typeof A n with
     | Tlocal r => (proj1_sig r)
     | Tdistr r => (proj1_sig r)
     end.
-
+    
   (* A slightly more interesting type with records to test the group by inference *)
   (* Note "partition" is there to check that the concat order in the type inference is right,
      the new "partition" for the group in the example should shadow the one from the input *)

--- a/compiler/core/tDNNRC/Typing/tDNNRCSub.v
+++ b/compiler/core/tDNNRC/Typing/tDNNRCSub.v
@@ -136,9 +136,9 @@ Section tDNNRCSub.
       dnnrc_base_type τc tenv e τ ->
       dnnrc_base_type_sub τc tenv e τ.
     Proof.
-      Hint Constructors dnnrc_base_type_sub.
+      Hint Constructors dnnrc_base_type_sub : qcert.
       revert tenv τ.
-      induction e; simpl; intros tenv τ dt; invcs dt; eauto.
+      induction e; simpl; intros tenv τ dt; invcs dt; qeauto.
       - econstructor; try eassumption.
         revert H5.
         apply Forall2_incl.

--- a/compiler/dune
+++ b/compiler/dune
@@ -15,3 +15,4 @@
 (copy_files extraction/*.{ml,mli})
 (copy_files parsing/*.{mll,mly})
 (copy_files# lib/*.{ml,mli})
+

--- a/compiler/extraction/util.ml
+++ b/compiler/extraction/util.ml
@@ -128,7 +128,12 @@ let qcert_string_of_float f =
 
 let string_of_enhanced_float f = char_list_of_string (string_of_float f)
 let string_of_enhanced_string s = char_list_of_string ("S\"" ^ s ^ "\"")
-	
+
+let float_sign f =
+  match Float.classify_float f with
+  | FP_normal -> if 0. < f then 1. else -1.
+  | _ -> f
+
 (**********************************)
 (* Timing function for CompStat   *)
 (**********************************)

--- a/compiler/extraction/util.mli
+++ b/compiler/extraction/util.mli
@@ -63,6 +63,7 @@ val qcert_string_of_float : float -> string
 val string_of_enhanced_float : float -> char list
 val string_of_enhanced_string : string -> char list
 
+val float_sign : float -> float
 (* Timing function for CompStat   *)
 
 val time : ('a -> 'b) -> 'a -> char list * 'b

--- a/coq-qcert.opam
+++ b/coq-qcert.opam
@@ -24,12 +24,11 @@ install: [
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
 depends: [
-  "ocaml" {>= "4.07.1"}
+  "ocaml" {>= "4.08.0"}
   "ocamlfind"
   "dune"
-  "coq" {>= "8.8.2" & < "8.9~"}
-  "coq-flocq" {>= "2.6.1" & < "3.0~"}
-  "coq-jsast" {>= "1.0.9"}
+  "coq" {>= "8.11.2" }
+  "coq-jsast" {>= "2.0.0"}
   "menhir"
   "base64"
   "uri"


### PR DESCRIPTION
- Requires coq >= 8.11.2 and ocaml >= 4.08.0
- Compiles without any (default) warnings being emitted on both 8.11.2 and 8.12.0
- changes to using native floats (and removes the flocq dependency).