### PR TITLE
Renaming

### DIFF
--- a/compiler/core/EJson/Operators/EJsonRuntimeOperators.v
+++ b/compiler/core/EJson/Operators/EJsonRuntimeOperators.v
@@ -129,8 +129,8 @@ Section EJsonRuntimeOperators.
       | EJsonRuntimeArrayAccess => "arrayAccess"
       (* Sum *)
       | EJsonRuntimeEither => "either"
-      | EJsonRuntimeToLeft=> "toLeft"
-      | EJsonRuntimeToRight=> "toRight"
+      | EJsonRuntimeToLeft=> "getLeft"
+      | EJsonRuntimeToRight=> "getRight"
       (* Brand *)
       | EJsonRuntimeBrand => "brand"
       | EJsonRuntimeUnbrand => "unbrand"

--- a/compiler/core/Translation/Lang/ImpDatatoImpEJson.v
+++ b/compiler/core/Translation/Lang/ImpDatatoImpEJson.v
@@ -681,7 +681,7 @@ Section ImpDatatoImpEJson.
           destruct (ejson_eq_dec (data_to_ejson d) (data_to_ejson d0));
           try reflexivity; subst.
         + congruence.
-        + apply data_to_ejson_inv in e; congruence.
+        + apply data_to_ejson_inj in e; congruence.
       - Case "OpRecConcat"%string.
         apply rconcat_key_encode_comm.
       - Case "OpRecMerge"%string.

