### PR TITLE
How can I instantiate Foreign in ImpEJsontoWasmAst.v ?

### DIFF
--- a/compiler/wasm/wasm_ast.ml
+++ b/compiler/wasm/wasm_ast.ml
@@ -6,6 +6,9 @@ include Wasm_backend.Make(struct
     include EJsonRuntimeOperators
     include Imp
     include ImpEJson
+
+    type foreign_model = EnhancedEJson.enhanced_ejson
+    type foreign_runtime_op = EnhancedEJson.enhanced_foreign_ejson_runtime_op
   end)
 
 (* Qcert compiles queries. There is only one function per [Imp.lib].

--- a/compiler/wasm/wasm_backend.ml
+++ b/compiler/wasm/wasm_backend.ml
@@ -11,12 +11,16 @@ module Make (ImpEJson: Wasm_intf.IMP_EJSON) : sig
   val runtime: Wasm.Ast.module_
 
   (** [eval wasm_module fn_name environment *)
-  val eval : Wasm.Ast.module_ -> char list -> (char list * 'a ejson) list -> ('a ejson) option
+  val eval :
+    Wasm.Ast.module_ -> char list -> (char list * foreign_model ejson) list ->
+    foreign_model ejson option
 
-  val imp_ejson_to_wasm_ast : brand_hierarchy -> ('a,'b) imp_ejson -> Wasm.Ast.module_
+  val imp_ejson_to_wasm_ast :
+    brand_hierarchy -> (foreign_model, foreign_runtime_op) imp_ejson ->
+    Wasm.Ast.module_
 
   val string_of_operator: imp_ejson_op -> string
-  val string_of_runtime_operator: 'a imp_ejson_runtime_op -> string
+  val string_of_runtime_operator: foreign_runtime_op imp_ejson_runtime_op -> string
 end = struct
   open ImpEJson
   module Encoding = Wasm_binary_ejson.Make(ImpEJson)

--- a/compiler/wasm/wasm_intf.ml
+++ b/compiler/wasm/wasm_intf.ml
@@ -173,4 +173,10 @@ module type IMP_EJSON = sig
   type ('foreign_ejson_model, 'foreign_ejson_runtime_op) imp_ejson =
     ('foreign_ejson_model imp_ejson_constant, imp_ejson_op,
      'foreign_ejson_runtime_op imp_ejson_runtime_op) imp
+
+
+  (* Foreign *)
+
+  type foreign_model
+  type foreign_runtime_op
 end


### PR DESCRIPTION
The new wasm_backend has to be aware of the actual foreign model and foreign operator. I tried to instantiate imp_ejson on the OCaml side, but that's not enough. I think have to instantiate in ImpEJsontoWasmAst.v too. Not sure how to do that.

I get this error:
```
File "compiler/ImpEJsontoWasmAst.ml", line 1:
Error: The implementation compiler/ImpEJsontoWasmAst.ml
       does not match the interface compiler/.qcert_lib.objs/byte/qcert_lib__ImpEJsontoWasmAst.cmi:
       Values do not match:
         val imp_ejson_to_wasm_ast :
           Qcert_lib.Wasm_backend.brand_hierarchy ->
           ('a *
            (EnhancedEJson.enhanced_ejson ImpEJson.imp_ejson_constant,
             ImpEJson.imp_ejson_op,
             EnhancedEJson.enhanced_foreign_ejson_runtime_op
             ImpEJson.imp_ejson_runtime_op)
            Imp.imp_function)
           list -> Wasm_ast.t
       is not included in
         val imp_ejson_to_wasm_ast :
           BrandRelation.brand_relation_t ->
           ('a1, 'a2) ImpEJson.imp_ejson -> Wasm_ast.t
       File "compiler/ImpEJsontoWasmAst.mli", lines 5-6, characters 0-54:
         Expected declaration
       File "compiler/ImpEJsontoWasmAst.ml", line 8, characters 4-25:
         Actual declaration
      ocamlc compiler/.qcert_lib.objs/byte/qcert_lib__WasmAst.{cmo,cmt} (exit 2)
(cd _build/default && /home/circleci/.opam/4.10.0/bin/ocamlc.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -w -27 -w -39 -w -33 -warn-error -A -g -bin-annot -I compiler/.qcert_lib.objs/byte -I /home/circleci/.opam/4.10.0/lib/angstrom -I /home/circleci/.opam/4.10.0/lib/base64 -I /home/circleci/.opam/4.10.0/lib/bigarray-compat -I /home/circleci/.opam/4.10.0/lib/bigstringaf -I /home/circleci/.opam/4.10.0/lib/bytes -I /home/circleci/.opam/4.10.0/lib/calendar -I /home/circleci/.opam/4.10.0/lib/stringext -I /home/circleci/.opam/4.10.0/lib/uri -I /home/circleci/.opam/4.10.0/lib/wasm -intf-suffix .ml -no-alias-deps -opaque -open Qcert_lib -o compiler/.qcert_lib.objs/byte/qcert_lib__WasmAst.cmo -c -impl compiler/WasmAst.ml)
File "compiler/WasmAst.ml", line 1:
Error: The implementation compiler/WasmAst.ml
       does not match the interface compiler/.qcert_lib.objs/byte/qcert_lib__WasmAst.cmi:
       Values do not match:
         val wasm_ast_eval :
           wasm_ast ->
           (char list * EnhancedEJson.enhanced_ejson EJson.ejson) list ->
           EnhancedEJson.enhanced_ejson EJson.ejson option
       is not included in
         val wasm_ast_eval :
           wasm_ast -> 'a1 EJson.jbindings -> 'a1 EJson.ejson option
       File "compiler/WasmAst.mli", line 13, characters 0-65:
         Expected declaration
       File "compiler/WasmAst.ml", line 15, characters 4-17:
         Actual declaration
    ocamlopt compiler/.qcert_lib.objs/native/qcert_lib__ImpEJsontoWasmAst.{cmx,o} (exit 2)
(cd _build/default && /home/circleci/.opam/4.10.0/bin/ocamlopt.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -w -27 -w -39 -w -33 -warn-error -A -g -I compiler/.qcert_lib.objs/byte -I compiler/.qcert_lib.objs/native -I /home/circleci/.opam/4.10.0/lib/angstrom -I /home/circleci/.opam/4.10.0/lib/base64 -I /home/circleci/.opam/4.10.0/lib/bigarray-compat -I /home/circleci/.opam/4.10.0/lib/bigstringaf -I /home/circleci/.opam/4.10.0/lib/bytes -I /home/circleci/.opam/4.10.0/lib/calendar -I /home/circleci/.opam/4.10.0/lib/stringext -I /home/circleci/.opam/4.10.0/lib/uri -I /home/circleci/.opam/4.10.0/lib/wasm -intf-suffix .ml -no-alias-deps -opaque -open Qcert_lib -o compiler/.qcert_lib.objs/native/qcert_lib__ImpEJsontoWasmAst.cmx -c -impl compiler/ImpEJsontoWasmAst.ml)
File "compiler/ImpEJsontoWasmAst.ml", line 1:
Error: The implementation compiler/ImpEJsontoWasmAst.ml
       does not match the interface compiler/.qcert_lib.objs/byte/qcert_lib__ImpEJsontoWasmAst.cmi:
       Values do not match:
         val imp_ejson_to_wasm_ast :
           Qcert_lib.Wasm_backend.brand_hierarchy ->
           ('a *
            (EnhancedEJson.enhanced_ejson ImpEJson.imp_ejson_constant,
             ImpEJson.imp_ejson_op,
             EnhancedEJson.enhanced_foreign_ejson_runtime_op
             ImpEJson.imp_ejson_runtime_op)
            Imp.imp_function)
           list -> Wasm_ast.t
       is not included in
         val imp_ejson_to_wasm_ast :
           BrandRelation.brand_relation_t ->
           ('a1, 'a2) ImpEJson.imp_ejson -> Wasm_ast.t
       File "compiler/ImpEJsontoWasmAst.mli", lines 5-6, characters 0-54:
         Expected declaration
       File "compiler/ImpEJsontoWasmAst.ml", line 8, characters 4-25:
         Actual declaration
    ocamlopt compiler/.qcert_lib.objs/native/qcert_lib__WasmAst.{cmx,o} (exit 2)
(cd _build/default && /home/circleci/.opam/4.10.0/bin/ocamlopt.opt -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs -w -27 -w -39 -w -33 -warn-error -A -g -I compiler/.qcert_lib.objs/byte -I compiler/.qcert_lib.objs/native -I /home/circleci/.opam/4.10.0/lib/angstrom -I /home/circleci/.opam/4.10.0/lib/base64 -I /home/circleci/.opam/4.10.0/lib/bigarray-compat -I /home/circleci/.opam/4.10.0/lib/bigstringaf -I /home/circleci/.opam/4.10.0/lib/bytes -I /home/circleci/.opam/4.10.0/lib/calendar -I /home/circleci/.opam/4.10.0/lib/stringext -I /home/circleci/.opam/4.10.0/lib/uri -I /home/circleci/.opam/4.10.0/lib/wasm -intf-suffix .ml -no-alias-deps -opaque -open Qcert_lib -o compiler/.qcert_lib.objs/native/qcert_lib__WasmAst.cmx -c -impl compiler/WasmAst.ml)
File "compiler/WasmAst.ml", line 1:
Error: The implementation compiler/WasmAst.ml
       does not match the interface compiler/.qcert_lib.objs/byte/qcert_lib__WasmAst.cmi:
       Values do not match:
         val wasm_ast_eval :
           wasm_ast ->
           (char list * EnhancedEJson.enhanced_ejson EJson.ejson) list ->
           EnhancedEJson.enhanced_ejson EJson.ejson option
       is not included in
         val wasm_ast_eval :
           wasm_ast -> 'a1 EJson.jbindings -> 'a1 EJson.ejson option
       File "compiler/WasmAst.mli", line 13, characters 0-65:
         Expected declaration
       File "compiler/WasmAst.ml", line 15, characters 4-17:
         Actual declaration
```