### PR TITLE
Update dependencies in coq-qcert.opam & test in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ common_steps: &common_steps
           echo "OCaml: " $OCAML_VERSION
           sudo curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh > install.sh
           echo | sudo sh install.sh
-          opam init --disable-sandboxing --jobs=1 --no-setup --yes --compiler=$OCAML_VERSION
+          opam init --disable-sandboxing --jobs=$NJOBS --no-setup --yes --compiler=$OCAML_VERSION
           sed -i "s/^jobs: [0-9]*/jobs: $NJOBS/g" ~/.opam/config
           eval $(opam env)
           opam repo add coq-released https://coq.inria.fr/opam/released || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,13 +37,8 @@ common_steps: &common_steps
           opam repo add coq-released https://coq.inria.fr/opam/released || true
           opam update || true
     - run:
-        name: "Install OCaml deps"
-        command: |
-          opam install -y --jobs=2 dune menhir base64 js_of_ocaml js_of_ocaml-ppx re calendar uri
-    - run:
-        name: "Install Coq deps"
-        command: |
-          opam install -y -v coq.8.11.2 coq-jsast.2.0.0
+        name: "Install OPAM deps"
+        command: opam install . --deps-only --yes
         no_output_timeout: 30m
     - save_cache:
         <<: *common_cache_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,11 +29,9 @@ common_steps: &common_steps
           echo "OCaml: " $OCAML_VERSION
           sudo curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh > install.sh
           echo | sudo sh install.sh
-          opam init --disable-sandboxing -j 1 -n -y
+          opam init --disable-sandboxing --jobs=1 --no-setup --yes --compiler=$OCAML_VERSION
           sed -i "s/^jobs: [0-9]*/jobs: $NJOBS/g" ~/.opam/config
           eval $(opam env)
-          opam switch create $OCAML_VERSION || true
-          opam switch set $OCAML_VERSION
           opam repo add coq-released https://coq.inria.fr/opam/released || true
           opam update || true
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,12 +73,12 @@ jobs:
       - NJOBS: 2
       - NPM_CONFIG_PREFIX: "~/.npm-global"
     <<: *common_steps
-  4.10.0:
+  4.10.2:
     docker:
     - image: circleci/openjdk:8-jdk
     environment:
       - TERM: dumb
-      - OCAML_VERSION: "4.10.0"
+      - OCAML_VERSION: "4.10.2"
       - CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
       - NJOBS: 2
       - NPM_CONFIG_PREFIX: "~/.npm-global"
@@ -89,4 +89,4 @@ workflows:
   build-deploy:
     jobs:
       - 4.09.1
-      - 4.10.0
+      - 4.10.2

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ opam install coq-qcert
 
 To build Q\*cert from the source, you will need:
 
-- OCaml 4.08.0 or later (http://ocaml.org/) along with the following libraries:
+- OCaml 4.09.1 or later (http://ocaml.org/) along with the following libraries:
   - dune, a build system (https://dune.build)
   - menhir, a parser generator (http://gallium.inria.fr/~fpottier/menhir/)
   - base64, a library for base64 encoding and decoding (https://github.com/mirage/ocaml-base64)
@@ -45,8 +45,7 @@ An easy way to get set up on most platforms is to use the OCaml package manager 
 
 ```
 $ opam repo add coq-released https://coq.inria.fr/opam/released
-$ opam install dune menhir base64 js_of_ocaml js_of_ocaml-ppx calendar uri
-$ opam install coq.8.11.2 coq-jsast
+$ opam install . --deps-only
 ```
 
 #### Java (Recommended)

--- a/coq-qcert.opam
+++ b/coq-qcert.opam
@@ -33,6 +33,8 @@ depends: [
   "coq-jsast" {>= "2.0.0"}
   "menhir"
   "base64"
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
   "uri"
   "calendar"
   "coq-coq2html" {with-doc}

--- a/coq-qcert.opam
+++ b/coq-qcert.opam
@@ -26,10 +26,10 @@ install: [
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.09.1"}
   "ocamlfind"
   "dune"
-  "coq" {>= "8.11.2" }
+  "coq" {= "8.11.2" }
   "coq-jsast" {>= "2.0.0"}
   "menhir"
   "base64"


### PR DESCRIPTION
I tried to build the project on a new machine and ran into missing dependencies. I think the complications arise from the fact that we track dependencies in three places: `coq-qcert.opam`, `README.md`, and `.circleci/config.yml`.

With this commit, I configure `coq-qcert.opam` as the single source of truth for the list of dependencies. One can now install all required dependencies with `opam install . --deps-only`. I update the README and CircleCI script accordingly.