--- a/compiler/core/Translation/Lang/NNRCtoJava.v
+++ b/compiler/core/Translation/Lang/NNRCtoJava.v
@@ -297,12 +297,12 @@ Section NNRCtoJava.
            (s1 +++ (indent i) +++ ^"final JsonElement " +++ res +++ ^";" +++ eol
                +++ (indent i) +++ ^"if (RuntimeUtils.either(" +++ (from_java_json e1) +++ ^")) {" +++ eol
                +++ (indent (i+1)) +++ ^"final JsonElement " +++ vl +++ eol
-               +++ (indent (i+1)) +++ ^" = RuntimeUtils.toLeft(" +++ (from_java_json e1) +++ ^");" +++ eol
+               +++ (indent (i+1)) +++ ^" = RuntimeUtils.getLeft(" +++ (from_java_json e1) +++ ^");" +++ eol
                +++ s2
                +++ (indent (i+1)) +++ res +++ ^" = " +++ (from_java_json e2) +++ ^";" +++ eol
                +++ (indent i) +++ ^"} else {" +++ eol
                +++ (indent (i+1)) +++ ^"final JsonElement " +++ vr  +++ eol
-               +++ (indent (i+1)) +++ ^" = RuntimeUtils.toRight(" +++ (from_java_json e1) +++ ^");" +++ eol
+               +++ (indent (i+1)) +++ ^" = RuntimeUtils.getRight(" +++ (from_java_json e1) +++ ^");" +++ eol
                +++ s3
                +++ (indent (i+1)) +++ res +++ ^" = " +++ (from_java_json e3) +++ ^";" +++ eol
                +++ (indent i) +++ ^"}" +++ eol,

--- a/compiler/core/Translation/Lang/NNRSimptoImpData.v
+++ b/compiler/core/Translation/Lang/NNRSimptoImpData.v
@@ -82,10 +82,10 @@ Section NNRSimptoImpData.
       (*   let e' := ImpExprVar x  in *)
       (*   ImpStmtIf *)
       (*     (ImpExprRuntimeCall DataRuntimeEither [e']) *)
-      (*     (ImpStmtBlock (* var x1 = toLeft(e); s1 *) *)
+      (*     (ImpStmtBlock (* var x1 = getLeft(e); s1 *) *)
       (*        [ (x1, Some (ImpExprRuntimeCall DataRuntimeToLeft [e'])) ] *)
       (*        [ nnrs_imp_stmt_to_imp_data s1 ]) *)
-      (*     (ImpStmtBlock (* var x2 = toRight(e); s2 *) *)
+      (*     (ImpStmtBlock (* var x2 = getRight(e); s2 *) *)
       (*        [ (x2, Some (ImpExprRuntimeCall DataRuntimeToRight [e'])) ] *)
       (*        [ nnrs_imp_stmt_to_imp_data s2 ]) *)
       | NNRSimpEither e x1 s1 x2 s2 =>
@@ -93,10 +93,10 @@ Section NNRSimptoImpData.
         let e' := nnrs_imp_expr_to_imp_data constants e in
         ImpStmtIf
           (ImpExprRuntimeCall DataRuntimeEither [e'])
-          (ImpStmtBlock (* var x1 = toLeft(e); s1 *)
+          (ImpStmtBlock (* var x1 = getLeft(e); s1 *)
              [ (x1, Some (ImpExprRuntimeCall DataRuntimeToLeft [e'])) ]
              [ nnrs_imp_stmt_to_imp_data constants s1 ])
-          (ImpStmtBlock (* var x2 = toRight(e); s2 *)
+          (ImpStmtBlock (* var x2 = getRight(e); s2 *)
              [ (x2, Some (ImpExprRuntimeCall DataRuntimeToRight [e'])) ]
              [ nnrs_imp_stmt_to_imp_data constants s2 ])
       end.

--- a/compiler/core/Translation/Model/DataToEJson.v
+++ b/compiler/core/Translation/Model/DataToEJson.v
@@ -282,7 +282,7 @@ Section DataToEJson.
     Qed.
 
     (* Means we can do inversion on data_to_ejson *)
-    Lemma data_to_ejson_inv j1 j2:
+    Lemma data_to_ejson_inj j1 j2:
       data_to_ejson j1 = data_to_ejson j2 -> j1 = j2.
     Proof.
       intros.
@@ -296,7 +296,7 @@ Section DataToEJson.
       data_to_ejson j1 = data_to_ejson j2 <-> j1 = j2.
     Proof.
       split; intros; subst.
-      - apply data_to_ejson_inv; assumption.
+      - apply data_to_ejson_inj; assumption.
       - reflexivity.
     Qed.
   End ModelRoundTrip.
@@ -789,7 +789,7 @@ Section DataToEJson.
       case_eq (data_eqdec d d0); case_eq (ejson_eqdec (data_to_ejson d) (data_to_ejson d0)); intros.
       - reflexivity.
       - congruence.
-      - clear H; apply data_to_ejson_inv in e.
+      - clear H; apply data_to_ejson_inj in e.
         congruence.
       - reflexivity.
     Qed.
@@ -889,7 +889,7 @@ Section DataToEJson.
       - rewrite in_map_iff in H.
         elim H; clear H; intros.
         elim H; clear H; intros.
-        apply data_to_ejson_inv in H.
+        apply data_to_ejson_inj in H.
         subst; assumption.
       - apply in_map; assumption.
     Qed.
@@ -913,7 +913,7 @@ Section DataToEJson.
         destruct (EquivDec.equiv_dec (data_to_ejson d) (data_to_ejson a));
         try reflexivity; simpl.
       - rewrite e in c; congruence.
-      - apply data_to_ejson_inv in e; subst; congruence.
+      - apply data_to_ejson_inj in e; subst; congruence.
     Qed.
 
     Lemma bminus_ejson_to_data_comm l1 l2:
@@ -1014,7 +1014,7 @@ Section DataToEJson.
         case_eq (data_eq_dec d a);
           case_eq (ejson_eq_dec (data_to_ejson d) (data_to_ejson a)); intros; try congruence.
         clear H.
-        apply data_to_ejson_inv in e.
+        apply data_to_ejson_inj in e.
         subst. congruence.
       - simpl; destruct (data_to_ejson a0); try reflexivity.
       - simpl; destruct (data_to_ejson a0); try reflexivity.

--- a/compiler/lib/pretty_query.ml
+++ b/compiler/lib/pretty_query.ml
@@ -493,9 +493,9 @@ let pretty_imp_data_runtime p sym pretty_imp_expr ff (op, args) =
   | Core.DataRuntimeEither, [e] ->
       fprintf ff "@[<hv 2>either@[<hv 2>(%a)@]@]" (pretty_imp_expr 0 sym) e
   | Core.DataRuntimeToLeft, [e] ->
-      fprintf ff "@[<hv 2>toLeft@[<hv 2>(%a)@]@]" (pretty_imp_expr 0 sym) e
+      fprintf ff "@[<hv 2>getLeft@[<hv 2>(%a)@]@]" (pretty_imp_expr 0 sym) e
   | Core.DataRuntimeToRight, [e] ->
-      fprintf ff "@[<hv 2>toRight@[<hv 2>(%a)@]@]" (pretty_imp_expr 0 sym) e
+      fprintf ff "@[<hv 2>getRight@[<hv 2>(%a)@]@]" (pretty_imp_expr 0 sym) e
   | _ -> assert false
   end
 

--- a/runtimes/java/src/org/qcert/runtime/BinaryOperators.java
+++ b/runtimes/java/src/org/qcert/runtime/BinaryOperators.java
@@ -224,7 +224,7 @@ public class BinaryOperators {
 		final DataComparator comp = DataComparator.getComparator();
 		for(JsonElement elem : ec) {
 //			if (elem instanceof JsonObject) {
-//				elem = RuntimeUtils.toLeft(elem);
+//				elem = RuntimeUtils.getLeft(elem);
 //			}
 			if(comp.compare(elem, e1) == 0) {
 				return new JsonPrimitive(true);

--- a/runtimes/java/src/org/qcert/runtime/RuntimeUtils.java
+++ b/runtimes/java/src/org/qcert/runtime/RuntimeUtils.java
@@ -85,11 +85,11 @@ public class RuntimeUtils {
         }
     }
 
-    public static JsonElement toLeft(JsonElement obj) {
+    public static JsonElement getLeft(JsonElement obj) {
         return asRec(obj).get("$left");
     }
 
-    public static JsonElement toRight(JsonElement obj) {
+    public static JsonElement getRight(JsonElement obj) {
         return asRec(obj).get("$right");
     }
 

--- a/runtimes/javascript/qcert-runtime-core.js
+++ b/runtimes/javascript/qcert-runtime-core.js
@@ -219,17 +219,17 @@ function either(v) {
     }
     throw new Error('TypeError: either called on non-sum');
 }
-function toLeft(v) {
+function getLeft(v) {
     if (typeof v === 'object' && isLeft(v)) {
         return unboxLeft(v);
     }
-    throw new Error('TypeError: toLeft called on non-sum');
+    throw new Error('TypeError: getLeft called on non-sum');
 }
-function toRight(v) {
+function getRight(v) {
     if (typeof v === 'object' && isRight(v)) {
         return unboxRight(v);
     }
-    throw new Error('TypeError: toRight called on non-sum');
+    throw new Error('TypeError: getRight called on non-sum');
 }
 
 /* Brand */


### PR DESCRIPTION
Rename the operators `toLeft` and `toRight` into `getLeft` and `getRight`, and rename the property `data_to_ejson_inv` into `data_to_ejson_inj`.

These changes might require additional changes in the wasm branch.