### PR TITLE
fix(ci): Add explicit libgmp library install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ common_steps: &common_steps
           sudo apt-get install -y m4
           sudo apt-get install -y pkg-config libncurses5-dev
           sudo apt-get install -y bubblewrap
+          sudo apt-get install -y libgmp-dev
     - run:
         name: "Initialize opam"
         command: |
@@ -41,11 +42,11 @@ common_steps: &common_steps
           opam update || true
     - run:
         name: "Install Coq"
-        command: opam install --jobs=$NJOBS --yes --confirm-level=unsafe-yes coq.$COQ_VERSION
+        command: opam install --jobs=$NJOBS --yes coq.$COQ_VERSION
         no_output_timeout: 45m
     - run:
         name: "Install OPAM deps"
-        command: opam install . --deps-only --jobs=$NJOBS --yes --confirm-level=unsafe-yes
+        command: opam install . --deps-only --jobs=$NJOBS --yes
         no_output_timeout: 45m
     - save_cache:
         <<: *common_cache_key


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

- Update linux library needed for CI runs on recent Coq versions
