### PR TITLE
fix(opam): Correct version number is 2.1.1

### DIFF
--- a/coq-qcert.opam
+++ b/coq-qcert.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "coq-qcert"
-version: "2.0.0"
+version: "2.1.1"
 synopsis: "Verified compiler for data-centric languages"
 description: """
 This is the Coq library for Q*cert, a platform for implementing and verifying data languages and compilers. It includes abstract syntax and semantics for several source query languages (OQL, SQL), for intermediate database representations (nested relational algebra and calculus), and correctness proofs for part of the compilation to JavaScript and Java.


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <Jerome.Simeon@docusign.com>

- Fixes the version number in the `.opam` file (should be `2.1.1`)
